### PR TITLE
[Bugfix:Forum] Forum Network and Reply Level Issues

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -624,7 +624,7 @@ class ForumController extends AbstractController {
                     'type' => 'new_post',
                     'thread_id' => $thread_id,
                     'post_id' => $post_id,
-                    'reply_level' => $reply_level,
+                    'reply_level' => $reply_level + 1,
                     'post_box_id' => $max_post_box_id
                 ]);
             }
@@ -865,7 +865,7 @@ class ForumController extends AbstractController {
                     'type' => 'edit_post',
                     'thread_id' => $thread_id,
                     'post_id' => $post_id,
-                    'reply_level' => $reply_level,
+                    'reply_level' => $reply_level + 1,
                     'post_box_id' => $post_box_id,
                 ]);
             }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2054,7 +2054,7 @@ function sortTable(sort_element_index, reverse = false) {
 }
 
 function loadThreadHandler() {
-    $('a.thread_box_link').click(function (event) {
+    $('a.thread_box_link').click(async function (event) {
         // if a thread is clicked on the full-forum-page just follow normal GET request else continue with ajax request
         if (window.location.origin + window.location.pathname === buildCourseUrl(['forum'])) {
             return;
@@ -2115,9 +2115,13 @@ function loadThreadHandler() {
                 $('.post_reply_form').submit(publishPost);
                 hljs.highlightAll();
             },
-            error: function () {
-                window.alert('Something went wrong while trying to display thread details. Please try again.');
-            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                if (jqXHR.status !== 0) {
+                    // AJAX request fails outside of network issues caused by WebSocket thread updates
+                    console.error("Request failed:", textStatus, errorThrown);
+                    window.alert('Something went wrong while trying to display thread details. Please try again.');
+                }
+            }
         });
     });
 }

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2115,13 +2115,13 @@ function loadThreadHandler() {
                 $('.post_reply_form').submit(publishPost);
                 hljs.highlightAll();
             },
-            error: function(jqXHR, textStatus, errorThrown) {
+            error: function (jqXHR, textStatus, errorThrown) {
                 if (jqXHR.status !== 0) {
                     // AJAX request fails outside of network issues caused by WebSocket thread updates
-                    console.error("Request failed:", textStatus, errorThrown);
+                    console.error('Request failed:', textStatus, errorThrown);
                     window.alert('Something went wrong while trying to display thread details. Please try again.');
                 }
-            }
+            },
         });
     });
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [X] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

When a user is on the same thread as another connected to the same WebSocket, after one of the users sends various new posts to the thread, once the other tries to click the thread on the left-hand thread list, an error is alerted with no further updates. 

I also realized the incorrect `reply_level` for new posts is being sent over the WebSocket, leading to an invalid tree structure and/or rendering errors for further modification of posts. The following displays the right-hand user receiving the invalid ordering from the WebSocket.

![image](https://github.com/user-attachments/assets/b0be33bf-2bb6-463f-8ee4-94779850451c)


### What is the new behavior?

No alert is shown for the potential network issue caused by the WebSocket updates interfering with the AJAX request cycle. Ordering posts from the WebSocket matches the expected output on both sides.

![image](https://github.com/user-attachments/assets/c4c3c968-4b62-4122-8ee9-786537b9b13d)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Fixes #10933 
