### PR TITLE
[Bug fix: Instructor UI] Fix variable substitution in self-registration course message .

### DIFF
--- a/site/app/templates/error/NoAccessCourse.twig
+++ b/site/app/templates/error/NoAccessCourse.twig
@@ -17,7 +17,7 @@
             Click <a href="{{main_url}}"> here </a> to back to homepage and see your courses list.
         {% endif %}
     {% else %}
-        The course <b>{{ course_name != course_id ? 'course_name (course_id)' : course_name  }}</b> for <b>{{ semester }}</b> is open to self registration <br />
+        The course <b>{{ course_name }} ({{ course_id }})</b> for <b>{{ semester }}</b> is open to self registration <br />
         You may select below to add yourself to the course. <br/>
         Your instructor will be notified and can then choose to keep you in the course.
         {% if course_home_url != '' %}


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The current behavior shows placeholders like ```course_name (course_id)``` in the self-registration message instead of displaying the actual course name and course ID.

This issue is described in issue #11310.

### What is the new behavior?
The self-registration message now correctly substitutes the actual course name and course ID. The message format is: ```Course Name (Course ID).```
For Example-
```
The course "Introduction to Computer Science (CS101)" for Spring 2025 is open to self-registration.
```

### Other information?
<!-- Is this a breaking change? -->
- This is not a breaking change.
<!-- How did you test -->
- Tested locally by navigating to the self-registration page and verifying that course name and course ID are displayed correctly.
