### PR TITLE
[Bugfix:InstructorUI] Fix icon misalignment when clicking 'Grades Configuration'

### DIFF
--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -26,6 +26,13 @@ aside {
         transition: margin 0.3s ease-out;
     }
 
+    aside ul li a span i.fa-exclamation-triangle {
+        margin: 0 0 0 15px;
+        display: inline-block;
+        border-bottom-width: 0;
+        padding-bottom: 0;
+    }
+
     aside li {
         list-style: none;
     }
@@ -102,5 +109,12 @@ aside {
 
     [data-theme="dark"] aside ul {
         background-color: var(--background-blue);
+    }
+
+    [data-theme="dark"] aside ul li a span i.fa-exclamation-triangle {
+        margin: 0 0 0 15px;
+        display: inline-block;
+        border-bottom-width: 0;
+        padding-bottom: 0;
     }
 }


### PR DESCRIPTION
Fix icon misalignment when clicking 'Grades Configuration'

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

https://github.com/user-attachments/assets/6357b91f-0639-499c-8804-bdff69c7570a



### What is the new behavior?

https://github.com/user-attachments/assets/e5636d68-23bb-4005-84f8-c4cb68dc3416


### Other information?
Fixes issue #11383 
<!-- Is this a breaking change? -->
<!-- How did you test -->
