### PR TITLE
[Refactor:System] Fix User Static Type in Core

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -32,8 +32,9 @@ class GlobalController extends AbstractController {
         }
 
         $unread_notifications_count = null;
-        if ($this->core->getUser() && $this->core->getConfig()->isCourseLoaded()) {
-            $unread_notifications_count = $this->core->getQueries()->getUnreadNotificationsCount($this->core->getUser()->getId(), null);
+        $user = $this->core->getUser();
+        if (!is_null($user) && $this->core->getConfig()->isCourseLoaded()) {
+            $unread_notifications_count = $this->core->getQueries()->getUnreadNotificationsCount($user->getId(), null);
         }
 
         $sidebar_buttons = [];

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -403,9 +403,9 @@ class Core {
      * Returns the user that the client is logged in as. Will return null if there is no user
      * to be logged in as.
      *
-     * @return User
+     * @return User|null
      */
-    public function getUser() {
+    public function getUser(): ?User {
         return $this->user;
     }
 

--- a/site/app/views/GlobalView.php
+++ b/site/app/views/GlobalView.php
@@ -25,7 +25,8 @@ class GlobalView extends AbstractView {
         }
 
         $page_title = "Submitty";
-        if ($this->core->getUser() === null) {
+        $user = $this->core->getUser();
+        if ($user === null) {
             $page_title = "Login";
         }
         elseif ($this->core->getConfig()->isCourseLoaded()) {
@@ -82,7 +83,7 @@ class GlobalView extends AbstractView {
             "page_title" => $page_title,
             "sidebar_buttons" => $sidebar_buttons,
             "breadcrumbs" => $breadcrumbs,
-            "user_given_name" => $this->core->getUser() ? $this->core->getUser()->getDisplayedGivenName() : "",
+            "user_given_name" => $user !== null ? $user->getDisplayedGivenName() : "",
             "base_url" => $this->core->getConfig()->getBaseUrl(),
             "course_url" => $this->core->buildCourseUrl(),
             "websocket_port" => $this->core->getConfig()->getWebsocketPort(),

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -167,11 +167,6 @@ parameters:
 			path: app/controllers/DockerInterfaceController.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 2
-			path: app/controllers/DockerInterfaceController.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/controllers/DockerInterfaceController.php
@@ -204,11 +199,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
-			path: app/controllers/GlobalController.php
-
-		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 1
 			path: app/controllers/GlobalController.php
 
 		-
@@ -272,7 +262,7 @@ parameters:
 			path: app/controllers/GlobalController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, app\\\\models\\\\User given on the left side\\.$#"
+			message: "#^Only booleans are allowed in &&, app\\\\models\\\\User\\|null given on the left side\\.$#"
 			count: 1
 			path: app/controllers/GlobalController.php
 
@@ -295,11 +285,6 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
-			path: app/controllers/HomePageController.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 4
 			path: app/controllers/HomePageController.php
 
 		-
@@ -8042,11 +8027,6 @@ parameters:
 			path: app/libraries/routers/WebRouter.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\User and null will always evaluate to true\\.$#"
-			count: 2
-			path: app/libraries/routers/WebRouter.php
-
-		-
 			message: "#^Variable method call on app\\\\models\\\\Config\\|null\\.$#"
 			count: 1
 			path: app/libraries/routers/WebRouter.php
@@ -8348,11 +8328,6 @@ parameters:
 
 		-
 			message: "#^Property app\\\\models\\\\Config\\:\\:\\$wrapper_files type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/models/Config.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\User and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/Config.php
 
@@ -10102,11 +10077,6 @@ parameters:
 			path: app/models/gradeable/Gradeable.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/gradeable/Gradeable.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 9
 			path: app/models/gradeable/Gradeable.php
@@ -11672,17 +11642,7 @@ parameters:
 			path: app/views/GlobalView.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, app\\\\models\\\\User given\\.$#"
-			count: 1
-			path: app/views/GlobalView.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\User and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/views/GlobalView.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: "#^Only booleans are allowed in a ternary operator condition, app\\\\models\\\\User\\|null given\\.$#"
 			count: 1
 			path: app/views/GlobalView.php
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -262,11 +262,6 @@ parameters:
 			path: app/controllers/GlobalController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, app\\\\models\\\\User\\|null given on the left side\\.$#"
-			count: 1
-			path: app/controllers/GlobalController.php
-
-		-
 			message: """
 				#^Call to deprecated method JsonOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
 				should not be used, just return JsonResponse directly$#
@@ -11638,11 +11633,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\views\\\\GlobalView\\:\\:header\\(\\) has parameter \\$wrapper_urls with no type specified\\.$#"
-			count: 1
-			path: app/views/GlobalView.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, app\\\\models\\\\User\\|null given\\.$#"
 			count: 1
 			path: app/views/GlobalView.php
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Related to #11262 
Currently, the static typing for user is incorrect, setting getUser() to User, when it really should be User or null
### What is the new behavior?
Changed the static type and refactored some comparison (evaluating User as true)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
