### PR TITLE
[Refactor:System] Set empty preferred names to NULL

### DIFF
--- a/migration/migrator/data/submitty_db.sql
+++ b/migration/migrator/data/submitty_db.sql
@@ -686,6 +686,8 @@ CREATE TABLE public.users (
     display_name_order character varying(255) DEFAULT 'GIVEN_F'::character varying NOT NULL,
     display_pronouns boolean DEFAULT false,
     user_preferred_locale character varying,
+    CONSTRAINT user_preferred_familyname_not_empty CHECK (((user_preferred_familyname)::text <> ''::text)),
+    CONSTRAINT user_preferred_givenname_not_empty CHECK (((user_preferred_givenname)::text <> ''::text)),
     CONSTRAINT users_user_access_level_check CHECK (((user_access_level >= 1) AND (user_access_level <= 3))),
     CONSTRAINT users_user_last_initial_format_check CHECK (((user_last_initial_format >= 0) AND (user_last_initial_format <= 3)))
 );

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -11,10 +11,22 @@ def up(config, database):
     :type database: migrator.db.Database
     """
 
-    database.execute("UPDATE users SET user_preferred_givenname = NULL WHERE user_preferred_givenname = ''")
-    database.execute("UPDATE users SET user_preferred_familyname = NULL WHERE user_preferred_familyname = ''")
-    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
-    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
+    database.execute("""
+    UPDATE users SET user_preferred_givenname = NULL 
+    WHERE user_preferred_givenname = ''
+    """)
+    database.execute("""
+    UPDATE users SET user_preferred_familyname = NULL 
+    WHERE user_preferred_familyname = ''
+    """)
+    database.execute("""
+    ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty 
+    CHECK (user_preferred_givenname <> '')
+    """)
+    database.execute("""
+    ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty 
+    CHECK (user_preferred_familyname <> '')
+    """)
 
 
 def down(config, database):
@@ -27,7 +39,17 @@ def down(config, database):
     :type database: migrator.db.Database
     """
 
-    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
-    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
-    database.execute("UPDATE users SET user_preferred_givenname = '' WHERE user_preferred_givenname IS NULL")
-    database.execute("UPDATE users SET user_preferred_familyname = '' WHERE user_preferred_familyname IS NULL")
+    database.execute("""
+    ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty
+    """)
+    database.execute("""
+    ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty
+    """)
+    database.execute("""
+    UPDATE users SET user_preferred_givenname = '' 
+    WHERE user_preferred_givenname IS NULL
+    """)
+    database.execute("""
+    UPDATE users SET user_preferred_familyname = '' 
+    WHERE user_preferred_familyname IS NULL
+    """)

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -1,0 +1,32 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    # Set all users with an empty string for user_preferred_givenname to NULL and add a constraint to prevent future empty strings
+    database.execute("UPDATE users SET user_preferred_givenname = NULL WHERE user_preferred_givenname = ''")
+    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
+    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    pass
+
+
+def down(config, database):
+    # Remove the constraint that prevents empty strings in user_preferred_givenname
+    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
+    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    pass

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -12,6 +12,7 @@ def up(config, database):
     """
 
     database.execute("UPDATE users SET user_preferred_givenname = NULL WHERE user_preferred_givenname = ''")
+    database.execute("UPDATE users SET user_preferred_familyname = NULL WHERE user_preferred_familyname = ''")
     database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
     database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
     pass

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -15,7 +15,6 @@ def up(config, database):
     database.execute("UPDATE users SET user_preferred_familyname = NULL WHERE user_preferred_familyname = ''")
     database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
     database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
-    pass
 
 
 def down(config, database):
@@ -30,4 +29,3 @@ def down(config, database):
 
     database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
     database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
-    pass

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -29,3 +29,5 @@ def down(config, database):
 
     database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
     database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
+    database.execute("UPDATE users SET user_preferred_givenname = '' WHERE user_preferred_givenname IS NULL")
+    database.execute("UPDATE users SET user_preferred_familyname = '' WHERE user_preferred_familyname IS NULL")

--- a/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
+++ b/migration/migrator/migrations/master/20250121144600_make_empty_preferred_names_null.py
@@ -2,10 +2,6 @@
 
 
 def up(config, database):
-    # Set all users with an empty string for user_preferred_givenname to NULL and add a constraint to prevent future empty strings
-    database.execute("UPDATE users SET user_preferred_givenname = NULL WHERE user_preferred_givenname = ''")
-    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
-    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
     """
     Run up migration.
 
@@ -14,13 +10,14 @@ def up(config, database):
     :param database: Object for interacting with given database for environment
     :type database: migrator.db.Database
     """
+
+    database.execute("UPDATE users SET user_preferred_givenname = NULL WHERE user_preferred_givenname = ''")
+    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_givenname_not_empty CHECK (user_preferred_givenname <> '')")
+    database.execute("ALTER TABLE users ADD CONSTRAINT user_preferred_familyname_not_empty CHECK (user_preferred_familyname <> '')")
     pass
 
 
 def down(config, database):
-    # Remove the constraint that prevents empty strings in user_preferred_givenname
-    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
-    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
     """
     Run down migration (rollback).
 
@@ -29,4 +26,7 @@ def down(config, database):
     :param database: Object for interacting with given database for environment
     :type database: migrator.db.Database
     """
+
+    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_givenname_not_empty")
+    database.execute("ALTER TABLE users DROP CONSTRAINT user_preferred_familyname_not_empty")
     pass

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -17,8 +17,8 @@ use Egulias\EmailValidator\Validation\RFCValidation;
  * @method void setNumericId(string $id)
  * @method string getPassword()
  * @method string getLegalGivenName() Get the given name of the loaded user
- * @method string getPreferredGivenName() Get the preferred given name of the loaded user
- * @method string getDisplayedGivenName() Returns the preferred given name if one exists and is not null or blank,
+ * @method string|null getPreferredGivenName() Get the preferred given name of the loaded user
+ * @method string|null getDisplayedGivenName() Returns the preferred given name if one exists and is not null or blank,
  *                                        otherwise return the legal given name field for the user.
  * @method string getLegalFamilyName() Get the family name of the loaded user
  * @method string getPreferredFamilyName()  Get the preferred family name of the loaded user
@@ -107,8 +107,8 @@ class User extends AbstractModel {
      * @var string The given name of the user */
     protected $legal_given_name;
     /** @prop
-     * @var string The preferred given name of the user */
-    protected $preferred_given_name = "";
+     * @var string|null The preferred given name of the user */
+    protected $preferred_given_name;
     /** @prop
      * @var  string The given name to be displayed by the system (either given name or preferred given name) */
     protected $displayed_given_name;
@@ -116,8 +116,8 @@ class User extends AbstractModel {
      * @var string The family name of the user */
     protected $legal_family_name;
     /** @prop
-     * @var string The preferred family name of the user */
-    protected $preferred_family_name = "";
+     * @var string|null The preferred family name of the user */
+    protected $preferred_family_name;
     /** @prop
      * @var  string The family name to be displayed by the system (either family name or preferred family name) */
     protected $displayed_family_name;

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -107,7 +107,7 @@ class User extends AbstractModel {
      * @var string The given name of the user */
     protected $legal_given_name;
     /** @prop
-     * @var string|null The preferred given name of the user */
+     * @var ?string The preferred given name of the user */
     protected $preferred_given_name;
     /** @prop
      * @var  string The given name to be displayed by the system (either given name or preferred given name) */
@@ -116,7 +116,7 @@ class User extends AbstractModel {
      * @var string The family name of the user */
     protected $legal_family_name;
     /** @prop
-     * @var string|null The preferred family name of the user */
+     * @var ?string The preferred family name of the user */
     protected $preferred_family_name;
     /** @prop
      * @var  string The family name to be displayed by the system (either family name or preferred family name) */

--- a/site/app/views/UserProfileView.php
+++ b/site/app/views/UserProfileView.php
@@ -23,10 +23,10 @@ class UserProfileView extends AbstractView {
         string $csrf_token
     ) {
         $autofill_preferred_name = [$user->getLegalGivenName(), $user->getLegalFamilyName()];
-        if ($user->getPreferredGivenName() != "") {
+        if ($user->getPreferredGivenName() !== "" && $user->getPreferredGivenName() !== null) {
             $autofill_preferred_name[0] = $user->getPreferredGivenName();
         }
-        if ($user->getPreferredFamilyName() != "") {
+        if ($user->getPreferredFamilyName() !== "" && $user->getPreferredFamilyName() !== null) {
             $autofill_preferred_name[1] = $user->getPreferredFamilyName();
         }
 

--- a/site/app/views/UserProfileView.php
+++ b/site/app/views/UserProfileView.php
@@ -23,10 +23,10 @@ class UserProfileView extends AbstractView {
         string $csrf_token
     ) {
         $autofill_preferred_name = [$user->getLegalGivenName(), $user->getLegalFamilyName()];
-        if ($user->getPreferredGivenName() !== "" && $user->getPreferredGivenName() !== null) {
+        if (!is_null($user->getPreferredGivenName())) {
             $autofill_preferred_name[0] = $user->getPreferredGivenName();
         }
-        if ($user->getPreferredFamilyName() !== "" && $user->getPreferredFamilyName() !== null) {
+        if (!is_null($user->getPreferredFamilyName())) {
             $autofill_preferred_name[1] = $user->getPreferredFamilyName();
         }
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -11997,11 +11997,6 @@ parameters:
 			path: app/views/PollView.php
 
 		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 2
-			path: app/views/UserProfileView.php
-
-		-
 			message: "#^Method app\\\\views\\\\admin\\\\ConfigurationView\\:\\:viewConfig\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/views/admin/ConfigurationView.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Preferred names can both be empty strings or null to indicate the user does not have a desired preferred name

### What is the new behavior?
All existing empty preferred names will be set to null and constraints are added to the database to ensure that empty preferred names cannot be added to the database in the future.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is part of a series of changes starting with https://github.com/Submitty/SysadminTools/pull/37 and will be followed up by more PRs to remove the handling of empty strings in the database to be able to further simplify the code to not have to handle 2 cases that both mean the user does not have a preferred name.