### PR TITLE
[Refactor:Developer] PHPStan: ignore PHPDoc types

### DIFF
--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -86,11 +86,6 @@ parameters:
 			path: app/authentication/SamlAuthentication.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\AutoGradedVersion and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/controllers/AbstractController.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/AbstractController.php
@@ -167,11 +162,6 @@ parameters:
 			path: app/controllers/DockerInterfaceController.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 2
-			path: app/controllers/DockerInterfaceController.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/controllers/DockerInterfaceController.php
@@ -204,11 +194,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
-			path: app/controllers/GlobalController.php
-
-		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 1
 			path: app/controllers/GlobalController.php
 
 		-
@@ -298,16 +283,6 @@ parameters:
 			path: app/controllers/HomePageController.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 4
-			path: app/controllers/HomePageController.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with null will always evaluate to true\\.$#"
-			count: 1
-			path: app/controllers/HomePageController.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/controllers/HomePageController.php
@@ -329,11 +304,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\controllers\\\\HomePageController\\:\\:getGroupUsers\\(\\) has parameter \\$group_name with no type specified\\.$#"
-			count: 1
-			path: app/controllers/HomePageController.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
 			count: 1
 			path: app/controllers/HomePageController.php
 
@@ -532,11 +502,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\controllers\\\\MiscController\\:\\:readFile\\(\\) has parameter \\$path with no type specified\\.$#"
-			count: 1
-			path: app/controllers/MiscController.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/MiscController.php
 
@@ -1158,11 +1123,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, string\\|null given\\.$#"
-			count: 1
-			path: app/controllers/admin/AdminGradeableController.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/controllers/admin/AdminGradeableController.php
 
@@ -1827,16 +1787,6 @@ parameters:
 			path: app/controllers/course/CourseMaterialsController.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: app/controllers/course/CourseMaterialsController.php
-
-		-
-			message: "#^Variable \\$title in isset\\(\\) always exists and is always null\\.$#"
-			count: 1
-			path: app/controllers/course/CourseMaterialsController.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 3
 			path: app/controllers/forum/ForumController.php
@@ -2183,11 +2133,6 @@ parameters:
 
 		-
 			message: "#^Elseif condition is always true\\.$#"
-			count: 1
-			path: app/controllers/grading/ElectronicGraderController.php
-
-		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: app/controllers/grading/ElectronicGraderController.php
 
@@ -2812,16 +2757,6 @@ parameters:
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and false will always evaluate to false\\.$#"
-			count: 1
-			path: app/controllers/grading/ElectronicGraderController.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between bool and 'true' will always evaluate to false\\.$#"
-			count: 1
-			path: app/controllers/grading/ElectronicGraderController.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
 			count: 2
 			path: app/controllers/grading/ElectronicGraderController.php
@@ -3198,16 +3133,6 @@ parameters:
 			path: app/controllers/student/SubmissionController.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to true\\.$#"
-			count: 1
-			path: app/controllers/student/SubmissionController.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/controllers/student/SubmissionController.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/controllers/student/TeamController.php
@@ -3516,11 +3441,6 @@ parameters:
 			path: app/entities/poll/Poll.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#"
-			count: 1
-			path: app/exceptions/BaseException.php
-
-		-
 			message: "#^Method app\\\\exceptions\\\\BaseException\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/exceptions/BaseException.php
@@ -3643,16 +3563,6 @@ parameters:
 		-
 			message: "#^Property app\\\\libraries\\\\Access\\:\\:\\$directories type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: app/libraries/Access.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to true\\.$#"
-			count: 2
-			path: app/libraries/Access.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
 			path: app/libraries/Access.php
 
 		-
@@ -3786,11 +3696,6 @@ parameters:
 			path: app/libraries/Core.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
-			path: app/libraries/Core.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, app\\\\libraries\\\\database\\\\AbstractDatabase given\\.$#"
 			count: 2
 			path: app/libraries/Core.php
@@ -3849,11 +3754,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$inline of method League\\\\CommonMark\\\\Inline\\\\Renderer\\\\CodeRenderer\\:\\:render\\(\\) expects League\\\\CommonMark\\\\Inline\\\\Element\\\\Code, League\\\\CommonMark\\\\Inline\\\\Element\\\\AbstractInline given\\.$#"
 			count: 1
 			path: app/libraries/CustomCodeInlineRenderer.php
-
-		-
-			message: "#^Instanceof between DateTime and DateTime will always evaluate to true\\.$#"
-			count: 1
-			path: app/libraries/DateUtils.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
@@ -4083,11 +3983,6 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 5
-			path: app/libraries/FileUtils.php
-
-		-
-			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
-			count: 1
 			path: app/libraries/FileUtils.php
 
 		-
@@ -4976,11 +4871,6 @@ parameters:
 			path: app/libraries/database/AbstractDatabase.php
 
 		-
-			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
-			count: 1
-			path: app/libraries/database/AbstractDatabase.php
-
-		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/libraries/database/AbstractDatabase.php
@@ -5076,16 +4966,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with array\\<string\\> will always evaluate to true\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with DateTime will always evaluate to false\\.$#"
-			count: 2
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Call to method app\\\\libraries\\\\database\\\\AbstractDatabase\\:\\:getRowCount\\(\\) with incorrect case\\: getrowcount$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
@@ -5102,16 +4982,6 @@ parameters:
 
 		-
 			message: "#^Foreach overwrites \\$post_id with its value variable\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\Gradeable and app\\\\models\\\\gradeable\\\\Gradeable will always evaluate to true\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseQueries.php
 
@@ -7711,11 +7581,6 @@ parameters:
 			path: app/libraries/database/DatabaseQueries.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<int\\> and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/libraries/database/DatabaseQueries.php
-
-		-
 			message: "#^Method app\\\\libraries\\\\database\\\\DatabaseRowIterator\\:\\:close\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/libraries/database/DatabaseRowIterator.php
@@ -7742,11 +7607,6 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/libraries/database/PostgresqlDatabase.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#"
 			count: 1
 			path: app/libraries/database/PostgresqlDatabase.php
 
@@ -8002,8 +7862,8 @@ parameters:
 			path: app/libraries/routers/WebRouter.php
 
 		-
-			message: "#^Instanceof between bool and app\\\\libraries\\\\response\\\\WebResponse will always evaluate to false\\.$#"
-			count: 2
+			message: "#^Instanceof between mixed and app\\\\libraries\\\\response\\\\WebResponse will always evaluate to false\\.$#"
+			count: 1
 			path: app/libraries/routers/WebRouter.php
 
 		-
@@ -8039,11 +7899,6 @@ parameters:
 		-
 			message: "#^Property app\\\\libraries\\\\routers\\\\WebRouter\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: app/libraries/routers/WebRouter.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\User and null will always evaluate to true\\.$#"
-			count: 2
 			path: app/libraries/routers/WebRouter.php
 
 		-
@@ -8352,11 +8207,6 @@ parameters:
 			path: app/models/Config.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\User and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/Config.php
-
-		-
 			message: "#^Variable property access on \\$this\\(app\\\\models\\\\Config\\)\\.$#"
 			count: 10
 			path: app/models/Config.php
@@ -8434,11 +8284,6 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 4
-			path: app/models/GradingOrder.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with array\\<string\\> will always evaluate to false\\.$#"
-			count: 2
 			path: app/models/GradingOrder.php
 
 		-
@@ -9227,21 +9072,6 @@ parameters:
 			path: app/models/User.php
 
 		-
-			message: "#^Call to function ctype_digit\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedGradeable.php
-
-		-
-			message: "#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedGradeable.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\AutoGradedVersion and app\\\\models\\\\gradeable\\\\AutoGradedVersion will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedGradeable.php
-
-		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedGradeable.php
@@ -9264,16 +9094,6 @@ parameters:
 		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\AutoGradedGradeable\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: app/models/gradeable/AutoGradedGradeable.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedGradeable.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\AutoGradedVersion and null will always evaluate to false\\.$#"
-			count: 8
 			path: app/models/gradeable/AutoGradedGradeable.php
 
 		-
@@ -9328,11 +9148,6 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedVersion.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with array\\<app\\\\models\\\\gradeable\\\\AutoGradedTestcase\\> will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersion.php
 
@@ -9517,11 +9332,6 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersion.php
 
 		-
-			message: "#^Offset 0 on array\\{total_elapsed_time\\: float, total_max_rss_size\\: int\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedVersion.php
-
-		-
 			message: "#^Property app\\\\models\\\\gradeable\\\\AutoGradedVersion\\:\\:\\$files type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersion.php
@@ -9537,22 +9347,7 @@ parameters:
 			path: app/models/gradeable/AutoGradedVersion.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedVersion.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between DateTime\\|string and null will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedVersion.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/gradeable/AutoGradedVersion.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between bool and 'true' will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/AutoGradedVersion.php
 
@@ -9837,22 +9632,7 @@ parameters:
 			path: app/models/gradeable/AutogradingTestcase.php
 
 		-
-			message: "#^Call to function ctype_digit\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Component.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/models/gradeable/Component.php
-
-		-
-			message: "#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Component.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\Mark and app\\\\models\\\\gradeable\\\\Mark will always evaluate to true\\.$#"
 			count: 1
 			path: app/models/gradeable/Component.php
 
@@ -10057,11 +9837,6 @@ parameters:
 			path: app/models/gradeable/Component.php
 
 		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/Component.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Gradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/Component.php
@@ -10102,11 +9877,6 @@ parameters:
 			path: app/models/gradeable/Gradeable.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with app\\\\models\\\\User will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/gradeable/Gradeable.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 9
 			path: app/models/gradeable/Gradeable.php
@@ -10114,16 +9884,6 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$user with its value variable\\.$#"
 			count: 2
-			path: app/models/gradeable/Gradeable.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\User and app\\\\models\\\\User will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Gradeable.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\Component and app\\\\models\\\\gradeable\\\\Component will always evaluate to true\\.$#"
-			count: 1
 			path: app/models/gradeable/Gradeable.php
 
 		-
@@ -10577,16 +10337,6 @@ parameters:
 			path: app/models/gradeable/Gradeable.php
 
 		-
-			message: "#^Result of && is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/Gradeable.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between DateTime and null will always evaluate to true\\.$#"
-			count: 2
-			path: app/models/gradeable/Gradeable.php
-
-		-
 			message: "#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#"
 			count: 2
 			path: app/models/gradeable/Gradeable.php
@@ -10737,11 +10487,6 @@ parameters:
 			path: app/models/gradeable/GradedComponent.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between DateTime\\|string and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/gradeable/GradedComponent.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Component and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/GradedComponent.php
@@ -10750,11 +10495,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\TaGradedGradeable and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/GradedComponent.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\GradedComponent and app\\\\models\\\\gradeable\\\\GradedComponent will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/GradedComponentContainer.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -10972,16 +10712,6 @@ parameters:
 			path: app/models/gradeable/LeaderboardConfig.php
 
 		-
-			message: "#^Call to function ctype_digit\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Mark.php
-
-		-
-			message: "#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Mark.php
-
-		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\Mark\\:\\:__construct\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/models/gradeable/Mark.php
@@ -11017,19 +10747,9 @@ parameters:
 			path: app/models/gradeable/Mark.php
 
 		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/Mark.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\Component and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/Mark.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\User and app\\\\models\\\\User will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/Submitter.php
 
 		-
 			message: "#^Method app\\\\models\\\\gradeable\\\\Submitter\\:\\:getAnonId\\(\\) has parameter \\$g_id with no type specified\\.$#"
@@ -11040,26 +10760,6 @@ parameters:
 			message: "#^Method app\\\\models\\\\gradeable\\\\Submitter\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/models/gradeable/Submitter.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/Submitter.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\Team\\|app\\\\models\\\\User and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/models/gradeable/Submitter.php
-
-		-
-			message: "#^Call to function ctype_digit\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/TaGradedGradeable.php
-
-		-
-			message: "#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#"
-			count: 1
-			path: app/models/gradeable/TaGradedGradeable.php
 
 		-
 			message: "#^Call to method SplFileInfo\\:\\:getPathname\\(\\) with incorrect case\\: getPathName$#"
@@ -11073,11 +10773,6 @@ parameters:
 
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$graders might not exist\\.$#"
-			count: 1
-			path: app/models/gradeable/TaGradedGradeable.php
-
-		-
-			message: "#^Instanceof between app\\\\models\\\\gradeable\\\\GradedComponentContainer and app\\\\models\\\\gradeable\\\\GradedComponentContainer will always evaluate to true\\.$#"
 			count: 1
 			path: app/models/gradeable/TaGradedGradeable.php
 
@@ -11193,16 +10888,6 @@ parameters:
 
 		-
 			message: "#^Property app\\\\models\\\\gradeable\\\\TaGradedGradeable\\:\\:\\$attachments type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/models/gradeable/TaGradedGradeable.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: app/models/gradeable/TaGradedGradeable.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between DateTime\\|string and null will always evaluate to false\\.$#"
 			count: 1
 			path: app/models/gradeable/TaGradedGradeable.php
 
@@ -11677,16 +11362,6 @@ parameters:
 			path: app/views/GlobalView.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\User and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/views/GlobalView.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 1
-			path: app/views/GlobalView.php
-
-		-
 			message: "#^Method app\\\\views\\\\HomePageView\\:\\:showCourseCreationPage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/views/HomePageView.php
@@ -11898,21 +11573,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\views\\\\NavigationView\\:\\:showGradeables\\(\\) has parameter \\$submit_everyone with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/views/NavigationView.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\gradeable\\\\AutoGradedGradeable and null will always evaluate to true\\.$#"
-			count: 1
-			path: app/views/NavigationView.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between float and 0 will always evaluate to false\\.$#"
-			count: 1
-			path: app/views/NavigationView.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between float and 1 will always evaluate to false\\.$#"
 			count: 1
 			path: app/views/NavigationView.php
 
@@ -12320,11 +11980,6 @@ parameters:
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/views/calendar/CalendarView.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with app\\\\entities\\\\course\\\\CourseMaterial will always evaluate to false\\.$#"
-			count: 1
-			path: app/views/course/CourseMaterialsView.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -12837,7 +12492,7 @@ parameters:
 			path: app/views/grading/ElectronicGraderView.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: "#^Offset string on array\\{\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: app/views/grading/ElectronicGraderView.php
 
@@ -12854,11 +12509,6 @@ parameters:
 		-
 			message: "#^Property app\\\\views\\\\grading\\\\ElectronicGraderView\\:\\:\\$user_id_to_User_cache has no type specified\\.$#"
 			count: 1
-			path: app/views/grading/ElectronicGraderView.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between int and null will always evaluate to false\\.$#"
-			count: 2
 			path: app/views/grading/ElectronicGraderView.php
 
 		-
@@ -12957,13 +12607,8 @@ parameters:
 			path: app/views/submission/HomeworkView.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to true\\.$#"
+			message: "#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#"
 			count: 2
-			path: app/views/submission/HomeworkView.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between app\\\\models\\\\gradeable\\\\GradedGradeable and null will always evaluate to false\\.$#"
-			count: 1
 			path: app/views/submission/HomeworkView.php
 
 		-

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -19,6 +19,7 @@ parameters:
     doctrine:
         objectManagerLoader: tests/phpstan/DoctrineExtensionTester.php
     checkGenericClassInNonGenericObjectType: false
+    treatPhpDocTypesAsCertain: false
 
 services:
     - class: tests\phpstan\ModelClassExtension


### PR DESCRIPTION
### What is the current behavior?
PHPStan trusts PHPDoc comments by default.  While this can be good if done carefully, the PHPDoc types in the Submitty codebase are not sufficiently thorough to take advantage of this.  Instead, our incorrect annotations can cause PHPStan to come to incorrect conclusions about the type constraints present.

### What is the new behavior?
This PR disables PHPStan's `treatPhpDocTypesAsCertain` rule, causing it to rely solely on types which are guaranteed to be correct based on the language itself.