### PR TITLE
[Bugfix:Autograding] config file for remove docker

### DIFF
--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -3,6 +3,7 @@
 namespace app\controllers;
 
 use app\libraries\FileUtils;
+use app\libraries\Logger;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\WebResponse;
 use app\libraries\response\JsonResponse;
@@ -144,6 +145,7 @@ class DockerInterfaceController extends AbstractController {
                 ),
                 $json
             );
+            Logger::logAccess('check json', json_encode($json), $this->core->getConfig()->getSubmittyInstallPath());
 
             if (!$this->updateDocker()) {
                 return JsonResponse::getFailResponse("Could not update docker images, please try again later.");
@@ -224,10 +226,14 @@ class DockerInterfaceController extends AbstractController {
         foreach ($json as $capability_key => $capability) {
             if (($key = array_search($image, $capability, true)) !== false) {
                 unset($json[$capability_key][$key]);
+                $json[$capability_key] = array_values($json[$capability_key]); // Re-index array
             }
         }
 
-        file_put_contents($jsonFilePath, json_encode($json, JSON_PRETTY_PRINT));
+        FileUtils::writeJsonFile(
+           $jsonFilePath,
+            $json
+        );
         return JsonResponse::getSuccessResponse($image . ' removed from docker images!');
     }
 }

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -229,8 +229,8 @@ class DockerInterfaceController extends AbstractController {
         }
 
         FileUtils::writeJsonFile(
-           $jsonFilePath,
-            $json
+            $jsonFilePath,
+            $json,
         );
         return JsonResponse::getSuccessResponse($image . ' removed from docker images!');
     }

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -3,7 +3,6 @@
 namespace app\controllers;
 
 use app\libraries\FileUtils;
-use app\libraries\Logger;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\WebResponse;
 use app\libraries\response\JsonResponse;
@@ -145,7 +144,6 @@ class DockerInterfaceController extends AbstractController {
                 ),
                 $json
             );
-            Logger::logAccess('check json', json_encode($json), $this->core->getConfig()->getSubmittyInstallPath());
 
             if (!$this->updateDocker()) {
                 return JsonResponse::getFailResponse("Could not update docker images, please try again later.");

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -223,8 +223,7 @@ class DockerInterfaceController extends AbstractController {
 
         foreach ($json as $capability_key => $capability) {
             if (($key = array_search($image, $capability, true)) !== false) {
-                unset($json[$capability_key][$key]);
-                $json[$capability_key] = array_values($json[$capability_key]); // Re-index array
+                array_splice($json[$capability_key], $key, 1);
             }
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Removing an image from the below `config`

```
{
    "default": [
        "grycap/cowsay:latest"
    ],
    "cpp": [
        "grycap/cowsay:latest"
    ],
    "et-cetera": [
        "grycap/cowsay:latest"
    ],
    "python": [
        "ubuntu/squid:latest",
        "ubuntu/squid:edge"
    ]
}
```

results in
```
{
    "default": [
        "grycap\/cowsay:latest"
    ],
    "cpp": [
        "grycap\/cowsay:latest"
    ],
    "et-cetera": [
        "grycap\/cowsay:latest"
    ],
    "python": [
        "ubuntu\/squid:latest"
    ]
}
```

and further removing also results in
**array based json indexing**

```
{
    "default": [
        "grycap\/cowsay:latest"
    ],
    "cpp": [
        "grycap\/cowsay:latest",
        "ubuntu\/squid:edge"
    ],
    "et-cetera": [
        "grycap\/cowsay:latest"
    ],
    "python": {
        "1": "ubuntu\/squid:edge"
    }
```

### What is the new behavior?
This PR fixes both the above mentioned issues and Fixes #11308

- Fixes the encode and write to file process
- Fixes the repercussion of unset of array inside json object by re-indexing the json value array

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
