### PR TITLE
[Bugfix:Forum] Redirect with error for invalid thread

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1184,7 +1184,9 @@ class ForumController extends AbstractController {
         $repo = $this->core->getCourseEntityManager()->getRepository(Thread::class);
         $thread = $repo->getThreadDetail($thread_id, $option, $show_deleted);
         if (is_null($thread)) {
-            return $this->core->getOutput()->renderJsonFail("Invalid thread id (NON-EXISTENT ID)");
+            $this->core->addErrorMessage("Requested thread does not exist.");
+            $this->core->redirect(($this->core->buildCourseUrl(['forum'])));
+            return;
         }
 
         $this->core->getQueries()->markNotificationAsSeen($user, -2, (string) $thread_id);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #11316. Requesting a deleted/invalid thread returns a JSON response.

### What is the new behavior?
It now redirects to the main forum page and adds an error message.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
