### PR TITLE
[UI/UX:Forum] Responsive Category Labels

### DIFF
--- a/site/public/css/bootstrap.css
+++ b/site/public/css/bootstrap.css
@@ -613,7 +613,7 @@ input[type="button"].btn-block {
     color: var(--btn-text-white);
     text-align: center;
 
-    /* white-space: nowrap; */
+    white-space: nowrap;
     word-wrap: break-word;
     vertical-align: baseline;
     border-radius: 0.25em;

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -96,7 +96,7 @@
 
 /* stylelint-disable-next-line selector-class-pattern */
 .thread_box {
-    padding: 6px;
+    padding: 5px;
     overflow-y: auto;
     word-wrap: break-word;
     align-items: stretch;
@@ -772,8 +772,7 @@
 .thread_box .flex-row,
 .thread-box-full .flex-row {
     align-items: stretch;
-    justify-content: flex-start;
-    gap: 8px;
+    justify-content: flex-end;
 }
 /* stylelint-disable-next-line selector-class-pattern */
 .content .thread_box_link {
@@ -872,7 +871,7 @@
 
 .pinned-thread {
     display: inline-block;
-    padding: 6px;
+    padding: 5px;
     cursor: pointer;
 }
 

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -96,7 +96,7 @@
 
 /* stylelint-disable-next-line selector-class-pattern */
 .thread_box {
-    padding: 5px;
+    padding: 6px;
     overflow-y: auto;
     word-wrap: break-word;
     align-items: stretch;
@@ -111,6 +111,10 @@
 #thread_list a {
     text-decoration: none;
     color: var(--text-black);
+}
+
+.label_forum {
+    white-space: pre;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -772,7 +776,8 @@
 .thread_box .flex-row,
 .thread-box-full .flex-row {
     align-items: stretch;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    gap: 8px;
 }
 /* stylelint-disable-next-line selector-class-pattern */
 .content .thread_box_link {
@@ -871,7 +876,7 @@
 
 .pinned-thread {
     display: inline-block;
-    padding: 5px;
+    padding: 6px;
     cursor: pointer;
 }
 

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -113,6 +113,7 @@
     color: var(--text-black);
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .label_forum {
     white-space: pre;
 }

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -114,11 +114,6 @@
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
-.label_forum {
-    white-space: pre;
-}
-
-/* stylelint-disable-next-line selector-class-pattern */
 .create_thread_button {
     border-radius: 3px;
     width: 100%;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Category labels for the discussion forum thread list that are too long in terms of text for small viewports end up wrapping onto the next line, where the expected behavior is for each box to correspond to one category, which is displayed via the category, `long label to display`, below.

![image](https://github.com/user-attachments/assets/c47b4eff-c62e-405d-b623-509680eaf3af)


### What is the new behavior?

Longer labels remain in a single box, where if the container is too long for a small viewport, the user may scroll horizontally to view the thread content.

![image](https://github.com/user-attachments/assets/f27667df-01f2-435f-ba14-a93948eb2f06)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

Fixes #10874 
