### PR TITLE
[Bugfix:Forum] Fix sorting alpha by registration

### DIFF
--- a/site/app/repositories/forum/ThreadRepository.php
+++ b/site/app/repositories/forum/ThreadRepository.php
@@ -134,18 +134,19 @@ class ThreadRepository extends EntityRepository {
         }
         switch ($order_posts_by) {
             case 'alpha':
-                $qb->addOrderBy('postAuthor.user_familyname', 'ASC')
+                $qb->addSelect("COALESCE(NULLIF(postAuthor.user_preferred_familyname, ''), postAuthor.user_familyname) AS HIDDEN user_familyname_order")
+                    ->addOrderBy('user_familyname_order', 'ASC')
                     ->addOrderBy('post.timestamp', 'ASC')
                     ->addOrderBy('post.id', 'ASC');
                 break;
             case 'alpha_by_registration':
                 $qb->addOrderBy('postAuthor.registration_section', 'ASC')
-                    ->addSelect('COALESCE(postAuthor.user_preferred_familyname, postAuthor.user_familyname) AS HIDDEN user_familyname_order')
+                    ->addSelect("COALESCE(NULLIF(postAuthor.user_preferred_familyname, ''), postAuthor.user_familyname) AS HIDDEN user_familyname_order")
                     ->addOrderBy('user_familyname_order', 'ASC');
                 break;
             case 'alpha_by_rotating':
                 $qb->addOrderBy('postAuthor.rotating_section', 'ASC')
-                    ->addSelect('COALESCE(postAuthor.user_preferred_familyname, postAuthor.user_familyname) AS HIDDEN user_familyname_order')
+                    ->addSelect("COALESCE(NULLIF(postAuthor.user_preferred_familyname, ''), postAuthor.user_familyname) AS HIDDEN user_familyname_order")
                     ->addOrderBy('user_familyname_order', 'ASC');
                 break;
             case 'reverse-time':


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #11321. sorting forum posts by 'Alpha by registration' doesn't work on production due to empty strings instead of nulls in database.

### What is the new behavior?
Alpha by registration sorting now works as it checks for empty strings as well as nulls.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
