### PR TITLE
removed party duck

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -684,7 +684,8 @@ class GlobalController extends AbstractController {
                 }
 
                 if ($day <= 3) {
-                    $februaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg';
+                    // $februaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg' Replaced the party duck;
+                    $februaryImages[] = 'moorthy_duck/00-original.svg';
                 }
                 //Valentines (Hearts)
                 if ($day >= 11 && $day <= 17) {
@@ -707,7 +708,9 @@ class GlobalController extends AbstractController {
                 }
 
                 if ($day >= 28) {
-                    $januaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg';
+                    // $januaryImages[] = 'moorthy_duck/party-duck/party-duck-10th.svg'; Replaced the party duck
+                    $januaryImages[] = 'moorthy_duck/00-original.svg';
+
                 }
                 $duck_img = $januaryImages[array_rand($januaryImages)];
                 break;


### PR DESCRIPTION
removed the party duck

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Earlier the party duck was showing at the header for marking 10 years of Submitty.
### What is the new behavior?
Since it's past 10 years, it's no longer there.
![Screenshot 2025-02-02 104404](https://github.com/user-attachments/assets/365f1ff8-4d8f-46e5-9c6a-1ec66c8557e9)
![Screenshot 2025-02-02 104415](https://github.com/user-attachments/assets/1ce463d9-673e-42ea-9724-91c4cace047a)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
