### PR TITLE
[Bugfix:InstructorUI] Fix Gradeable Configuration format

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -190,7 +190,7 @@
                         {% endfor %}
                     </ol>
                 </div>
-                <div id="gradeable_config" data-testid="gradeable-config" style="background-color:var(--standard-peachpuff);margin-top:50px;width:1000px;padding:5px;">
+                <div id="gradeable_config" data-testid="gradeable-config" style="background-color:var(--standard-peachpuff);margin-top:50px;overflow:auto;width:1000px;padding:5px;">
                     <h2>Category/Gradeable Configuration:
                         <i id="pencilIcon" class="fas fa-pencil-alt black-btn"></i>
                     </h2>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Category/Gradeable Configuration wraps around the assigned buckets list:
![406786256-4727a6ed-c55c-42e4-9670-5c7010bd4d3c](https://github.com/user-attachments/assets/1933ab30-b1b3-436c-b2bf-534add76d285)

### What is the new behavior?
Category/Gradeable Configuration is always below the assigned buckets list and available buckets:
![image](https://github.com/user-attachments/assets/dd8c1d99-26d1-4348-a4c1-0c8cecf2af84)

### Other information?
Fixes issue #11369.
When testing, add different number of buckets between assigned and available. See instructions in linked issue.
