### PR TITLE
[Bugfix:InstructorUI] Fixing UI in the registration page.

### DIFF
--- a/site/app/templates/error/NoAccessCourse.twig
+++ b/site/app/templates/error/NoAccessCourse.twig
@@ -17,7 +17,7 @@
             Click <a href="{{main_url}}"> here </a> to back to homepage and see your courses list.
         {% endif %}
     {% else %}
-        The course <b>{{ course_name != course_id ? 'course_name (course_id)' : course_name  }}</b> for <b>{{ semester }}</b> is open to self registration <br />
+        The course <b>{{ course_name != course_id ? course_name + ' (' + course_id + ')' : course_name }}</b> for <b>{{ semester }}</b> is open to self registration <br />
         You may select below to add yourself to the course. <br/>
         Your instructor will be notified and can then choose to keep you in the course.
         {% if course_home_url != '' %}


### PR DESCRIPTION
The current issue is that the course name and course ID are not being correctly displayed in the message where the user is informed whether they have access to a course. The placeholder for the course name and ID is not properly filled in.

Fixes #11310

The course name and course ID are now correctly displayed in the message to users, with the proper values inserted where needed.
The conditional logic now checks if the course_name is different from the course_id, and displays the correct information accordingly.