### PR TITLE
Fix upduck button wrap

### DIFF
--- a/site/app/templates/error/NoAccessCourse.twig
+++ b/site/app/templates/error/NoAccessCourse.twig
@@ -17,7 +17,7 @@
             Click <a href="{{main_url}}"> here </a> to back to homepage and see your courses list.
         {% endif %}
     {% else %}
-        The course <b>{{ course_name != course_id ? 'course_name (course_id)' : course_name  }}</b> for <b>{{ semester }}</b> is open to self registration <br />
+        The course <b>{{ course_name }} ({{ course_id }})</b> for <b>{{ semester }}</b> is open to self registration <br />
         You may select below to add yourself to the course. <br/>
         Your instructor will be notified and can then choose to keep you in the course.
         {% if course_home_url != '' %}

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -256,20 +256,33 @@
 }
 
 .upduck-container{
-    display: inline-block;
+    display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
+    gap: 5px;
 }
 
 .upduck-button {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
     background: none; 
     border: none; 
     padding: 0; 
     cursor: pointer; 
     outline: none;
     vertical-align: middle;
+}
+
+.upduck-count, .reply-button {
+    display: inline-flex;
+    align-items: center;
+}
+
+@media (max-width: 600px) {
+    .upduck-container {
+        flex-wrap: wrap; /* Allow wrapping on smaller screens */
+        gap: 2px; /* Reduce spacing for compact layout */
+    }
 }
 
 .like-counter{


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The upduck button in the forum UI does not align properly with the upduck count and reply button on smaller screens. The elements wrap incorrectly and appear disorganized.
Fixes #11175.

### What is the new behavior?
The upduck button, upduck count, and reply button are now aligned properly in the .upduck-container. They remain inline on larger screens and wrap cleanly on smaller screens.
Flexbox is used for layout alignment, ensuring consistent behavior across various screen sizes.


### Other information?
Is this a breaking change?  - No
<!-- How did you test -->
