### PR TITLE
[UI/UX:TAGrading] Fixed Checkbox Contrast in Dark Mode

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -6,6 +6,9 @@ input[readonly]:not(.btn-danger) {
 input[disabled]:not(#admin-gradeable-peers-submit) {
     background: var(--standard-medium-gray);
 }
+[data-theme="dark"] input[disabled]:not(#admin-gradeable-peers-submit) {
+    background: var(--standard-dark-gray);
+}
 
 input.readonly.peerstudents {
     border: 1px solid var(--standard-light-gray);

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -6,6 +6,7 @@ input[readonly]:not(.btn-danger) {
 input[disabled]:not(#admin-gradeable-peers-submit) {
     background: var(--standard-medium-gray);
 }
+
 [data-theme="dark"] input[disabled]:not(#admin-gradeable-peers-submit) {
     background: var(--standard-dark-gray);
 }


### PR DESCRIPTION
fixes issue #11386 

In the TA grading screen for a notebook gradeable, the contrast between the check and the box is low. This happens because the variable for the background is overridden in dark mode, changing it to a lighter shade of gray while the check remains white.

### What is the current behavior?
Checked box has low contrast in dark mode.

**Light Mode:**
![checkbox_lm](https://github.com/user-attachments/assets/230366a4-c284-476e-9614-749544b4272a)

**Dark Mode:**
![checkbox_dm](https://github.com/user-attachments/assets/74fac053-1930-416f-bd2a-7fd5ddbae9b5)

### What is the new behavior?
I couldn't find any variables that would work well for both light and dark mode, so I added a dark mode version of the current css with a different variable.

**Light Mode:**
![checkbox_fix_lm](https://github.com/user-attachments/assets/60f5eb1a-fb28-47e0-86af-1f6fd4b4794b)

**Dark Mode:**
![checkbox_fix_dm](https://github.com/user-attachments/assets/f6f8cd7e-0328-476f-be99-743f1af88e9c)