### PR TITLE
[Refactor:Developer] Begin switch from phpcs to php-cs-fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
         run: |
             php vendor/bin/phpcs --version
             php vendor/bin/phpcs
+            php vendor/bin/php-cs-fixer --version
+            php vendor/bin/php-cs-fixer fix --dry-run
       - name: Static analysis
         run: |
             php vendor/bin/phpstan  --version

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ coverage.xml
 /site/public/vue/
 /site/report/
 /site/incremental_build/
+/site/.php-cs-fixer.cache
 
 db_update.php
 .setup/data/random_users.txt

--- a/site/.php-cs-fixer.dist.php
+++ b/site/.php-cs-fixer.dist.php
@@ -1,0 +1,14 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('node_modules')
+    ->exclude('vendor')
+    ->exclude('cache')
+    ->in(__DIR__)
+;
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+])
+    ->setFinder($finder)
+    ;

--- a/site/.php-cs-fixer.dist.php
+++ b/site/.php-cs-fixer.dist.php
@@ -9,6 +9,12 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([
-])
-    ->setFinder($finder)
-    ;
+    '@PSR12' => true,
+    'braces_position' => [
+        'classes_opening_brace' => 'same_line',
+        'functions_opening_brace' => 'same_line',
+    ],
+    'control_structure_continuation_position' => [
+        'position' => 'next_line',
+    ],
+])->setFinder($finder);

--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -17,7 +17,7 @@ use app\views\MiscView;
 use Symfony\Component\Routing\Annotation\Route;
 
 class MiscController extends AbstractController {
-    const GENERIC_NO_ACCESS_MSG = 'You do not have access to this file';
+    public const GENERIC_NO_ACCESS_MSG = 'You do not have access to this file';
 
     /**
      * Get the current server time

--- a/site/app/controllers/NotificationController.php
+++ b/site/app/controllers/NotificationController.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
  *
  */
 class NotificationController extends AbstractController {
-    const NOTIFICATION_SELECTIONS = [
+    public const NOTIFICATION_SELECTIONS = [
         'merge_threads',
         'all_new_threads',
         'all_new_posts',
@@ -27,7 +27,7 @@ class NotificationController extends AbstractController {
         'self_notification'
     ];
 
-    const EMAIL_SELECTIONS = [
+    public const EMAIL_SELECTIONS = [
         'merge_threads_email',
         'all_new_threads_email',
         'all_new_posts_email',

--- a/site/app/controllers/OfficeHoursQueueController.php
+++ b/site/app/controllers/OfficeHoursQueueController.php
@@ -730,7 +730,7 @@ class OfficeHoursQueueController extends AbstractController {
         $result = $this->core->getQueries()->studentQueueSearch($user_id);
         $data = [];
         foreach ($result as $row) {
-                $data[] = $row;
+            $data[] = $row;
         }
         $responseData = json_encode($data);
         return JsonResponse::getSuccessResponse($responseData);

--- a/site/app/controllers/PollController.php
+++ b/site/app/controllers/PollController.php
@@ -193,12 +193,12 @@ class PollController extends AbstractController {
         }
 
         if (!in_array($_POST["release_histogram"], PollUtils::getReleaseHistogramSettings())) {
-                    $this->core->addErrorMessage("Invalid student histogram release setting");
+            $this->core->addErrorMessage("Invalid student histogram release setting");
             return new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
 
         if (!in_array($_POST["release_answer"], PollUtils::getReleaseAnswerSettings())) {
-                    $this->core->addErrorMessage("Invalid poll answer release setting");
+            $this->core->addErrorMessage("Invalid poll answer release setting");
             return new RedirectResponse($this->core->buildCourseUrl(['polls']));
         }
 

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -34,7 +34,7 @@ class AdminGradeableController extends AbstractController {
         }
     }
 
-    const syllabus_buckets = [
+    public const syllabus_buckets = [
         'homework', 'assignment', 'problem-set',
         'quiz', 'test', 'exam',
         'exercise', 'lecture-exercise', 'reading', 'lab', 'recitation', 'worksheet',
@@ -42,7 +42,7 @@ class AdminGradeableController extends AbstractController {
         'participation', 'note',
         'none (for practice only)'];
 
-    const gradeable_type_strings = [
+    public const gradeable_type_strings = [
         'checkpoint' => 'Checkpoints (simple data entry: full/half/no credit)',
         'numeric' => 'Numeric/Text (simple data entry: integer or floating point and/or short text strings)',
         'electronic_hw' => 'Students will submit one or more files by direct upload to the Submitty website',
@@ -1487,10 +1487,12 @@ class AdminGradeableController extends AbstractController {
                 //convert the property name to a setter name
                 $setter_name = 'set' . implode(
                     '',
-                    array_map(function ($val) {
-                        return ucfirst($val);
-                    },
-                    explode('_', $prop))
+                    array_map(
+                        function ($val) {
+                            return ucfirst($val);
+                        },
+                        explode('_', $prop)
+                    )
                 );
                 $gradeable->$setter_name($post_val);
             }

--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -20,12 +20,12 @@ use Symfony\Component\Routing\Annotation\Route;
 class ConfigurationController extends AbstractController {
     // The message that should be returned to the user if they fail the required validation to enable the nightly
     // rainbow grades build checkbox
-    const FAIL_AUTO_RG_MSG = 'You may not enable automatic rainbow grades generation until you have supplied a ' .
-    'customization.json file.  To have one generated for you, you may use the Web-Based Rainbow Grades Generation inside the Grade ' .
-    'Reports tab.  You may also manually create the file and upload it to your course\'s rainbow_grades directory.';
-    const NO_SELF_REGISTER = 0; // Self registration disabled
-    const REQUEST_SELF_REGISTER = 1; // Self registration allowed, users request and instructors can approve
-    const ALL_SELF_REGISTER = 2; // Self registration allowed, and all users who register are automatically added
+    public const FAIL_AUTO_RG_MSG = 'You may not enable automatic rainbow grades generation until you have supplied a ' .
+        'customization.json file.  To have one generated for you, you may use the Web-Based Rainbow Grades Generation inside the Grade ' .
+        'Reports tab.  You may also manually create the file and upload it to your course\'s rainbow_grades directory.';
+    public const NO_SELF_REGISTER = 0; // Self registration disabled
+    public const REQUEST_SELF_REGISTER = 1; // Self registration allowed, users request and instructors can approve
+    public const ALL_SELF_REGISTER = 2; // Self registration allowed, and all users who register are automatically added
 
     /**
      * @return MultiResponse
@@ -191,7 +191,7 @@ class ConfigurationController extends AbstractController {
         }
 
         if ($name === 'all_self_registration') {
-            $this->core->getQueries()->setSelfRegistrationType($this->core->getConfig()->getTerm(), $this->core->getConfig()->getCourse(), $entry === 'true' ?  ConfigurationController::ALL_SELF_REGISTER : ConfigurationController::NO_SELF_REGISTER);
+            $this->core->getQueries()->setSelfRegistrationType($this->core->getConfig()->getTerm(), $this->core->getConfig()->getCourse(), $entry === 'true' ? ConfigurationController::ALL_SELF_REGISTER : ConfigurationController::NO_SELF_REGISTER);
             $this->core->getQueries()->setDefaultRegistrationSection($this->core->getConfig()->getTerm(), $this->core->getConfig()->getCourse(), $_POST['default_section']);
             $name = 'self_registration_type';
             $entry = $entry === 'true' ? ConfigurationController::ALL_SELF_REGISTER : ConfigurationController::NO_SELF_REGISTER;

--- a/site/app/controllers/admin/EmailRoomSeatingController.php
+++ b/site/app/controllers/admin/EmailRoomSeatingController.php
@@ -19,8 +19,8 @@ use Symfony\Component\Routing\Annotation\Route;
  * @AccessControl(role="INSTRUCTOR")
  */
 class EmailRoomSeatingController extends AbstractController {
-    const DEFAULT_EMAIL_SUBJECT = 'Seating Assignment for {$gradeable_id}';
-    const DEFAULT_EMAIL_BODY = 'Hello,
+    public const DEFAULT_EMAIL_SUBJECT = 'Seating Assignment for {$gradeable_id}';
+    public const DEFAULT_EMAIL_BODY = 'Hello,
 
 Listed below is your seating assignment for the upcoming exam {$gradeable_id} on {$exam_date} at {$exam_time}.
 

--- a/site/app/controllers/admin/LateController.php
+++ b/site/app/controllers/admin/LateController.php
@@ -193,7 +193,7 @@ class LateController extends AbstractController {
             }
         }
         else {
-            if ((!isset($_POST['g_id']) || $_POST['g_id'] == "" )) {
+            if ((!isset($_POST['g_id']) || $_POST['g_id'] == "")) {
                 $error = "Please choose a gradeable_id";
                 $this->core->addErrorMessage($error);
                 return MultiResponse::JsonOnlyResponse(

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -33,8 +33,8 @@ use app\exceptions\ValidationException;
  * @AccessControl(role="INSTRUCTOR")
  */
 class ReportController extends AbstractController {
-    const MAX_AUTO_RG_WAIT_TIME = 45;       // Time in seconds a call to autoRainbowGradesStatus should
-                                            // wait for the job to complete before timing out and returning failure
+    public const MAX_AUTO_RG_WAIT_TIME = 45;       // Time in seconds a call to autoRainbowGradesStatus should
+    // wait for the job to complete before timing out and returning failure
 
     private $all_overrides = [];
 
@@ -606,6 +606,7 @@ class ReportController extends AbstractController {
                 else {
                     return 'Unsubmitted';
                 }
+                // no break
             default:
                 return 'ERROR';
         }

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -584,7 +584,7 @@ class UsersController extends AbstractController {
                 $default_section = $this->core->getQueries()->getDefaultRegistrationSection($term, $course);
                 $is_self_register =  $this->core->getQueries()->getSelfRegistrationType($term, $course) !== ConfigurationController::NO_SELF_REGISTER;
                 if ($default_section === $_POST['delete_reg_section'] && $is_self_register) {
-                        $this->core->addErrorMessage("Section {$_POST['delete_reg_section']} not removed.  Cannot delete the default registration section if self registration is enabled.");
+                    $this->core->addErrorMessage("Section {$_POST['delete_reg_section']} not removed.  Cannot delete the default registration section if self registration is enabled.");
                 }
                 else {
                     $num_del_sections = $this->core->getQueries()->deleteRegistrationSection($_POST['delete_reg_section']);
@@ -1257,7 +1257,7 @@ class UsersController extends AbstractController {
                 $user->setGroup($user_group);
             }
             else {
-               // Registration section has to exist, or a DB exception gets thrown on INSERT or UPDATE.
+                // Registration section has to exist, or a DB exception gets thrown on INSERT or UPDATE.
                 // ON CONFLICT clause in DB query prevents thrown exceptions when registration section already exists.
                 if (!empty($row[$registration_section_idx])) {
                     $this->core->getQueries()->insertNewRegistrationSection($row[$registration_section_idx]);

--- a/site/app/controllers/admin/WrapperController.php
+++ b/site/app/controllers/admin/WrapperController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * @AccessControl(permission="admin.wrapper")
  */
 class WrapperController extends AbstractController {
-    const WRAPPER_FILES = [
+    public const WRAPPER_FILES = [
         'override.css',
         'sidebar.json'
     ];

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -455,7 +455,7 @@ class ForumController extends AbstractController {
                 }
 
                 $result['next_page'] = $this->core->buildCourseUrl(['forum', 'threads', $thread_id]);
-                 $this->sendSocketMessage(['type' => 'new_thread', 'thread_id' => $thread_id]);
+                $this->sendSocketMessage(['type' => 'new_thread', 'thread_id' => $thread_id]);
             }
         }
         return $this->core->getOutput()->renderJsonSuccess($result);
@@ -721,7 +721,7 @@ class ForumController extends AbstractController {
         $markdown = !empty($_POST['markdown_status']);
 
         if (!$this->core->getAccess()->canI("forum.modify_post", ['post_author' => $post['author_user_id']])) {
-                return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
+            return $this->core->getOutput()->renderJsonFail('You do not have permissions to do that.');
         }
         if (isset($_POST['thread_id']) && $post['thread_id'] !== intval($_POST['thread_id'])) {
             return $this->core->getOutput()->renderJsonFail("You do not have permission to do that.");
@@ -790,7 +790,7 @@ class ForumController extends AbstractController {
             $type = null;
             $isError = false;
             $messageString = '';
-             // Author of first post and thread must be same
+            // Author of first post and thread must be same
             if (is_null($status_edit_thread) && is_null($status_edit_post)) {
                 $this->core->addErrorMessage("No data submitted. Please try again.");
             }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -160,9 +160,9 @@ class ElectronicGraderController extends AbstractController {
         [ [A,[C,E]],[B,[F,D]], ...]
         A grades C and E, B grades F and D ..and so on!
         */
-            $max_offset = count($student_array);
-            $offset_array = [];
-            $temp_offset = [];
+        $max_offset = count($student_array);
+        $offset_array = [];
+        $temp_offset = [];
         for ($i = 1; $i < $max_offset; ++$i) {
             array_push($temp_offset, $i);
         }
@@ -189,7 +189,7 @@ class ElectronicGraderController extends AbstractController {
             }
             array_push($final_grading_info, [$n_array_peers[0][$i],$temp]);
         }
-            return $final_grading_info;
+        return $final_grading_info;
     }
 
     /**
@@ -303,9 +303,9 @@ class ElectronicGraderController extends AbstractController {
         $student_list = [];
         $students = $this->core->getQueries()->getUsersByRegistrationSections($order->getSectionNames());
         foreach ($students as $student) {
-             $reg_sec = ($student->getRegistrationSection() === null) ? 'NULL' : $student->getRegistrationSection();
-             $sorted_students[$reg_sec][] = $student;
-             array_push($student_list, ['user_id' => $student->getId()]);
+            $reg_sec = ($student->getRegistrationSection() === null) ? 'NULL' : $student->getRegistrationSection();
+            $sorted_students[$reg_sec][] = $student;
+            array_push($student_list, ['user_id' => $student->getId()]);
             if ($submit_before_grading) {
                 if ($this->core->getQueries()->getUserHasSubmission($gradeable, $student->getId())) {
                     array_push($student_array, $student->getId());
@@ -743,8 +743,8 @@ class ElectronicGraderController extends AbstractController {
                 ];
             }
             if ($peer) {
-                 // If a team assignment => Team Peer Grading Stats Should be Visible
-                 // Stats are broken, Update this after Teams work fine with Randomized Peer Assignments
+                // If a team assignment => Team Peer Grading Stats Should be Visible
+                // Stats are broken, Update this after Teams work fine with Randomized Peer Assignments
                 if ($gradeable->isTeamAssignment()) {
                     $sections['stu_grad'] = [
                        'total_components' => count($gradeable->getPeerComponents()), // Multiply it by number of teams assigned to grade
@@ -1997,9 +1997,9 @@ class ElectronicGraderController extends AbstractController {
         // Filter out the components that we shouldn't see
         //  TODO: instructors see all components, some may not be visible in non-super-edit-mode
         $return['components'] = array_map(function (Component $component) {
-                return $component->toArray();
+            return $component->toArray();
         }, array_filter($gradeable->getComponents(), function (Component $component) use ($gradeable) {
-                return $this->core->getAccess()->canI('grading.electronic.view_component', ['gradeable' => $gradeable, 'component' => $component]);
+            return $this->core->getAccess()->canI('grading.electronic.view_component', ['gradeable' => $gradeable, 'component' => $component]);
         }));
         $return['components'] = array_values($return['components']);
         return $return;

--- a/site/app/controllers/grading/popup_refactor/RubricGraderController.php
+++ b/site/app/controllers/grading/popup_refactor/RubricGraderController.php
@@ -18,6 +18,7 @@
  */
 
 // Namespace:
+
 namespace app\controllers\grading\popup_refactor;
 
 // Includes:

--- a/site/app/entities/calendar/CalendarItem.php
+++ b/site/app/entities/calendar/CalendarItem.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 #[ORM\Table(name: "calendar_messages")]
 class CalendarItem {
-    const TEXT = 0;
-    const ANNOUNCEMENT = 1;
+    public const TEXT = 0;
+    public const ANNOUNCEMENT = 1;
 
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]

--- a/site/app/entities/calendar/GlobalItem.php
+++ b/site/app/entities/calendar/GlobalItem.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 #[ORM\Table(name: "global_calendar_items")]
 class GlobalItem {
-    const TEXT = 0;
-    const ANNOUNCEMENT = 1;
+    public const TEXT = 0;
+    public const ANNOUNCEMENT = 1;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/site/app/entities/course/CourseMaterial.php
+++ b/site/app/entities/course/CourseMaterial.php
@@ -18,9 +18,9 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: CourseMaterialRepository::class)]
 #[ORM\Table(name: "course_materials")]
 class CourseMaterial {
-    const FILE = 0;
-    const LINK = 1;
-    const DIR = 2;
+    public const FILE = 0;
+    public const LINK = 1;
+    public const DIR = 2;
 
     #[ORM\Id]
     #[ORM\Column(type: Types::INTEGER)]
@@ -224,7 +224,7 @@ class CourseMaterial {
 
     public function userHasViewed(string $user_id): bool {
         return $this->accesses->filter(function (CourseMaterialAccess $courseMaterialAccess) use ($user_id) {
-                return $courseMaterialAccess->getUserId() === $user_id;
+            return $courseMaterialAccess->getUserId() === $user_id;
         })->count() > 0;
     }
 

--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -13,89 +13,89 @@ class Access {
     // Access control options
 
     /** Allow Instructors to do this */
-    const ALLOW_INSTRUCTOR              = 1 << 0;
+    public const ALLOW_INSTRUCTOR              = 1 << 0;
     /** Allow full access graders to do this */
-    const ALLOW_FULL_ACCESS_GRADER      = 1 << 1;
+    public const ALLOW_FULL_ACCESS_GRADER      = 1 << 1;
     /** Allow limited access graders to do this */
-    const ALLOW_LIMITED_ACCESS_GRADER   = 1 << 2;
+    public const ALLOW_LIMITED_ACCESS_GRADER   = 1 << 2;
     /** Allow students to do this */
-    const ALLOW_STUDENT                 = 1 << 3;
+    public const ALLOW_STUDENT                 = 1 << 3;
     /** Allow logged out users to do this */
-    const ALLOW_LOGGED_OUT              = 1 << 4;
+    public const ALLOW_LOGGED_OUT              = 1 << 4;
     /**
      * Check that the current user is at or above the minimum grading group required for a gradeable
      * If the gradeable has peer grading, this will also accept for students
      */
-    const CHECK_GRADEABLE_MIN_GROUP     = 1 << 5 | self::REQUIRE_ARG_GRADEABLE;
+    public const CHECK_GRADEABLE_MIN_GROUP     = 1 << 5 | self::REQUIRE_ARG_GRADEABLE;
     /**
      * Check that a given user is in the current user's grading section for a gradeable
      * Only applies to limited access graders
      */
-    const CHECK_GRADING_SECTION_GRADER  = 1 << 6 | self::REQUIRE_ARG_GRADEABLE;
+    public const CHECK_GRADING_SECTION_GRADER  = 1 << 6 | self::REQUIRE_ARG_GRADEABLE;
     /**
      * Check that a given user is in the current user's peer grading assignment for a gradeable
      * Only applies to students
      */
-    const CHECK_PEER_ASSIGNMENT_STUDENT = 1 << 7 | self::REQUIRE_ARG_GRADEABLE;
+    public const CHECK_PEER_ASSIGNMENT_STUDENT = 1 << 7 | self::REQUIRE_ARG_GRADEABLE;
     /** Require that the given gradeable have an active version / submission */
-    const CHECK_HAS_SUBMISSION          = 1 << 8 | self::REQUIRE_ARG_GRADEABLE;
+    public const CHECK_HAS_SUBMISSION          = 1 << 8 | self::REQUIRE_ARG_GRADEABLE;
     /** Check that a valid CSRF token was passed in the request */
-    const CHECK_CSRF                    = 1 << 9;
+    public const CHECK_CSRF                    = 1 << 9;
     /** Allow access if the gradeable is our own, even if sections are checked */
-    const ALLOW_SELF_GRADEABLE          = 1 << 10 | self::REQUIRE_ARG_GRADEABLE;
+    public const ALLOW_SELF_GRADEABLE          = 1 << 10 | self::REQUIRE_ARG_GRADEABLE;
     /** Only allow access if the gradeable is our own */
-    const ALLOW_ONLY_SELF_GRADEABLE     = 1 << 11 | self::REQUIRE_ARG_GRADEABLE;
+    public const ALLOW_ONLY_SELF_GRADEABLE     = 1 << 11 | self::REQUIRE_ARG_GRADEABLE;
     /**
      * Check if the given component allows peer grading
      * Only applies to students
      */
-    const CHECK_COMPONENT_PEER_STUDENT  = 1 << 12 | self::REQUIRE_ARG_COMPONENT;
+    public const CHECK_COMPONENT_PEER_STUDENT  = 1 << 12 | self::REQUIRE_ARG_COMPONENT;
     /** Check if they can access the given file and directory */
-    const CHECK_FILE_DIRECTORY          = 1 << 13 | self::REQUIRE_ARGS_DIR_PATH;
+    public const CHECK_FILE_DIRECTORY          = 1 << 13 | self::REQUIRE_ARGS_DIR_PATH;
     /** Require that the given file exists */
-    const CHECK_FILE_EXISTS             = 1 << 14 | self::REQUIRE_ARGS_DIR_PATH;
+    public const CHECK_FILE_EXISTS             = 1 << 14 | self::REQUIRE_ARGS_DIR_PATH;
     /**
      * Check that students are allowed to view the given gradeable
      * Only applies to students
      */
-    const CHECK_STUDENT_VIEW            = 1 << 15 | self::REQUIRE_ARG_GRADEABLE;
+    public const CHECK_STUDENT_VIEW            = 1 << 15 | self::REQUIRE_ARG_GRADEABLE;
     /**
      * Check that students are allowed to submit the given gradeable
      * Only applies to students
      */
-    const CHECK_STUDENT_SUBMIT = 1 << 16 | self::REQUIRE_ARG_GRADEABLE | self::REQUIRE_ARG_VERSION;
+    public const CHECK_STUDENT_SUBMIT = 1 << 16 | self::REQUIRE_ARG_GRADEABLE | self::REQUIRE_ARG_VERSION;
     /**
      * Checks that students are allowed to view and download submission files for the given gradeable
      * Only applies to students
      */
-    const CHECK_STUDENT_DOWNLOAD = 1 << 17 | self::REQUIRE_ARG_GRADEABLE | self::REQUIRE_ARG_VERSION;
+    public const CHECK_STUDENT_DOWNLOAD = 1 << 17 | self::REQUIRE_ARG_GRADEABLE | self::REQUIRE_ARG_VERSION;
 
     /** Check that the course status is such that the user can view the course */
-    const CHECK_COURSE_STATUS           = 1 << 18;
+    public const CHECK_COURSE_STATUS           = 1 << 18;
 
     /** If the current set of flags requires the "gradeable" (type Gradeable) argument */
-    const REQUIRE_ARG_GRADEABLE         = 1 << 24;
+    public const REQUIRE_ARG_GRADEABLE         = 1 << 24;
     /** If the current set of flags requires the "component" (type GradeableComponent) argument */
-    const REQUIRE_ARG_COMPONENT         = 1 << 25;
+    public const REQUIRE_ARG_COMPONENT         = 1 << 25;
     /** If the current set of flags requires the "dir" (type string) and "path" (type string) arguments */
-    const REQUIRE_ARGS_DIR_PATH         = 1 << 26;
+    public const REQUIRE_ARGS_DIR_PATH         = 1 << 26;
     /** If the current set of flags requires the "gradeable_version" (type int) argument */
-    const REQUIRE_ARG_VERSION           = 1 << 27;
+    public const REQUIRE_ARG_VERSION           = 1 << 27;
     /** If the current set of flags requires the "semester" (type string) and "course" (type string) arguments */
-    const REQUIRE_ARGS_SEMESTER_COURSE  = 1 << 28;
+    public const REQUIRE_ARGS_SEMESTER_COURSE  = 1 << 28;
     /** Ensure on the forum the operation is done by the correct user. */
-    const REQUIRE_FORUM_SAME_STUDENT    = 1 << 29;
+    public const REQUIRE_FORUM_SAME_STUDENT    = 1 << 29;
 
 
     // Broader user group access cases since generally actions are "minimum this group"
 
-    const ALLOW_MIN_STUDENT               = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER | self::ALLOW_LIMITED_ACCESS_GRADER | self::ALLOW_STUDENT;
-    const ALLOW_MIN_LIMITED_ACCESS_GRADER = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER | self::ALLOW_LIMITED_ACCESS_GRADER;
-    const ALLOW_MIN_FULL_ACCESS_GRADER    = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER;
-    const ALLOW_MIN_INSTRUCTOR            = self::ALLOW_INSTRUCTOR;
-    const DENY_ALL                        = -1;
+    public const ALLOW_MIN_STUDENT               = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER | self::ALLOW_LIMITED_ACCESS_GRADER | self::ALLOW_STUDENT;
+    public const ALLOW_MIN_LIMITED_ACCESS_GRADER = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER | self::ALLOW_LIMITED_ACCESS_GRADER;
+    public const ALLOW_MIN_FULL_ACCESS_GRADER    = self::ALLOW_INSTRUCTOR | self::ALLOW_FULL_ACCESS_GRADER;
+    public const ALLOW_MIN_INSTRUCTOR            = self::ALLOW_INSTRUCTOR;
+    public const DENY_ALL                        = -1;
 
-    const ACCESS_LEVELS = [
+    public const ACCESS_LEVELS = [
         User::LEVEL_USER        => "User",
         User::LEVEL_FACULTY     => "Faculty",
         User::LEVEL_SUPERUSER   => "Superuser"

--- a/site/app/libraries/CodeMirrorUtils.php
+++ b/site/app/libraries/CodeMirrorUtils.php
@@ -3,14 +3,14 @@
 namespace app\libraries;
 
 class CodeMirrorUtils {
-    const DEFAULT_CSS_FILES = [
+    public const DEFAULT_CSS_FILES = [
         'codemirror/codemirror.css',
         'codemirror/theme/eclipse.css',
         'codemirror/theme/monokai.css',
         'codemirror-spell-checker/spell-checker.min.css'
     ];
 
-    const DEFAULT_JS_FILES = [
+    public const DEFAULT_JS_FILES = [
         'codemirror/codemirror.js',
         'codemirror/addon/display/autorefresh.js',
         'codemirror/addon/display/placeholder.js',
@@ -28,7 +28,7 @@ class CodeMirrorUtils {
         'codemirror-spell-checker/spell-checker.min.js',
     ];
 
-    const DEFAULT_JS_FILES_CODEMIRROR_6 = [
+    public const DEFAULT_JS_FILES_CODEMIRROR_6 = [
         'codemirror6/autocomplete/dist/index.js',
         'codemirror6/commands/dist/index.js',
         'codemirror6/language/dist/index.js',
@@ -36,13 +36,13 @@ class CodeMirrorUtils {
         'codemirror6/view/dist/index.js',
     ];
 
-    const DEFAULT_MIME_TYPE = 'text/plain';
+    public const DEFAULT_MIME_TYPE = 'text/plain';
 
     /**
      * Defines a map between languages (keys) that submitty developers/users have been using and the mime-types (values)
      * that CodeMirror uses for their mode.
      */
-    const MIME_TYPE_MAP = [
+    public const MIME_TYPE_MAP = [
         'bash' => 'text/x-sh',
         'c' => 'text/x-csrc',
         'clike' => 'text/x-csrc',

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -703,11 +703,11 @@ class Core {
         return $course_name;
     }
 
-     /**
-      * Returns either the 'actual' coursename or the coursename set by the professor.
-      *
-      * @return string
-      */
+    /**
+     * Returns either the 'actual' coursename or the coursename set by the professor.
+     *
+     * @return string
+     */
     public function getDisplayedCourseName() {
         if ($this->getConfig()->getCourseName() !== "") {
             return htmlentities($this->getConfig()->getCourseName());
@@ -927,7 +927,7 @@ class Core {
             if (empty($files)) {
                 return [];
             }
-            $files = array_filter($files, fn(string $file): bool => str_ends_with($file, ".php"));
+            $files = array_filter($files, fn (string $file): bool => str_ends_with($file, ".php"));
             $files = array_map(function (string $file) {
                 $parts = explode(DIRECTORY_SEPARATOR, $file);
                 return substr(end($parts), 0, -4);

--- a/site/app/libraries/DateUtils.php
+++ b/site/app/libraries/DateUtils.php
@@ -11,10 +11,10 @@ use app\models\User;
  */
 class DateUtils {
     /** @var string $MAX_TIME Max limit we allow for parsed DateTimes to avoid compatibility issues between PHP and DB */
-    const MAX_TIME = '9999-02-01 00:00:00';
+    public const MAX_TIME = '9999-02-01 00:00:00';
 
     /** @var string $BEGINNING_OF_TIME feature we use in Course Materials */
-    const BEGINNING_OF_TIME = '1900-02-01T00:00:00';
+    public const BEGINNING_OF_TIME = '1900-02-01T00:00:00';
 
     /** @var \DateTimeZone $timezone */
     private static $timezone;

--- a/site/app/libraries/DiffViewer.php
+++ b/site/app/libraries/DiffViewer.php
@@ -83,13 +83,13 @@ class DiffViewer {
      */
     private $white_spaces = [];
 
-    const SPECIAL_CHARS_ORIGINAL = 'original';
-    const SPECIAL_CHARS_ESCAPE = 'escape';
-    const SPECIAL_CHARS_UNICODE = 'unicode';
+    public const SPECIAL_CHARS_ORIGINAL = 'original';
+    public const SPECIAL_CHARS_ESCAPE = 'escape';
+    public const SPECIAL_CHARS_UNICODE = 'unicode';
 
     //The first element of array is used to find the special char, the second is the visual representation, the third is
     // the escape code
-    const SPECIAL_CHARS_LIST = [
+    public const SPECIAL_CHARS_LIST = [
         "space" => [" ", "&nbsp;", " "],
         "tabs" => ["\t", "↹", "\\t"],
         "carriage return" => ["\r", "↵<br>", "\\r<br>"],
@@ -101,8 +101,8 @@ class DiffViewer {
         "en dash" => ["\xE2\x80\x93", "–", "\\xE2\\x80\\x93"]
     ];
 
-    const EXPECTED = 'expected';
-    const ACTUAL = 'actual';
+    public const EXPECTED = 'expected';
+    public const ACTUAL = 'actual';
 
     public static function isValidSpecialCharsOption($option) {
         return in_array($option, [

--- a/site/app/libraries/ErrorMessages.php
+++ b/site/app/libraries/ErrorMessages.php
@@ -39,12 +39,12 @@ class ErrorMessages {
         }
     }
 
-     /**
-      * Given a response code after opening a Zip Archive, check if anything went wrong
-      * @param bool | int $res Error code or status for opening archive
-      *
-      * @return string Message for what went wrong with upload
-      */
+    /**
+     * Given a response code after opening a Zip Archive, check if anything went wrong
+     * @param bool | int $res Error code or status for opening archive
+     *
+     * @return string Message for what went wrong with upload
+     */
     public static function getZipErrorMessage($res) {
 
         if ($res === true) {

--- a/site/app/libraries/ExceptionHandler.php
+++ b/site/app/libraries/ExceptionHandler.php
@@ -78,7 +78,7 @@ class ExceptionHandler {
                 $elem,
                 isset($frame['file']) ? $frame['file'] : 'unknown file',
                 isset($frame['line']) ? $frame['line'] : 'unknown line',
-                (isset($frame['class']))  ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
+                (isset($frame['class'])) ? $frame['class'] . $frame['type'] . $frame['function'] : $frame['function'],
                 static::parseArgs((is_a($exception, '\app\exceptions\AuthenticationException') || !isset($frame['args'])) ? [] : $frame['args'])
             );
         }

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -10,9 +10,9 @@ use app\exceptions\FileReadException;
  * Contains various useful functions for interacting with files and directories.
  */
 class FileUtils {
-    const IGNORE_FOLDERS = [".svn", ".git", ".idea", "__macosx"];
-    const IGNORE_FILES = ['.ds_store'];
-    const ALLOWED_IMAGE_TYPES = ['jpg', 'jpeg', 'png', 'gif'];
+    public const IGNORE_FOLDERS = [".svn", ".git", ".idea", "__macosx"];
+    public const IGNORE_FILES = ['.ds_store'];
+    public const ALLOWED_IMAGE_TYPES = ['jpg', 'jpeg', 'png', 'gif'];
 
     /**
      * Return all files from a given directory.  All subdirectories
@@ -440,7 +440,7 @@ class FileUtils {
             case 'pdf':
                 $content_type = "application/pdf";
                 break;
-            // images
+                // images
             case 'png':
                 $content_type = "image/png";
                 break;
@@ -454,7 +454,7 @@ class FileUtils {
             case 'bmp':
                 $content_type = "image/bmp";
                 break;
-            // text
+                // text
             case 'c':
                 $content_type = 'text/x-csrc';
                 break;

--- a/site/app/libraries/ForumUtils.php
+++ b/site/app/libraries/ForumUtils.php
@@ -11,7 +11,7 @@ use app\libraries\FileUtils;
  * Contains various useful functions for interacting with the forum
  */
 class ForumUtils {
-    const FORUM_CHAR_POST_LIMIT = 5000;
+    public const FORUM_CHAR_POST_LIMIT = 5000;
 
     public static function checkGoodAttachment($isThread, $thread_id, $file_post) {
         if ((!isset($_FILES[$file_post])) || $_FILES[$file_post]['error'][0] === UPLOAD_ERR_NO_FILE) {

--- a/site/app/libraries/GradeableType.php
+++ b/site/app/libraries/GradeableType.php
@@ -3,9 +3,9 @@
 namespace app\libraries;
 
 abstract class GradeableType {
-    const ELECTRONIC_FILE = 0;
-    const CHECKPOINTS     = 1;
-    const NUMERIC_TEXT    = 2;
+    public const ELECTRONIC_FILE = 0;
+    public const CHECKPOINTS     = 1;
+    public const NUMERIC_TEXT    = 2;
 
     public static function typeToString(int $type): string {
         switch ($type) {

--- a/site/app/libraries/GradingQueue.php
+++ b/site/app/libraries/GradingQueue.php
@@ -30,12 +30,12 @@ class GradingQueue {
     private $grading_path = '';
     private $grading_remaining = [];
 
-    const GRADING_FILE_PREFIX = 'GRADING_';
-    const VCS_FILE_PREFIX = 'VCS__';
-    const QUEUE_FILE_SEPARATOR = '__';
+    public const GRADING_FILE_PREFIX = 'GRADING_';
+    public const VCS_FILE_PREFIX = 'VCS__';
+    public const QUEUE_FILE_SEPARATOR = '__';
 
-    const NOT_QUEUED = -1;
-    const GRADING = 0;
+    public const NOT_QUEUED = -1;
+    public const GRADING = 0;
 
     public function __construct($semester, $course, $submitty_path) {
         $this->queue_path = FileUtils::joinPaths($submitty_path, 'to_be_graded_queue');

--- a/site/app/libraries/Logger.php
+++ b/site/app/libraries/Logger.php
@@ -16,11 +16,11 @@ class Logger {
     /**
      * Log levels for the logger
      */
-    const DEBUG = 0;
-    const INFO = 1;
-    const WARN = 2;
-    const ERROR = 3;
-    const FATAL = 4;
+    public const DEBUG = 0;
+    public const INFO = 1;
+    public const WARN = 2;
+    public const ERROR = 3;
+    public const FATAL = 4;
 
     private static $log_path = null;
 

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -134,7 +134,7 @@ class Output {
             return call_user_func_array('self::renderTemplate', $args);
         }, ["is_safe" => ["html"]]));
         $this->twig->addFunction(new \Twig\TwigFunction('base64_image', function (string $base64_data, string $mime_type, string $title): string {
-                return <<<HTML
+            return <<<HTML
 <img alt="{$title}" src="data:{$mime_type};base64,{$base64_data}" />
 HTML;
         }, ['is_safe' => ['html']]));

--- a/site/app/libraries/SessionManager.php
+++ b/site/app/libraries/SessionManager.php
@@ -16,7 +16,7 @@ use DateTime;
  * they logged in.
  */
 class SessionManager {
-    const SESSION_EXPIRATION = "2 weeks";
+    public const SESSION_EXPIRATION = "2 weeks";
 
     /**
      * @var Core

--- a/site/app/libraries/Utils.php
+++ b/site/app/libraries/Utils.php
@@ -238,13 +238,13 @@ class Utils {
         return json_encode(array_merge($students_full->toArray(), $null_students->toArray()));
     }
 
-   /**
-    * Convert the shorthand byte notation in php.ini to bytes.
-    * E.g : php returnBytes(ini_get('post_max_size'))
-    * Src : https://www.php.net/manual/en/function.ini-get.php
-    * @param string $size_str
-    * @return int
-    */
+    /**
+     * Convert the shorthand byte notation in php.ini to bytes.
+     * E.g : php returnBytes(ini_get('post_max_size'))
+     * Src : https://www.php.net/manual/en/function.ini-get.php
+     * @param string $size_str
+     * @return int
+     */
     public static function returnBytes(string $size_str): int {
         switch (strtolower(substr($size_str, -1))) {
             case 'm':

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1818,7 +1818,7 @@ WHERE term=? AND course=? AND user_id=?",
 
 
         $version = 0;
-// Get gradeable version where all submitters have a good status
+        // Get gradeable version where all submitters have a good status
         if ($gg->getGradeable()->isTeamAssignment()) {
             // Check if all members have a valid instance
             if ($this->course_db->getRowCount() === count($gg->getSubmitter()->getTeam()->getMemberUsers())) {
@@ -2285,7 +2285,7 @@ ORDER BY merged_data.{$section_key}
     public function getBadGradedComponentsCountByGradingSections($g_id, $sections, $section_key, $is_team) {
         //getBadTeamSubmissionsByGradingSection
         //getBadUserSubmissionsByGradingSection
-         $u_or_t = "u";
+        $u_or_t = "u";
         $users_or_teams = "users";
         $user_or_team_id = "user_id";
         if ($is_team) {
@@ -3186,11 +3186,11 @@ ORDER BY rotating_section"
         );
     }
 
-     /**
-      * Return an array of user id's for users that have been assigned a registration section
-      *
-      * @return string[] user id's
-      */
+    /**
+     * Return an array of user id's for users that have been assigned a registration section
+     *
+     * @return string[] user id's
+     */
     public function getRegisteredUserIds() {
         $this->course_db->query(
             "
@@ -3476,7 +3476,7 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
         // Map the results into a non-associative array of team/user ids
         return array_map(
             function ($row) use ($row_type) {
-                    return $row[$row_type];
+                return $row[$row_type];
             },
             $this->course_db->rows()
         );
@@ -3661,13 +3661,13 @@ VALUES(?, ?, ?, ?, 0, 0, 0, 0, ?)",
         return $sections;
     }
 
-     /**
-      * returns 2d array of new graders after rotating sections set up
-      * for all access grading and limited access graders gradeables,
-      * top level is all graders' ids and second level is all rotating sections
-      *
-      * @return array
-      */
+    /**
+     * returns 2d array of new graders after rotating sections set up
+     * for all access grading and limited access graders gradeables,
+     * top level is all graders' ids and second level is all rotating sections
+     *
+     * @return array
+     */
     public function getNewGraders() {
         $new_graders = [];
         $all_sections = $this->core->getQueries()->getAllRotatingSections();
@@ -4454,7 +4454,7 @@ ORDER BY gt.{$section_key}",
             [$gradeable_id,$user_id]
         );
 
-          return ($this->course_db->getRowCount() > 0) ? new SimpleGradeOverriddenUser($this->core, $this->course_db->row()) : null;
+        return ($this->course_db->getRowCount() > 0) ? new SimpleGradeOverriddenUser($this->core, $this->course_db->row()) : null;
     }
 
     public function getAllOverriddenGrades() {
@@ -4663,11 +4663,11 @@ SQL;
         }
     }
 
-  /**
-   * Bulk Uploads Peer Grading Assignments
-   *
-   * @param string $values
-   */
+    /**
+     * Bulk Uploads Peer Grading Assignments
+     *
+     * @param string $values
+     */
     public function insertBulkPeerGradingAssignment($values) {
         $this->course_db->query("INSERT INTO peer_assign(grader_id, user_id, g_id) VALUES " . $values);
     }
@@ -5023,8 +5023,8 @@ AND gc_id IN (
         $this->course_db->query("SELECT user_givenname, user_preferred_givenname, user_familyname, user_preferred_familyname, user_email, user_pronouns, display_pronouns FROM users WHERE user_id = ?", [$user_id]);
         $name_rows = $this->course_db->rows()[0];
         $ar = [];
-        $ar["given_name"] = (empty($name_rows["user_preferred_givenname"])) ? $name_rows["user_givenname"]      : $name_rows["user_preferred_givenname"];
-        $ar["family_name"]  = (empty($name_rows["user_preferred_familyname"]))  ? " " . $name_rows["user_familyname"] : " " . $name_rows["user_preferred_familyname"];
+        $ar["given_name"] = (empty($name_rows["user_preferred_givenname"])) ? $name_rows["user_givenname"] : $name_rows["user_preferred_givenname"];
+        $ar["family_name"]  = (empty($name_rows["user_preferred_familyname"])) ? " " . $name_rows["user_familyname"] : " " . $name_rows["user_preferred_familyname"];
         $ar["user_email"] = $name_rows["user_email"];
         $ar["pronouns"] = $name_rows["user_pronouns"];
         $ar["display_pronouns"] = $name_rows["display_pronouns"];
@@ -5135,7 +5135,7 @@ AND gc_id IN (
             return true;
         }
         catch (DatabaseException $dbException) {
-             $this->course_db->rollback();
+            $this->course_db->rollback();
         }
         return false;
     }
@@ -7502,21 +7502,21 @@ AND gc_id IN (
 
 
 
-/////////////////Office Hours Queue queries/////////////////////////////////////
+    /////////////////Office Hours Queue queries/////////////////////////////////////
 
-  /*
-  current_state values
-      ('waiting'):Waiting
-      ('being_helped'):Being helped
-      ('done'):Done/Fully out of the queue
-  removal_type values
-      (null):Still in queue
-      ('self'):Removed yourself
-      ('helped'):Mentor/TA helped you
-      ('removed'):Mentor/TA removed you
-      ('emptied'):Kicked out because queue emptied
-      ('self_helped'):You helped you
-  */
+    /*
+    current_state values
+        ('waiting'):Waiting
+        ('being_helped'):Being helped
+        ('done'):Done/Fully out of the queue
+    removal_type values
+        (null):Still in queue
+        ('self'):Removed yourself
+        ('helped'):Mentor/TA helped you
+        ('removed'):Mentor/TA removed you
+        ('emptied'):Kicked out because queue emptied
+        ('self_helped'):You helped you
+    */
 
     public function getCurrentQueue() {
         $query = "
@@ -8121,7 +8121,7 @@ WHERE current_state IN
 
 
 
-/////////////////END Office Hours Queue queries//////////////////////////////////
+    /////////////////END Office Hours Queue queries//////////////////////////////////
 
 
 
@@ -8900,7 +8900,7 @@ WHERE current_state IN
      * Maps sort keys to an array of expressions to sort by in place of the key.
      *  Useful for ambiguous keys or for key alias's
      */
-    const graded_gradeable_key_map_user = [
+    public const graded_gradeable_key_map_user = [
         'registration_section' => [
             'SUBSTRING(u.registration_section, \'^[^0-9]*\')',
             'COALESCE(SUBSTRING(u.registration_section, \'[0-9]+\')::INT, -1)',
@@ -8914,7 +8914,7 @@ WHERE current_state IN
             'u.registration_subsection',
         ]
     ];
-    const graded_gradeable_key_map_team = [
+    public const graded_gradeable_key_map_team = [
         'registration_section' => [
             'SUBSTRING(team.registration_section, \'^[^0-9]*\')',
             'COALESCE(SUBSTRING(team.registration_section, \'[0-9]+\')::INT, -1)',
@@ -9404,8 +9404,8 @@ ORDER BY
         $current_owner = $this->getDockerImageOwner($image);
         if ($current_owner === false) {
             $this->submitty_db->query("INSERT INTO docker_images (image_name, user_id) values (?, ?)", [$image,$user_id]);
-        // If an instructor wants to add an image they didn't upload to a capability, the image will have no owner.
-        // Only sysadmin will be able to remove it.
+            // If an instructor wants to add an image they didn't upload to a capability, the image will have no owner.
+            // Only sysadmin will be able to remove it.
         }
         elseif ($current_owner !== $user_id) {
             $this->submitty_db->query("UPDATE docker_images SET user_id = NULL WHERE image_name = ?", [$image]);

--- a/site/app/libraries/database/QueryIdentifier.php
+++ b/site/app/libraries/database/QueryIdentifier.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace app\libraries\database;
 
 class QueryIdentifier {
-    const SELECT = 'select';
-    const INSERT = 'insert';
-    const UPDATE = 'update';
-    const DELETE = 'delete';
-    const UNKNOWN = 'unknown';
+    public const SELECT = 'select';
+    public const INSERT = 'insert';
+    public const UPDATE = 'update';
+    public const DELETE = 'delete';
+    public const UNKNOWN = 'unknown';
 
     public static function identify(string $query): string {
         $query = strtolower(trim($query));

--- a/site/app/libraries/plagiarism/PlagiarismUtils.php
+++ b/site/app/libraries/plagiarism/PlagiarismUtils.php
@@ -8,7 +8,7 @@ class PlagiarismUtils {
      * hash size and language name are listed but more parameters can be added in the future.
      * @var int
      */
-    const SUPPORTED_LANGUAGES = [
+    public const SUPPORTED_LANGUAGES = [
         "plaintext" => [
             "hash_size" => 14
         ],
@@ -30,7 +30,7 @@ class PlagiarismUtils {
      * This constant represents the default common code threshold listed on the plagiarism configuration form
      * @var int
      */
-    const DEFAULT_THRESHOLD = 10;
+    public const DEFAULT_THRESHOLD = 10;
 
     /**
      * @param string $filename

--- a/site/app/models/AbstractModel.php
+++ b/site/app/models/AbstractModel.php
@@ -13,9 +13,9 @@ use app\libraries\Core;
  * @method bool isModified()
  */
 abstract class AbstractModel {
-    const CALL_SET = 1;
-    const CALL_GET = 2;
-    const CALL_IS = 3;
+    public const CALL_SET = 1;
+    public const CALL_GET = 2;
+    public const CALL_IS = 3;
 
     protected static $properties = [];
 

--- a/site/app/models/Course.php
+++ b/site/app/models/Course.php
@@ -34,8 +34,8 @@ class Course extends AbstractModel {
      * @var string $registration_section for homepage view */
     protected $registration_section;
 
-    const ACTIVE_STATUS = 1;
-    const ARCHIVED_STATUS = 2;
+    public const ACTIVE_STATUS = 1;
+    public const ARCHIVED_STATUS = 2;
 
     /**
      * Course constructor.

--- a/site/app/models/DateTimeFormat.php
+++ b/site/app/models/DateTimeFormat.php
@@ -7,10 +7,10 @@ use app\libraries\Core;
 
 class DateTimeFormat extends AbstractModel {
     // Set of legal specifiers
-    const SPECIFIERS = ['MDY', 'DMY'];
+    public const SPECIFIERS = ['MDY', 'DMY'];
 
     // Keys available to use with getDateFormat
-    const DATE_FORMATS_KEYS = [
+    public const DATE_FORMATS_KEYS = [
         'gradeable',
         'gradeable_with_seconds',
         'forum',
@@ -22,7 +22,7 @@ class DateTimeFormat extends AbstractModel {
     ];
 
     // Internationalized DateTime formatting strings
-    const DATE_FORMATS = [
+    public const DATE_FORMATS = [
         'MDY' => [
             'gradeable' => 'm/d/Y @ h:i A T',
             'gradeable_with_seconds' => 'm/d/Y @ h:i:s A T',

--- a/site/app/models/DisplayImage.php
+++ b/site/app/models/DisplayImage.php
@@ -23,10 +23,10 @@ use app\libraries\FileUtils;
  */
 class DisplayImage extends AbstractModel {
     /** string[] The set of legal display_image_state which may be collected from the DB */
-    const LEGAL_IMAGE_STATES = ['system', 'preferred', 'flagged'];
+    public const LEGAL_IMAGE_STATES = ['system', 'preferred', 'flagged'];
 
     /** string[] The set of directories for which it is legal to save a DisplayImage to */
-    const LEGAL_FOLDERS = ['system_images', 'user_images'];
+    public const LEGAL_FOLDERS = ['system_images', 'user_images'];
 
     /**
      * int
@@ -34,7 +34,7 @@ class DisplayImage extends AbstractModel {
      * have the larger dimension resized to this constant, while the other dimension will be reduced to maintain the
      * original form factor of the image.
      */
-    const IMG_MAX_DIMENSION = 500;
+    public const IMG_MAX_DIMENSION = 500;
 
     /** @prop
      * @var string The file path to the selected image */

--- a/site/app/models/GradeableAutocheck.php
+++ b/site/app/models/GradeableAutocheck.php
@@ -122,8 +122,8 @@ class GradeableAutocheck extends AbstractModel {
                 else {
                     $this->core->addErrorMessage("Expected file not found.");
                 }
-            // Try to find the file in the details directory. Do not print an error,
-            // as the file is likely student generated.
+                // Try to find the file in the details directory. Do not print an error,
+                // as the file is likely student generated.
             }
             else {
                 if (file_exists($results_path . "/details/" . $details["expected_file"])) {

--- a/site/app/models/GradingOrder.php
+++ b/site/app/models/GradingOrder.php
@@ -326,7 +326,7 @@ class GradingOrder extends AbstractModel {
                 return null;
             }
 
-        // Else $submitter is not in one of our sections so set $index to number of submitters in our sections
+            // Else $submitter is not in one of our sections so set $index to number of submitters in our sections
         }
         else {
             $count = 0;
@@ -345,7 +345,8 @@ class GradingOrder extends AbstractModel {
                 return null;
             }
             //Repeat until we find one that works
-        } while (!$fn($sub));
+        }
+        while (!$fn($sub));
 
         return $sub;
     }
@@ -366,7 +367,7 @@ class GradingOrder extends AbstractModel {
                 return null;
             }
 
-        // Else $submitter is not in one of our sections so set $index to -1
+            // Else $submitter is not in one of our sections so set $index to -1
         }
         else {
             $index = -1;
@@ -379,7 +380,8 @@ class GradingOrder extends AbstractModel {
                 return null;
             }
             //Repeat until we find one that works
-        } while (!$fn($sub));
+        }
+        while (!$fn($sub));
 
         return $sub;
     }

--- a/site/app/models/OfficeHoursQueueModel.php
+++ b/site/app/models/OfficeHoursQueueModel.php
@@ -350,8 +350,8 @@ class OfficeHoursQueueModel extends AbstractModel {
             $time_in = DateUtils::parseDateTime($this->getCurrentQueueTimeIn(), $this->core->getConfig()->getTimezone());
         }
         else {
-          //Check assuming their time_in is current time because then it assumes
-          //everyone not helped this week is in front of them
+            //Check assuming their time_in is current time because then it assumes
+            //everyone not helped this week is in front of them
             $time_in = $this->core->getDateTimeNow();
         }
         return $this->core->getQueries()->getNumberAheadInQueueThisWeek($this->getCurrentQueueCode(), $time_in);
@@ -362,8 +362,8 @@ class OfficeHoursQueueModel extends AbstractModel {
             $time_in = DateUtils::parseDateTime($this->getCurrentQueueTimeIn(), $this->core->getConfig()->getTimezone());
         }
         else {
-          //Check assuming their time_in is current time because then it assumes
-          //everyone not helped today is in front of them
+            //Check assuming their time_in is current time because then it assumes
+            //everyone not helped today is in front of them
             $time_in = $this->core->getDateTimeNow();
         }
         return $this->core->getQueries()->getNumberAheadInQueueToday($this->getCurrentQueueCode(), $time_in);

--- a/site/app/models/PDFGenerator.php
+++ b/site/app/models/PDFGenerator.php
@@ -7,8 +7,8 @@ use app\libraries\Core;
 class PDFGenerator extends AbstractModel {
     public function __construct(Core $core) {
         parent::__construct($core);
-//        $pdf = new Fpdi();
-//        $test = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'submissions/open_homework/instructor/6/upload.pdf');
-//        $pageCount = $pdf->setSourceFile($test);
+        //        $pdf = new Fpdi();
+        //        $test = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'submissions/open_homework/instructor/6/upload.pdf');
+        //        $pageCount = $pdf->setSourceFile($test);
     }
 }

--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -55,7 +55,7 @@ class RainbowCustomization extends AbstractModel {
      * which is a lot nicer to type.
      */
     //XXX: 'none (for practice only)' we want to truncate to just 'none'.
-    const syllabus_buckets = [
+    public const syllabus_buckets = [
         'homework', 'assignment', 'problem-set',
         'quiz', 'test', 'exam',
         'exercise', 'lecture-exercise', 'reading', 'lab', 'recitation', 'worksheet',

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -53,10 +53,10 @@ class RainbowCustomizationJSON extends AbstractModel {
     private array $warning = [];
 
     // The order of allowed_display and allowed_display_description has to match
-    const allowed_display = ['grade_summary', 'grade_details', 'exam_seating', 'section',
+    public const allowed_display = ['grade_summary', 'grade_details', 'exam_seating', 'section',
         'messages', 'warning', 'final_grade', 'final_cutoff', 'instructor_notes', 'display_rank_to_individual'];
 
-    const allowed_display_description = [
+    public const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary
         "Display a column(row) for each gradeable within each gradeable bucket on the syllabus.", //grade_details
         "Used for assigned seating for exams, see also:  <a href='https://submitty.org/instructor/course_settings/rainbow_grades/exam_seating'>Exam Seating</a> ", //exam_seating
@@ -70,7 +70,7 @@ class RainbowCustomizationJSON extends AbstractModel {
     ];
 
 
-    const allowed_display_benchmarks = ["average", "stddev", "perfect", "lowest_a-", "lowest_b-", "lowest_c-",
+    public const allowed_display_benchmarks = ["average", "stddev", "perfect", "lowest_a-", "lowest_b-", "lowest_c-",
         "lowest_d"
     ];
 

--- a/site/app/models/Team.php
+++ b/site/app/models/Team.php
@@ -50,7 +50,7 @@ class Team extends AbstractModel {
     protected $team_name;
     /** @prop
      * @var number Maximum length of the team name */
-    const MAX_TEAM_NAME_LENGTH = 30;
+    public const MAX_TEAM_NAME_LENGTH = 30;
     /**
      * Team constructor.
      * @param Core  $core
@@ -110,7 +110,8 @@ class Team extends AbstractModel {
                     /** @noinspection PhpUnhandledExceptionInspection */
                     $random .= $alpha[random_int(0, $alpha_length)];
                 }
-            } while (in_array($random, $anon_ids));
+            }
+            while (in_array($random, $anon_ids));
             $this->anon_id = $random;
             $this->core->getQueries()->updateTeamAnonId($this->getId(), $random);
         }

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -60,32 +60,32 @@ class User extends AbstractModel {
      * Access groups, lower is more access
      */
 
-    const GROUP_INSTRUCTOR            = 1;
-    const GROUP_FULL_ACCESS_GRADER    = 2;
-    const GROUP_LIMITED_ACCESS_GRADER = 3;
-    const GROUP_STUDENT               = 4;
+    public const GROUP_INSTRUCTOR            = 1;
+    public const GROUP_FULL_ACCESS_GRADER    = 2;
+    public const GROUP_LIMITED_ACCESS_GRADER = 3;
+    public const GROUP_STUDENT               = 4;
     /** Logged out */
-    const GROUP_NONE                  = 5;
+    public const GROUP_NONE                  = 5;
 
     /**
      * Access levels, lower level means more access
      */
-    const LEVEL_SUPERUSER             = 1;
-    const LEVEL_FACULTY               = 2;
-    const LEVEL_USER                  = 3;
+    public const LEVEL_SUPERUSER             = 1;
+    public const LEVEL_FACULTY               = 2;
+    public const LEVEL_USER                  = 3;
 
     /**
      * Profile image set return codes
      */
-    const PROFILE_IMG_SET_FAILURE = 0;
-    const PROFILE_IMG_SET_SUCCESS = 1;
+    public const PROFILE_IMG_SET_FAILURE = 0;
+    public const PROFILE_IMG_SET_SUCCESS = 1;
     /** Profile image quota of 50 images exhausted */
-    const PROFILE_IMG_QUOTA_EXHAUSTED = 2;
+    public const PROFILE_IMG_QUOTA_EXHAUSTED = 2;
 
     /**
      * Last initial display formats
      */
-    const LAST_INITIAL_FORMATS = [ "Single", "Multi", "Hyphen-Multi", "None" ];
+    public const LAST_INITIAL_FORMATS = [ "Single", "Multi", "Hyphen-Multi", "None" ];
 
     /** @prop
      * @var bool Is this user actually loaded (else you cannot access the other member variables) */
@@ -578,7 +578,7 @@ class User extends AbstractModel {
                 $spaced = preg_split('/\s+/', $family_name, -1, PREG_SPLIT_NO_EMPTY);
                 foreach ($spaced as $part) {
                     $dashed = explode('-', $part);
-                    $l = array_map(fn(string $part) => $part[0], $dashed);
+                    $l = array_map(fn (string $part) => $part[0], $dashed);
                     $last_initial .= implode('-', $l) . '.';
                 }
                 break;
@@ -645,7 +645,8 @@ class User extends AbstractModel {
                     /** @noinspection PhpUnhandledExceptionInspection */
                     $random .= $alpha[random_int(0, $alpha_length)];
                 }
-            } while (in_array($random, $anon_ids));
+            }
+            while (in_array($random, $anon_ids));
             $this->core->getQueries()->insertGradeableAnonId($this->id, $g_id, $random);
         }
         return $anon_id ?? $random ?? null;
@@ -662,8 +663,8 @@ class User extends AbstractModel {
 
         switch ($field) {
             case 'user_id':
-                 //Username / user_id must contain only lowercase alpha,
-                 //numbers, underscores, hyphens
+                //Username / user_id must contain only lowercase alpha,
+                //numbers, underscores, hyphens
                 return preg_match("~^[a-z0-9_\-]+$~", $data) === 1;
             case 'user_legal_givenname':
             case 'user_legal_familyname':

--- a/site/app/models/gradeable/AutoGradedVersion.php
+++ b/site/app/models/gradeable/AutoGradedVersion.php
@@ -560,7 +560,7 @@ class AutoGradedVersion extends AbstractModel {
         }
     }
 
-    const point_properties = [
+    public const point_properties = [
         'non_hidden_non_extra_credit',
         'non_hidden_extra_credit',
         'hidden_non_extra_credit',

--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -98,9 +98,9 @@ class Component extends AbstractModel {
     private $any_grades = false;
 
     /** @var int Pass to setPage to indicate student-assigned pdf page */
-    const PDF_PAGE_STUDENT = -1;
+    public const PDF_PAGE_STUDENT = -1;
     /** @var int Pass to setPage to indicate no pdf page */
-    const PDF_PAGE_NONE = 0;
+    public const PDF_PAGE_NONE = 0;
 
     /**
      * Component constructor.
@@ -238,7 +238,7 @@ class Component extends AbstractModel {
         $this->modified = true;
     }
 
-    const point_properties = [
+    public const point_properties = [
         'lower_clamp',
         'default',
         'max_value',

--- a/site/app/models/gradeable/GradeInquiry.php
+++ b/site/app/models/gradeable/GradeInquiry.php
@@ -15,8 +15,8 @@ use app\models\AbstractModel;
  * @method int getGcId()
  */
 class GradeInquiry extends AbstractModel {
-    const STATUS_RESOLVED = 0;
-    const STATUS_ACTIVE = -1;
+    public const STATUS_RESOLVED = 0;
+    public const STATUS_ACTIVE = -1;
 
     /** @var int The unique Id of this grade inquiry */
     private $id = 0;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -120,7 +120,7 @@ class Gradeable extends AbstractModel {
     /**
      * Enum range for blind and unblind grading:
      * 1 is unblind, 2 is single blind, 3 is double blind
-    */
+     */
 
     public const UNBLIND_GRADING = 1;
     public const SINGLE_BLIND_GRADING = 2;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -113,18 +113,18 @@ use app\controllers\admin\AdminGradeableController;
  */
 class Gradeable extends AbstractModel {
     /* Enum range for grader_assignment_method */
-    const ROTATING_SECTION = 0;
-    const REGISTRATION_SECTION = 1;
-    const ALL_ACCESS = 2;
+    public const ROTATING_SECTION = 0;
+    public const REGISTRATION_SECTION = 1;
+    public const ALL_ACCESS = 2;
 
     /**
      * Enum range for blind and unblind grading:
      * 1 is unblind, 2 is single blind, 3 is double blind
     */
 
-    const UNBLIND_GRADING = 1;
-    const SINGLE_BLIND_GRADING = 2;
-    const DOUBLE_BLIND_GRADING = 3;
+    public const UNBLIND_GRADING = 1;
+    public const SINGLE_BLIND_GRADING = 2;
+    public const DOUBLE_BLIND_GRADING = 3;
 
     /* Properties for all types of gradeables */
 
@@ -453,7 +453,7 @@ class Gradeable extends AbstractModel {
     /**
      * All \DateTime properties for this class
      */
-    const date_properties = [
+    public const date_properties = [
         'ta_view_start_date',
         'team_lock_date',
         'submission_open_date',
@@ -468,7 +468,7 @@ class Gradeable extends AbstractModel {
     /**
      * Display names for the different date properties (for forming error messages)
      */
-    const date_display_names = [
+    public const date_display_names = [
         'ta_view_start_date' => 'Beta Testing',
         'submission_open_date' => 'Submission Open',
         'submission_due_date' => 'Submission Due',
@@ -484,7 +484,7 @@ class Gradeable extends AbstractModel {
     /**
      * All \DateTime properties that should be validated
      */
-    const date_validated_properties = [
+    public const date_validated_properties = [
         'ta_view_start_date',
         'team_lock_date',
         'submission_open_date',
@@ -500,7 +500,7 @@ class Gradeable extends AbstractModel {
      * All \DateTime properties for NUMERIC_TEXT and CHECKPOINT gradeables
      * Note: this is in validation order
      */
-    const date_properties_simple = [
+    public const date_properties_simple = [
         'ta_view_start_date',
         'grade_start_date',
         'grade_due_date',
@@ -511,7 +511,7 @@ class Gradeable extends AbstractModel {
      * All \DateTime properties for ELECTRONIC gradeables with ta grading
      * Note: this is in validation order
      */
-    const date_properties_elec_ta = [
+    public const date_properties_elec_ta = [
         'ta_view_start_date',
         'submission_open_date',
         'grade_start_date',
@@ -522,7 +522,7 @@ class Gradeable extends AbstractModel {
      * All \DateTime properties for ELECTRONIC gradeables with no ta grading
      * Note: this is in validation order
      */
-    const date_properties_elec_no_ta = [
+    public const date_properties_elec_no_ta = [
         'ta_view_start_date',
         'submission_open_date'
     ];
@@ -531,7 +531,7 @@ class Gradeable extends AbstractModel {
      * All \DateTime properties for ELECTRONIC exam gradeables
      * Note: this is in validation order
      */
-    const date_properties_elec_exam = [
+    public const date_properties_elec_exam = [
         'ta_view_start_date',
         'grade_start_date',
         'grade_due_date'
@@ -542,7 +542,7 @@ class Gradeable extends AbstractModel {
      * Note: This is also the set for no student upload AND no ta grading
      * Note: this is in validation order
      */
-    const date_properties_bare = [
+    public const date_properties_bare = [
         'ta_view_start_date'
     ];
 
@@ -676,9 +676,9 @@ class Gradeable extends AbstractModel {
             }
             $query_string = chop($query_string, ',');
             $query_string .= ";";
-                $this->core->getQueries()->insertBulkPeerGradingAssignment($query_string);
-                $this->modified = true;
-                $this->peer_grading_pairs = $this->core->getQueries()->getPeerGradingAssignment($this->getId());
+            $this->core->getQueries()->insertBulkPeerGradingAssignment($query_string);
+            $this->modified = true;
+            $this->peer_grading_pairs = $this->core->getQueries()->getPeerGradingAssignment($this->getId());
         }
     }
     public function setPeerGradersList($input) {
@@ -1802,7 +1802,7 @@ class Gradeable extends AbstractModel {
      * @return bool True if the gradeable can be deleted
      */
     public function canDelete() {
-//        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
+        //        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
         return false;
     }
 

--- a/site/app/models/gradeable/GradeableList.php
+++ b/site/app/models/gradeable/GradeableList.php
@@ -26,12 +26,12 @@ use app\models\User;
  * @method \app\models\gradeable\Gradeable[] getGradedGradeables()
  */
 class GradeableList extends AbstractModel {
-    const FUTURE  = 0;
-    const BETA    = 1;
-    const OPEN    = 2;
-    const CLOSED  = 3;
-    const GRADING = 4;
-    const GRADED  = 5;
+    public const FUTURE  = 0;
+    public const BETA    = 1;
+    public const OPEN    = 2;
+    public const CLOSED  = 3;
+    public const GRADING = 4;
+    public const GRADED  = 5;
 
     /** @prop
      * @var User */

--- a/site/app/models/gradeable/GradeableUtils.php
+++ b/site/app/models/gradeable/GradeableUtils.php
@@ -9,12 +9,12 @@ use app\models\User;
 use app\views\NavigationView;
 
 class GradeableUtils {
-    const VCS_TYPE_NONE = -1;
-    const VCS_TYPE_SUBMITTY_HOSTED = 0;
-    const VCS_TYPE_SUBMITTY_HOSTED_URL = 1;
-    const VCS_TYPE_PUBLIC_GITHUB = 2;
-    const VCS_TYPE_PRIVATE_GITHUB = 3;
-    const VCS_TYPE_SELF_HOSTED = 4;
+    public const VCS_TYPE_NONE = -1;
+    public const VCS_TYPE_SUBMITTY_HOSTED = 0;
+    public const VCS_TYPE_SUBMITTY_HOSTED_URL = 1;
+    public const VCS_TYPE_PUBLIC_GITHUB = 2;
+    public const VCS_TYPE_PRIVATE_GITHUB = 3;
+    public const VCS_TYPE_SELF_HOSTED = 4;
 
     /**
      * Get the gradeables of a specified course.

--- a/site/app/models/gradeable/LateDayInfo.php
+++ b/site/app/models/gradeable/LateDayInfo.php
@@ -17,10 +17,10 @@ use app\models\User;
  * @method string getId()
  */
 class LateDayInfo extends AbstractModel {
-    const STATUS_NO_ACTIVE_VERSION = 0;
-    const STATUS_GOOD = 1;
-    const STATUS_LATE = 2;
-    const STATUS_BAD = 3;
+    public const STATUS_NO_ACTIVE_VERSION = 0;
+    public const STATUS_GOOD = 1;
+    public const STATUS_LATE = 2;
+    public const STATUS_BAD = 3;
 
     public static function isValidStatus(int $status): bool {
         return in_array($status, [self::STATUS_GOOD, self::STATUS_LATE, self::STATUS_BAD]);
@@ -338,6 +338,7 @@ class LateDayInfo extends AbstractModel {
                 else {
                     return 'No Submission';
                 }
+                // no break
             case self::STATUS_GOOD:
                 return 'Good';
             case self::STATUS_LATE:
@@ -350,6 +351,7 @@ class LateDayInfo extends AbstractModel {
                 else {
                     return 'Bad (too many late days used on this assignment)';
                 }
+                // no break
             default:
                 return 'INTERNAL ERROR';
         }

--- a/site/app/models/gradeable/LateDays.php
+++ b/site/app/models/gradeable/LateDays.php
@@ -111,13 +111,15 @@ class LateDays extends AbstractModel {
                     'gg' => $gg
                 ];
             }, $graded_gradeables),
-            array_map(function ($update) {
-                return [
-                    'timestamp' => $update['since_timestamp'],
-                    'update' => $update
-                ];
-            },
-            $this->late_days_updates)
+            array_map(
+                function ($update) {
+                    return [
+                        'timestamp' => $update['since_timestamp'],
+                        'update' => $update
+                    ];
+                },
+                $this->late_days_updates
+            )
         );
 
         // Sort by 'timestamp'

--- a/site/app/models/gradeable/TaGradedGradeable.php
+++ b/site/app/models/gradeable/TaGradedGradeable.php
@@ -144,13 +144,13 @@ class TaGradedGradeable extends AbstractModel {
         }
 
         // Uncomment this block if we want to serialize these values all the time
-//        $percent_graded = $this->getPercentGraded();
-//        $percent_graded = is_nan($percent_graded) ? 0 : $percent_graded;
-//        $details['percent_graded'] = $percent_graded;
-//
-//        $graded_percent = $this->getGradedPercent();
-//        $graded_percent = is_nan($graded_percent) ? 0 : $graded_percent;
-//        $details['graded_percent'] = $graded_percent;
+        //        $percent_graded = $this->getPercentGraded();
+        //        $percent_graded = is_nan($percent_graded) ? 0 : $percent_graded;
+        //        $details['percent_graded'] = $percent_graded;
+        //
+        //        $graded_percent = $this->getGradedPercent();
+        //        $graded_percent = is_nan($graded_percent) ? 0 : $graded_percent;
+        //        $details['graded_percent'] = $graded_percent;
 
         return $details;
     }

--- a/site/app/models/notebook/Notebook.php
+++ b/site/app/models/notebook/Notebook.php
@@ -49,7 +49,7 @@ class Notebook extends AbstractModel {
 
 
     protected function parseNotebook(array $details): void {
-         // Setup $this->notebook
+        // Setup $this->notebook
         $actual_input = [];
         $this->notebook = [];
         $this->item_pool = $details["item_pool"] ?? [];
@@ -120,7 +120,7 @@ class Notebook extends AbstractModel {
         // Setup $this->inputs
         for ($i = 0; $i < count($actual_input); $i++) {
             if ($actual_input[$i]['type'] == 'short_answer') {
-                    $this->inputs[$i] = new SubmissionCodeBox($this->core, $actual_input[$i]);
+                $this->inputs[$i] = new SubmissionCodeBox($this->core, $actual_input[$i]);
             }
             elseif ($actual_input[$i]['type'] == 'multiple_choice') {
                 $actual_input[$i]['allow_multiple'] = $actual_input[$i]['allow_multiple'] ?? false;
@@ -153,16 +153,16 @@ class Notebook extends AbstractModel {
     }
 
 
-   /**
-    * Gets a new 'notebook' which contains information about most recent submissions
-    *
-    * @return array An updated 'notebook' which has the most recent submission data entered into the
-    * @param array $new_notebook a notebook config to parse
-    * @param int $version which version to get notebook submission values from
-    * @param string $student_id which student's notebook to pull data from
-    * @param ?int $display_version selected version (may not be active version)
-    * @param string $gradeable_id
-    */
+    /**
+     * Gets a new 'notebook' which contains information about most recent submissions
+     *
+     * @return array An updated 'notebook' which has the most recent submission data entered into the
+     * @param array $new_notebook a notebook config to parse
+     * @param int $version which version to get notebook submission values from
+     * @param string $student_id which student's notebook to pull data from
+     * @param ?int $display_version selected version (may not be active version)
+     * @param string $gradeable_id
+     */
     public function getMostRecentNotebookSubmissions(int $version, array $new_notebook, string $student_id, ?int $display_version, string $gradeable_id): array {
         foreach ($new_notebook as $notebookKey => $notebookVal) {
             if (isset($notebookVal['type'])) {

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -5,8 +5,8 @@ namespace app\repositories\email;
 use Doctrine\ORM\EntityRepository;
 
 class EmailRepository extends EntityRepository {
-    const PAGE_SIZE = 5000;
-    const MAX_SUBJECTS_PER_PAGE = 10;
+    public const PAGE_SIZE = 5000;
+    public const MAX_SUBJECTS_PER_PAGE = 10;
 
     public function getEmailsByPage(int $page, $semester = null, $course = null): array {
         $subjects = $this->getPageSubjects($page, $semester, $course);

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -578,10 +578,10 @@ class AutoGradingView extends AbstractView {
 
                     'show_mark' => $mark->isPublish() || $container->hasMark($mark),
                     'earned' => array_map(function (User $grader) use ($mark, $container) {
-                                    return $container->hasMark($mark, $grader);
+                        return $container->hasMark($mark, $grader);
                     }, $container->getGraders()),
                     'num_earned' => count(array_filter($container->getGraders(), function (User $grader) use ($mark, $container) {
-                                    return $container->hasMark($mark, $grader);
+                        return $container->hasMark($mark, $grader);
                     })),
                 ];
             }, $component->getMarks());

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -15,7 +15,7 @@ use app\models\gradeable\GradeableList;
 use app\libraries\FileUtils;
 
 class NavigationView extends AbstractView {
-    const gradeableSections = [
+    public const gradeableSections = [
         GradeableList::FUTURE => [
             //What title is displayed to the user for each category
             "title" => "FUTURE",

--- a/site/app/views/UserProfileView.php
+++ b/site/app/views/UserProfileView.php
@@ -38,14 +38,14 @@ class UserProfileView extends AbstractView {
 
         $user_utc_offset = DateUtils::getUTCOffset($user->getTimeZone());
         $user_time_zone_with_offset = $user_utc_offset === 'NOT SET'
-            ?  $user->getTimeZone()
+            ? $user->getTimeZone()
             : "(UTC" . $user_utc_offset . ") " . $user->getTimeZone();
 
         $this->core->getOutput()->addInternalModuleJs('user-profile.js');
 
         $curr_locale = $this->core->getConfig()->getLocale()->getName();
         $supported_locales = $this->core->getSupportedLocales() ?? [];
-        $locale_names = array_map(fn(string $locale): string => mb_convert_case(\Locale::getDisplayName($locale, $curr_locale), MB_CASE_TITLE, 'UTF-8'), $supported_locales);
+        $locale_names = array_map(fn (string $locale): string => mb_convert_case(\Locale::getDisplayName($locale, $curr_locale), MB_CASE_TITLE, 'UTF-8'), $supported_locales);
         $supported_locales = array_combine($supported_locales, $locale_names);
         $default_locale_name = mb_convert_case(\Locale::getDisplayName($this->core->getConfig()->getDefaultLocaleName(), $curr_locale), MB_CASE_TITLE, 'UTF-8');
 

--- a/site/app/views/calendar/CalendarView.php
+++ b/site/app/views/calendar/CalendarView.php
@@ -24,8 +24,8 @@ class CalendarView extends AbstractView {
      */
     public function showCalendar(CalendarInfo $info, GlobalCalendarInfo $global_info, array $courses, bool $in_course = false): string {
 
-        $year = (isset($_GET['year']) && $_GET['year'] != "")  ?  (int) $_GET['year']  : (int) date("Y");
-        $month = (isset($_GET['month']) && $_GET['month'] != "") ?  (int) $_GET['month'] : (int) date("n");
+        $year = (isset($_GET['year']) && $_GET['year'] != "") ? (int) $_GET['year'] : (int) date("Y");
+        $month = (isset($_GET['month']) && $_GET['month'] != "") ? (int) $_GET['month'] : (int) date("n");
         $show_table = (isset($_GET['show_table'])) ? (int) $_GET['show_table'] : 0; // not showing the table by default
 
         // Error checking
@@ -71,7 +71,7 @@ class CalendarView extends AbstractView {
         $course_colors["PURPLE"]    = "var(--category-color-8)";
 
         //Get if legend will be displayed
-        $show_legend = (isset($_COOKIE['show_legend']))  ?  (int) $_COOKIE['show_legend'] : 1;
+        $show_legend = (isset($_COOKIE['show_legend'])) ? (int) $_COOKIE['show_legend'] : 1;
 
         $this->core->getOutput()->addInternalCss("navigation.css");
         $this->core->getOutput()->addInternalCss('calendar.css');

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -204,11 +204,11 @@ class ForumThreadView extends AbstractView {
 
         if (!$ajax) {
             $this->core->getOutput()->addBreadcrumb("Discussion Forum", $this->core->buildCourseUrl(['forum']), null, true);
-             // Add breadcrumb for the current thread
-             $max_length = 25;
-             $fullTitle = $thread->getTitle();
-             $title = strlen($fullTitle) > $max_length ? substr($fullTitle, 0, $max_length - 3) . "..." : $fullTitle;
-             $this->core->getOutput()->addBreadcrumb("(" . $thread->getId() . ") " . $title, $this->core->buildCourseUrl(['forum', 'threads', $thread->getId()]), null, true);
+            // Add breadcrumb for the current thread
+            $max_length = 25;
+            $fullTitle = $thread->getTitle();
+            $title = strlen($fullTitle) > $max_length ? substr($fullTitle, 0, $max_length - 3) . "..." : $fullTitle;
+            $this->core->getOutput()->addBreadcrumb("(" . $thread->getId() . ") " . $title, $this->core->buildCourseUrl(['forum', 'threads', $thread->getId()]), null, true);
 
             //Body Style is necessary to make sure that the forum is still readable...
             $this->core->getOutput()->addVendorCss('codemirror/codemirror.css');
@@ -862,7 +862,8 @@ class ForumThreadView extends AbstractView {
         $post_content = $post->getContent();
         do {
             $post_content = preg_replace('/(?:!\[(.*?)\]\((.*?)\))/', '$2', $post_content, -1, $count);
-        } while ($count > 0);
+        }
+        while ($count > 0);
 
         $post_user_info = [];
 

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -144,14 +144,14 @@ class ElectronicGraderView extends AbstractView {
             $graded_total = $num_components > 0 ? round($graded / $num_components, 2) : 0;
             $non_late_graded_total = $num_components > 0 ? round($non_late_graded / $num_components, 2) : 0;
             if ($submitted_total > 0) {
-                $total_grading_percentage =  number_format(($graded_total / $submitted_total ) * 100, 1);
+                $total_grading_percentage =  number_format(($graded_total / $submitted_total) * 100, 1);
             }
             else {
                 $total_grading_percentage = 0;
             }
 
             if ($non_late_submitted_total > 0) {
-                $non_late_total_grading_percentage =  number_format(($non_late_graded_total / $non_late_submitted_total ) * 100, 1);
+                $non_late_total_grading_percentage =  number_format(($non_late_graded_total / $non_late_submitted_total) * 100, 1);
             }
             else {
                 $non_late_total_grading_percentage = 0;
@@ -191,12 +191,12 @@ class ElectronicGraderView extends AbstractView {
                     if ($num_peer_components > 0) {
                         $total_students_submitted =  floor(($sections['peer_stu_grad']['total_who_submitted']));
                         $submitted_percentage_peer = round((($total_students_submitted) / $total_submissions) * 100, 1);
-                        $total_grading_percentage =  number_format(($graded_total / $total_students_submitted ) * 100, 1);
+                        $total_grading_percentage =  number_format(($graded_total / $total_students_submitted) * 100, 1);
                         $entire_peer_total =  floor(($sections['peer_stu_grad']['view_peer_components']));
                         $entire_peer_graded =  $sections['peer_stu_grad']['view_peer_graded_components'] / $num_peer_components;
                     }
                     if ($entire_peer_total > 0) {
-                        $entire_peer_percentage = number_format(($entire_peer_graded / ($entire_peer_total) ) * 100, 1);
+                        $entire_peer_percentage = number_format(($entire_peer_graded / ($entire_peer_total)) * 100, 1);
                     }
                     else {
                         $entire_peer_percentage = 0;
@@ -214,7 +214,7 @@ class ElectronicGraderView extends AbstractView {
                         }
                     }
                     if ($peer_total > 0) {
-                        $peer_percentage = number_format(($peer_graded / ($peer_total) ) * 100, 1);
+                        $peer_percentage = number_format(($peer_graded / ($peer_total)) * 100, 1);
                     }
                     else {
                         $peer_percentage = 0;
@@ -249,7 +249,7 @@ class ElectronicGraderView extends AbstractView {
                     $section['non_late_verified_percentage'] = number_format(($section['non_late_verified'] / $section['non_late_total']) * 100, 1);
                 }
             }
-                unset($section); // Clean up reference
+            unset($section); // Clean up reference
 
             if ($gradeable->isTaGradeReleased()) {
                 if ($peer) {
@@ -1097,26 +1097,26 @@ HTML;
                     <div class="content-item content-item-right">
 HTML;
 
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2), $anon_mode, $blind_grading);
-            $return .= $this->core->getOutput()->renderTemplate(
-                ['grading', 'ElectronicGrader'],
-                'renderGradingPanelHeader',
-                $isPeerPanel,
-                $isPeerGrader,
-                $isPeerAutograding,
-                $isPeerRubric,
-                $isPeerFiles,
-                $isPeerSolutions,
-                $isPeerDiscussion,
-                $isStudentInfoPanel,
-                $isDiscussionPanel,
-                $isGradeInquiryPanel,
-                $gradeable->getAutogradingConfig()->isNotebookGradeable(),
-                $error_message['color'],
-                $error_message['message']
-            );
+        $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() == User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() == 2), $anon_mode, $blind_grading);
+        $return .= $this->core->getOutput()->renderTemplate(
+            ['grading', 'ElectronicGrader'],
+            'renderGradingPanelHeader',
+            $isPeerPanel,
+            $isPeerGrader,
+            $isPeerAutograding,
+            $isPeerRubric,
+            $isPeerFiles,
+            $isPeerSolutions,
+            $isPeerDiscussion,
+            $isStudentInfoPanel,
+            $isDiscussionPanel,
+            $isGradeInquiryPanel,
+            $gradeable->getAutogradingConfig()->isNotebookGradeable(),
+            $error_message['color'],
+            $error_message['message']
+        );
 
-            $return .= <<<HTML
+        $return .= <<<HTML
                 <div class="panels-container">
                     <div class="two-panel-cont">
                          <div class="two-panel-item two-panel-left active">

--- a/site/app/views/grading/ImagesView.php
+++ b/site/app/views/grading/ImagesView.php
@@ -9,13 +9,13 @@ use app\libraries\Utils;
 
 class ImagesView extends AbstractView {
     /** Defines the html for the icon used to flag an image */
-    const FLAG_ICON_HTML = '<i class="fas fa-flag"></i>';
+    public const FLAG_ICON_HTML = '<i class="fas fa-flag"></i>';
 
     /** Defines the html for the icon used to unflag an image */
-    const UNDO_ICON_HTML = '<i class="fas fa-undo"></i>';
+    public const UNDO_ICON_HTML = '<i class="fas fa-undo"></i>';
 
     /** Defines the maximum dimension for images being displayed on the student photos page */
-    const IMG_MAX_DIMENSION = 200;
+    public const IMG_MAX_DIMENSION = 200;
 
     /**
      * @param User[] $students

--- a/site/app/views/grading/popup_refactor/RubricGraderView.php
+++ b/site/app/views/grading/popup_refactor/RubricGraderView.php
@@ -15,6 +15,7 @@
  */
 
 // Namespace:
+
 namespace app\views\grading\popup_refactor;
 
 // Includes:

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -177,7 +177,7 @@ class HomeworkView extends AbstractView {
         $active_days_late =  $late_day_info !== null ? $late_day_info->getDaysLate() : 0;
         $extensions = $late_day_info !== null ? $late_day_info->getLateDayException() : 0;
         $active_days_charged = $late_day_info !== null ? $late_day_info->getLateDaysCharged() : $active_days_late - $extensions;
-        $late_day_budget = $late_day_info !== null ? $late_day_info->getLateDaysRemaining() :  $late_days_remaining;
+        $late_day_budget = $late_day_info !== null ? $late_day_info->getLateDaysRemaining() : $late_days_remaining;
 
         $late_days_allowed = $gradeable->getLateDays();
 
@@ -226,7 +226,7 @@ class HomeworkView extends AbstractView {
                         $daylight_message_required = intval($due_date->format("m")) < 6 && intval($due_date_with_late_days->format("m")) > 6;
                     }
 
-                // different year, only false if we go from second non-DST to first non-DST
+                    // different year, only false if we go from second non-DST to first non-DST
                 }
                 else {
                     if (
@@ -829,10 +829,10 @@ class HomeworkView extends AbstractView {
         ]);
     }
 
-     /**
-      * @param GradedGradeable $graded_gradeable
-      * @return string
-      */
+    /**
+     * @param GradedGradeable $graded_gradeable
+     * @return string
+     */
     private function renderLeaderboardBox(GradedGradeable $graded_gradeable): string {
         $autograding_config = $graded_gradeable->getGradeable()->getAutogradingConfig();
         if (is_null($autograding_config)) {
@@ -847,12 +847,12 @@ class HomeworkView extends AbstractView {
         ]);
     }
 
-     /**
-      * @param GradedGradeable $graded_gradeable
-      * @param AutoGradedVersion|null $version_instance
-      * @param bool $show_hidden
-      * @return string
-      */
+    /**
+     * @param GradedGradeable $graded_gradeable
+     * @param AutoGradedVersion|null $version_instance
+     * @param bool $show_hidden
+     * @return string
+     */
     private function renderTotalScoreBox(GradedGradeable $graded_gradeable, $version_instance, bool $show_hidden): string {
         $gradeable = $graded_gradeable->getGradeable();
         $autograding_config = $gradeable->getAutogradingConfig();
@@ -971,12 +971,12 @@ class HomeworkView extends AbstractView {
         );
     }
 
-     /**
-      * @param GradedGradeable $graded_gradeable
-      * @param AutoGradedVersion|null $version_instance
-      * @param bool $show_hidden
-      * @return string
-      */
+    /**
+     * @param GradedGradeable $graded_gradeable
+     * @param AutoGradedVersion|null $version_instance
+     * @param bool $show_hidden
+     * @return string
+     */
     private function renderAutogradingBox(GradedGradeable $graded_gradeable, $version_instance, bool $show_hidden): string {
         $gradeable = $graded_gradeable->getGradeable();
         $autograding_config = $gradeable->getAutogradingConfig();
@@ -1154,7 +1154,7 @@ class HomeworkView extends AbstractView {
                 foreach ($param['files'] as $file) {
                     if (str_contains($file['relative_name'], 'failed')) {
                         $failed_file = file_get_contents($file['path']);
-                    // Exclude the Exception error message
+                        // Exclude the Exception error message
                         $failed_file = substr(strstr($failed_file, "\n"), 3);
                     }
                 }

--- a/site/composer.json
+++ b/site/composer.json
@@ -42,6 +42,7 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "1.0.0",
+    "friendsofphp/php-cs-fixer": "3.67.0",
     "php-mock/php-mock-phpunit": "2.9.0",
     "phpstan/phpstan": "1.10.57",
     "phpstan/phpstan-deprecation-rules": "1.1.4",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcada3d4a541299b759bd35d1585850a",
+    "content-hash": "569dd570f802da56f8003d337c9e4ca8",
     "packages": [
         {
             "name": "aptoma/twig-markdown",
@@ -5504,6 +5504,288 @@
     ],
     "packages-dev": [
         {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "04229f163664973f68f38f6f73d917799168ef24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/04229f163664973f68f38f6f73d917799168ef24",
+                "reference": "04229f163664973f68f38f6f73d917799168ef24",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-27T13:40:54+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T14:15:21+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v1.0.0",
             "source": {
@@ -5580,6 +5862,170 @@
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
             "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-06T10:04:20+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.67.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "0ad34c75d1172f7d30320460e803887981830cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/0ad34c75d1172f7d30320460e803887981830cbf",
+                "reference": "0ad34c75d1172f7d30320460e803887981830cbf",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.0",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.2",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.5",
+                "react/event-loop": "^1.0",
+                "react/promise": "^2.0 || ^3.0",
+                "react/socket": "^1.0",
+                "react/stream": "^1.0",
+                "sebastian/diff": "^4.0 || ^5.1 || ^6.0",
+                "symfony/console": "^5.4 || ^6.4 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.4 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.31",
+                "symfony/polyfill-php80": "^1.31",
+                "symfony/polyfill-php81": "^1.31",
+                "symfony/process": "^5.4 || ^6.4 || ^7.2",
+                "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.4",
+                "infection/infection": "^0.29.8",
+                "justinrainbow/json-schema": "^5.3 || ^6.0",
+                "keradus/cli-executor": "^2.1",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.7",
+                "php-cs-fixer/accessible-object": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.5",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.5",
+                "phpunit/phpunit": "^9.6.22 || ^10.5.40 || ^11.5.2",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.15 || ^7.2.0",
+                "symfony/yaml": "^5.4.45 || ^6.4.13 || ^7.2.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Fixer/Internal/*"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.67.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-08T10:17:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6713,6 +7159,135 @@
                 }
             ],
             "time": "2023-06-11T06:13:56+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "e71eb1aa55f057c7a4a0d08d06b0b0a484bead43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/e71eb1aa55f057c7a4a0d08d06b0b0a484bead43",
+                "reference": "e71eb1aa55f057c7a4a0d08d06b0b0a484bead43",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+                "react/socket": "^1.8",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/WyriHaximus",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-16T13:41:56+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -7872,6 +8447,416 @@
             "time": "2024-04-02T18:44:12+00:00"
         },
         {
+            "name": "symfony/event-dispatcher",
+            "version": "v6.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
+                "reference": "0ffc48080ab3e9132ea74ef4e09d8dcf26bf897e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<5.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:18:03+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v6.4.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "1d0e8266248c5d9ab6a87e3789e6dc482af3c9c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/1d0e8266248c5d9ab6a87e3789e6dc482af3c9c7",
+                "reference": "1d0e8266248c5d9ab6a87e3789e6dc482af3c9c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v6.4.17"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-29T13:51:37+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v6.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "368128ad168f20e22c32159b9f761e456cec0c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/368128ad168f20e22c32159b9f761e456cec0c78",
+                "reference": "368128ad168f20e22c32159b9f761e456cec0c78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-20T10:57:02+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v6.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3cb242f059c14ae08591c5c4087d1fe443564392",
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T14:19:14+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v6.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "2cae0a6f8d04937d02f6d19806251e2104d54f92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/2cae0a6f8d04937d02f6d19806251e2104d54f92",
+                "reference": "2cae0a6f8d04937d02f6d19806251e2104d54f92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v6.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:18:03+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.2",
             "source": {
@@ -7924,11 +8909,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },

--- a/site/phpcs.xml
+++ b/site/phpcs.xml
@@ -13,6 +13,7 @@
     <rule ref="SubmittyStandard">
         <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.NotSnakeCase" />
         <exclude name="SubmittyStandard.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
+        <exclude name="SubmittyStandard.ControlStructures.StroustrupStructure.Found" />
 
         <exclude name="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed" />
         <exclude name="Generic.Files.LineLength.TooLong" />

--- a/site/tests/LocalizeTest.php
+++ b/site/tests/LocalizeTest.php
@@ -25,7 +25,7 @@ class LocalizeTest extends \PHPUnit\Framework\TestCase {
 
             $body = file_get_contents($file['path']);
 
-            $blocks = array_map(fn($s) => explode('}}', $s)[0], array_slice(explode('{{', $body), 1));
+            $blocks = array_map(fn ($s) => explode('}}', $s)[0], array_slice(explode('{{', $body), 1));
 
             foreach ($blocks as $block) {
                 preg_match_all($expression, $block, $matches, PREG_SET_ORDER);

--- a/site/tests/app/controllers/admin/LateControllerTester.php
+++ b/site/tests/app/controllers/admin/LateControllerTester.php
@@ -9,7 +9,7 @@ use app\libraries\response\WebResponse;
 use app\controllers\admin\LateController;
 
 class LateControllerTester extends BaseUnitTest {
-   /** @var LateController */
+    /** @var LateController */
     protected $controller;
 
     /** @var Core */

--- a/site/tests/app/controllers/admin/SqlToolboxControllerTester.php
+++ b/site/tests/app/controllers/admin/SqlToolboxControllerTester.php
@@ -18,7 +18,7 @@ use ReflectionClass;
 use tests\BaseUnitTest;
 
 class SqlToolboxControllerTester extends BaseUnitTest {
-   /** @var SqlToolboxController */
+    /** @var SqlToolboxController */
     protected $controller;
 
     /** @var Core */

--- a/site/tests/app/entities/plagiarism/PlagiarismConfigTester.php
+++ b/site/tests/app/entities/plagiarism/PlagiarismConfigTester.php
@@ -124,17 +124,17 @@ class PlagiarismConfigTester extends BaseUnitTest {
     }
 
     public function testSetRegexDirs() {
-         // submissions dir
-         $this->my_config->setRegexDirSubmissions(false);
-         $this->assertFalse($this->my_config->isRegexDirSubmissionsSelected());
+        // submissions dir
+        $this->my_config->setRegexDirSubmissions(false);
+        $this->assertFalse($this->my_config->isRegexDirSubmissionsSelected());
 
-         // results dir
-         $this->my_config->setRegexDirResults(true);
-         $this->assertTrue($this->my_config->isRegexDirResultsSelected());
+        // results dir
+        $this->my_config->setRegexDirResults(true);
+        $this->assertTrue($this->my_config->isRegexDirResultsSelected());
 
-         // checkout dir
-         $this->my_config->setRegexDirCheckout(true);
-         $this->assertTrue($this->my_config->isRegexDirCheckoutSelected());
+        // checkout dir
+        $this->my_config->setRegexDirCheckout(true);
+        $this->assertTrue($this->my_config->isRegexDirCheckoutSelected());
     }
 
     public function testSetIgnoredPermissions() {

--- a/site/tests/app/libraries/database/DatabaseFactoryTester.php
+++ b/site/tests/app/libraries/database/DatabaseFactoryTester.php
@@ -36,9 +36,9 @@ class DatabaseFactoryTester extends BaseUnitTest {
     }
 
     public function testDatabaseFactoryInvalid() {
-         $factory = new DatabaseFactory('invalid');
-         $this->expectException(\app\exceptions\NotImplementedException::class);
-         $this->expectExceptionMessage('Database not implemented for driver: invalid');
-         $factory->getDatabase([]);
+        $factory = new DatabaseFactory('invalid');
+        $this->expectException(\app\exceptions\NotImplementedException::class);
+        $this->expectExceptionMessage('Database not implemented for driver: invalid');
+        $factory->getDatabase([]);
     }
 }

--- a/site/tests/app/libraries/database/QueryIdentifierTester.php
+++ b/site/tests/app/libraries/database/QueryIdentifierTester.php
@@ -21,7 +21,7 @@ class QueryIdentifierTester extends \PHPUnit\Framework\TestCase {
      * @dataProvider dataProvider
      */
     public function testIdentify(string $query, string $expected): void {
-         $this->assertEquals($expected, QueryIdentifier::identify($query));
+        $this->assertEquals($expected, QueryIdentifier::identify($query));
     }
 
     public function testCteSelectIdentify(): void {
@@ -73,7 +73,7 @@ class QueryIdentifierTester extends \PHPUnit\Framework\TestCase {
             left join G on A.user_id=G.user_id
             ORDER BY A.registration_section, A.user_familyname, A.user_givenname, A.user_id;
 SQL;
-          $this->assertEquals(QueryIdentifier::SELECT, QueryIdentifier::identify($query));
+        $this->assertEquals(QueryIdentifier::SELECT, QueryIdentifier::identify($query));
     }
 
     public function invalidQueriesDataProvider(): array {
@@ -88,6 +88,6 @@ SQL;
      * @dataProvider invalidQueriesDataProvider
      */
     public function testInvalidQueriesReturnUnknown(string $query): void {
-          $this->assertEquals(QueryIdentifier::UNKNOWN, QueryIdentifier::identify($query));
+        $this->assertEquals(QueryIdentifier::UNKNOWN, QueryIdentifier::identify($query));
     }
 }

--- a/site/tests/app/models/DisplayImageTester.php
+++ b/site/tests/app/models/DisplayImageTester.php
@@ -12,8 +12,8 @@ use app\models\DisplayImage;
 use tests\BaseUnitTest;
 
 class DisplayImageTester extends BaseUnitTest {
-    const TEST_USER_NAME = 'abc_test_user';
-    const TEST_IMAGE = 'test_image.gif';
+    public const TEST_USER_NAME = 'abc_test_user';
+    public const TEST_IMAGE = 'test_image.gif';
 
     private $core;
     private $test_image_path;


### PR DESCRIPTION
### What is the current behavior?
Submitty currently uses a [custom extension](https://github.com/Submitty/submitty-php-codesniffer) of [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) to ensure PHP code meets the [style guidelines](https://submitty.org/developer/software_and_system_design/coding_style_guide/php).  phpcs has undergone a significant amount of [turmoil](https://github.com/squizlabs/PHP_CodeSniffer/issues/3932) in the last few years and our configuration is partially broken as a result.

### What is the new behavior?
This PR adds [php-cs-fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) to the CI, using a subset of the existing rules.  Changes necessary to make the formatter pass are included.

### Other information?
A documentation PR will be forthcoming shortly.
