### PR TITLE
[Bugfix:InstructorUI] Correctly set allowed minutes on config

### DIFF
--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -82,15 +82,15 @@ def main():
                 if 'allowed_minutes' in testcase['validation'][0]:
                     timelimit_case = testcase
                     break
-                
+   
     allowed_minutes = override = None
     # If time limit exists, set it to the correct time limit
     if timelimit_case is not None:
         allowed_minutes = timelimit_case['validation'][0]['allowed_minutes']
         if 'override' in timelimit_case['validation'][0]:
             override = timelimit_case['validation'][0]['override']
-    
-    # sets allowed_minutes and override to the correct values
+
+    # sets allowed_minutes and override in the database
     try:
         db, metadata = setup_db()
         send_data(db, allowed_minutes, override)

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -75,27 +75,31 @@ def main():
         json_string = config_file.read()
     CONFIG_FILE = json.loads(json_string)
     timelimit_case = None
+    # Check if time limit exists
     for testcase in CONFIG_FILE['testcases']:
         if testcase['title'] == "Check Time Limit":
             if 'validation' in testcase and len(testcase['validation']) > 0:
                 if 'allowed_minutes' in testcase['validation'][0]:
                     timelimit_case = testcase
                     break
-
+                
+    allowed_minutes = override = None
+    # If time limit exists, set it to the correct time limit
     if timelimit_case is not None:
         allowed_minutes = timelimit_case['validation'][0]['allowed_minutes']
-        override = None
         if 'override' in timelimit_case['validation'][0]:
             override = timelimit_case['validation'][0]['override']
-        try:
-            db, metadata = setup_db()
-            send_data(db, allowed_minutes, override)
-        except exc.IntegrityError:
-            sys.exit(1)
-        except IOError:
-            print("WARNING: You do not have access to set allowed minutes from CLI." +
-                  " Please use website to set that.")
-            exit()
+    
+    # sets allowed_minutes and override to the correct values
+    try:
+        db, metadata = setup_db()
+        send_data(db, allowed_minutes, override)
+    except exc.IntegrityError:
+        sys.exit(1)
+    except IOError:
+        print("WARNING: You do not have access to set allowed minutes from CLI." +
+                " Please use website to set that.")
+        exit()
 
 
 if __name__ == "__main__":

--- a/bin/set_allowed_mins.py
+++ b/bin/set_allowed_mins.py
@@ -82,7 +82,7 @@ def main():
                 if 'allowed_minutes' in testcase['validation'][0]:
                     timelimit_case = testcase
                     break
-   
+
     allowed_minutes = override = None
     # If time limit exists, set it to the correct time limit
     if timelimit_case is not None:
@@ -98,7 +98,7 @@ def main():
         sys.exit(1)
     except IOError:
         print("WARNING: You do not have access to set allowed minutes from CLI." +
-                " Please use website to set that.")
+              " Please use website to set that.")
         exit()
 
 


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Fixes #10542. The issue will be outlined in the steps below.

1. Create a new gradeable
2.  In SQLToolbox, run this query, `select g_id, g_allowed_minutes from gradeable;`
3. Observe that `allowed_minutes` is set to `null`, which is correct
4.  Set autograding path to `/usr/local/submitty/more_autograding_examples/notebook_time_limit/config` 
5. run this query again and observe that `allowed_minutes` is set to `10`, which is correct (you can look at the config to see `allowed_minutes` is 10.
6. Change the config to something different, I chose upload but you can use any config, the one from the issue shows the point. Might need to wait a little bit for new config to build.
7. Rerun the query, notice the `allowed_minutes` is still set to `10`, which is incorrect now that we have a new config. Our new config does not have a `allowed_minutes` field.
8. Error, we should be setting `allowed_minutes` based on the current config, which would make it `null`, not the previous config.

### What is the new behavior?
This PR aims to correctly set the `allowed_minutes` to `null` when you build a new config that does not have an allowed_minutes field

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
One of the reasons why this is important is that notebook gradeable that have a time limit of 10 minutes has an allowed_minutes of 10. A notebook gradeable that does not have a time limit might still show the 10 minute timer if allowed_minutes is set to 10, but the timer does not do anything.
