### PR TITLE
[Bugfix: Gradeables]: Fixed 0 clamp

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -423,7 +423,7 @@ function setupNumericTextCells() {
             }
             // Input greater than the max_clamp for the component is not allowed
             else {
-                if (elem.data('maxclamp') && elem.data('maxclamp') < this.value) {
+                if (elem.data('maxclamp') >=0 && elem.data('maxclamp') < this.value) {
                     alert(`Score should be less than or equal to the max clamp value: ${elem.data('maxclamp')}`);
                     this.value = 0;
                 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
In the preview grading screen when the max marks for a particular label are set to 0, no validation error is triggered if the score is set above 0.
### What is the new behavior?
Fixes #11269 
A validation error is triggered if a score greater than 0 is set for a label whose max marks are 0.

![image](https://github.com/user-attachments/assets/7a2b2578-b7eb-45d0-9f68-8214321ccf8b)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
