### PR TITLE
[Bugfix:Submission] Grader submission during beta

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1193,7 +1193,7 @@ class SubmissionController extends AbstractController {
         }
 
         // if student submission, make sure that gradeable allows submissions
-        if (!$this->core->getUser()->accessFullGrading() && !$gradeable->canStudentSubmit()) {
+        if (!$this->core->getUser()->accessGrading() && !$gradeable->canStudentSubmit()) {
             $msg = "You do not have access to that page.";
             $this->core->addErrorMessage($msg);
             return $this->uploadResult($msg, false);


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Graders, aka limited access graders, are not able to submit during beta. I believe that they should, since they can see the gradeable when it is in the "TA Beta".

### What is the new behavior?
Graders can submit

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
You can log in as grader and that would be a limited access grader.
Many student mentors complained about this, so we should make this more consistent.
