### PR TITLE
[UI/UX:InstructorUI] Removed anniversary duck

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -683,10 +683,6 @@ class GlobalController extends AbstractController {
                     $februaryImages = ['moorthy_duck/black-history-duck.svg'];
                 }
 
-                if ($day <= 3) {
-                    $februaryImages[] = 'moorthy_duck/00-original.svg';
-                }
-                //Valentines (Hearts)
                 if ($day >= 11 && $day <= 17) {
                     $februaryImages[] = 'moorthy_duck/02-february.svg';
                 }
@@ -704,10 +700,6 @@ class GlobalController extends AbstractController {
                 else {
                     //January (Snowflakes)
                     $januaryImages = ['moorthy_duck/01-january.svg'];
-                }
-
-                if ($day >= 28) {
-                    $januaryImages[] = 'moorthy_duck/00-original.svg';
                 }
                 $duck_img = $januaryImages[array_rand($januaryImages)];
                 break;

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -684,7 +684,7 @@ class GlobalController extends AbstractController {
                 }
 
                 if ($day <= 3) {
-                    $februaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg';
+                    $februaryImages[] = 'moorthy_duck/00-original.svg';
                 }
                 //Valentines (Hearts)
                 if ($day >= 11 && $day <= 17) {
@@ -707,7 +707,7 @@ class GlobalController extends AbstractController {
                 }
 
                 if ($day >= 28) {
-                    $januaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg';
+                    $januaryImages[] = 'moorthy_duck/00-original.svg';
                 }
                 $duck_img = $januaryImages[array_rand($januaryImages)];
                 break;


### PR DESCRIPTION
removed anniversary duck

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The 10 year anniversary duck is still showing even though 10 years have passed. 
### What is the new behavior?
Fixes #11415
The 10 year icon has been removed. Only the icons for special occasions are displayed
![Screenshot 2025-02-02 104415](https://github.com/user-attachments/assets/9c5f6afa-07dd-4c66-aa08-534d0b50f476)
![Screenshot 2025-02-02 104404](https://github.com/user-attachments/assets/b5466f66-e9e3-4db8-bfcb-ca64a5702c38)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
