### PR TITLE
[Testing:TAGrading] Temporarily disable failing tests

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
@@ -32,7 +32,7 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="add-new-mark-button"]')
             .should('not.exist');
-        /* commented out due to issue #11309 TODO: Find permanent solution
+        /* commented out due to issue #11309 becuase Cypress drag and drop is flaky TODO: Find permanent solution
         cy.get('[data-testid^="component"]').eq(-1).click(20, 25);
         cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
             .should('contain', 'Save');

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
@@ -32,24 +32,24 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="add-new-mark-button"]')
             .should('not.exist');
-        cy.get('[data-testid^="component"]').eq(-1).click(20, 25);
-        cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
-            .should('contain', 'Save');
-        cy.get('[data-testid="mark-reorder"]').eq(-2).then(($el) => {
-            const rect = $el[0].getBoundingClientRect();
-            // Needed due to drag and drop weirdness
-            // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
-            cy.wrap($el)
-                .trigger('mousedown', { which: 1 })
-                .wait(1000)
-                .trigger('mousemove', { which: 1, force: true, pageX: rect.left + 40, pageY: rect.top - 30 })
-                .wait(1000)
-                .trigger('mouseup', { force: true });
-        });
-        cy.get('#edit-mode-enabled').click();
-        cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
-            .should('contain', 'Save');
-        cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-3).should('contain', 'Second New Mark');
-        cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-2).should('contain', 'First New Mark');
+        // cy.get('[data-testid^="component"]').eq(-1).click(20, 25);
+        // cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
+        //     .should('contain', 'Save');
+        // cy.get('[data-testid="mark-reorder"]').eq(-2).then(($el) => {
+        //     const rect = $el[0].getBoundingClientRect();
+        //     // Needed due to drag and drop weirdness
+        //     // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
+        //     cy.wrap($el)
+        //         .trigger('mousedown', { which: 1 })
+        //         .wait(1000)
+        //         .trigger('mousemove', { which: 1, force: true, pageX: rect.left + 40, pageY: rect.top - 30 })
+        //         .wait(1000)
+        //         .trigger('mouseup', { force: true });
+        // });
+        // cy.get('#edit-mode-enabled').click();
+        // cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
+        //     .should('contain', 'Save');
+        // cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-3).should('contain', 'Second New Mark');
+        // cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-2).should('contain', 'First New Mark');
     });
 });

--- a/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_editing.spec.js
@@ -32,24 +32,26 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="add-new-mark-button"]')
             .should('not.exist');
-        // cy.get('[data-testid^="component"]').eq(-1).click(20, 25);
-        // cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
-        //     .should('contain', 'Save');
-        // cy.get('[data-testid="mark-reorder"]').eq(-2).then(($el) => {
-        //     const rect = $el[0].getBoundingClientRect();
-        //     // Needed due to drag and drop weirdness
-        //     // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
-        //     cy.wrap($el)
-        //         .trigger('mousedown', { which: 1 })
-        //         .wait(1000)
-        //         .trigger('mousemove', { which: 1, force: true, pageX: rect.left + 40, pageY: rect.top - 30 })
-        //         .wait(1000)
-        //         .trigger('mouseup', { force: true });
-        // });
-        // cy.get('#edit-mode-enabled').click();
-        // cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
-        //     .should('contain', 'Save');
-        // cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-3).should('contain', 'Second New Mark');
-        // cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-2).should('contain', 'First New Mark');
+        /* commented out due to issue #11309 TODO: Find permanent solution
+        cy.get('[data-testid^="component"]').eq(-1).click(20, 25);
+        cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
+        cy.get('[data-testid="mark-reorder"]').eq(-2).then(($el) => {
+            const rect = $el[0].getBoundingClientRect();
+            // Needed due to drag and drop weirdness
+            // eslint-disable-next-line cypress/no-unnecessary-waiting, cypress/unsafe-to-chain-command
+            cy.wrap($el)
+                .trigger('mousedown', { which: 1 })
+                .wait(1000)
+                .trigger('mousemove', { which: 1, force: true, pageX: rect.left + 40, pageY: rect.top - 30 })
+                .wait(1000)
+                .trigger('mouseup', { force: true });
+        });
+        cy.get('#edit-mode-enabled').click();
+        cy.get('[data-testid^="component"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
+        cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-3).should('contain', 'Second New Mark');
+        cy.get('[data-testid^="component"] [data-testid="mark-title"]').eq(-2).should('contain', 'First New Mark');
+        */
     });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
During the creation of #11189, it was merged before the tests were finished (#11309). This means that currently on main the tests are failing and a proper fix will potentially take time to implement.

### What is the new behavior?
This is a stopgap measure, commenting out the failing parts of the tests with hope to fix them properly in the future.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
