### PR TITLE
[UI/UX:TAGrading] Fixed Radio Button Contrast in Dark Mode

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -1550,7 +1550,7 @@ input[type="radio"][disabled=""]:checked::before {
     width: 7px;
     height: 7px;
     border-radius: 100%;
-    background: var(--standard-medium-dark-gray);
+    background: var(--standard-dark-gray);
 }
 
 /* Media queries */


### PR DESCRIPTION
fixes issue #11374

In the TA grading screen for a notebook gradeable, the selected radio button is hard to see due to low contrast in dark mode. This happens because the variable is overridden in dark mode, changing it to a lighter shade of gray.

### What is the current behavior?
Selected Radio Button has no contrast in dark mode.

**Light Mode:**
![light_mode_grading](https://github.com/user-attachments/assets/4f66e5dc-747b-4240-838b-14f4454938c6)

**Dark Mode:**
![dark_mode_grading](https://github.com/user-attachments/assets/0954d4f3-f796-44e5-82b1-1bb6a5506a15)

### What is the new behavior?
Selected Radio button now uses a variable that is visible in both light and dark mode.

**Light Mode:**
![light_mode_fixed](https://github.com/user-attachments/assets/ace41155-57f0-4385-b353-f42122d4d3fb)

**Dark Mode:**
![Screenshot 2025-01-31 124738](https://github.com/user-attachments/assets/c1689294-ddbb-43ad-bf75-1e22375d8308)