### PR TITLE
[Bugfix:RainbowGrades] Remove alert when section label blank

### DIFF
--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -278,14 +278,15 @@ class RainbowCustomizationJSON extends AbstractModel {
      *
      * @param string $sectionID The sectionID
      * @param string $label The label you would like to assign to the sectionID
-     * @throws BadArgumentException The passed in section label is empty
      */
     public function addSection(string $sectionID, string $label): void {
+        // If label is not set, use sectionID as default
         if ($label === '') {
-            throw new BadArgumentException('The section label may not be empty.');
+            $this->section->$sectionID = $sectionID;
         }
-
-        $this->section->$sectionID = $label;
+        else {
+            $this->section->$sectionID = $label;
+        }
     }
 
     /**

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -281,12 +281,7 @@ class RainbowCustomizationJSON extends AbstractModel {
      */
     public function addSection(string $sectionID, string $label): void {
         // If label is not set, use sectionID as default
-        if ($label === '') {
-            $this->section->$sectionID = $sectionID;
-        }
-        else {
-            $this->section->$sectionID = $label;
-        }
+        $this->section->$sectionID = $label === '' ? $sectionID : $label;
     }
 
     /**

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -831,7 +831,7 @@ function saveChanges() {
                 $('#save_status').text('All changes saved');
             }
             else {
-                console.log(response);
+                console.error(response);
             }
         },
         // error: function (jqXHR, textStatus, errorThrown) {

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -827,13 +827,11 @@ function saveChanges() {
         processData: false,
         contentType: false,
         success: function (response) {
-            console.log(response);
             if (response['status'] === 'success') {
                 $('#save_status').text('All changes saved');
             }
             else {
-                // lets keep the alert, because users may not notice it even if it fails
-                alert(`An error occurred: ${response.data}`);
+                console.log(response);
             }
         },
         // error: function (jqXHR, textStatus, errorThrown) {

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -172,10 +172,6 @@ function getSection() {
         const section = this.getAttribute('data-section').toString();
         const label = this.value;
 
-        if (label === '') {
-            $('#save_status').text('All sections MUST have a label before saving');
-        }
-
         // Add to sections
         sections[section] = label;
     });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Login to Instructor, then navigate to _Grades Configuration_. Under **Display**, toggle **section**, then scroll down to **Section Labels**.

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
After clicking out of a label that has been left empty, an alert pops up immediately. Instructors have to close this alert before they proceed, which leads to bad behavior while the instructor tries to edit the section labels.

### What is the new behavior?
Any sections that are left without labels will be given their default values.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
