### PR TITLE
[Bugfix:Forum] Keeping Attachments Open on Refresh

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2662,3 +2662,16 @@ function pinAnnouncement(thread_id, type, csrf_token) {
         });
     }
 }
+
+document.addEventListener("DOMContentLoaded", function () {
+    const openAttachments = JSON.parse(localStorage.getItem('open_attachments')) || [];
+
+    openAttachments.forEach(id => {
+        const attachment = document.querySelector(`.attachment-container[data-attachment-id="${id}"]`);
+        if (attachment) {
+            attachment.classList.remove('hidden'); 
+        }
+    });
+
+    localStorage.removeItem('open_attachments');
+});

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -186,6 +186,12 @@ function publishFormWithAttachments(form, test_category, error_message, is_threa
         form[0].reportValidity();
         return false;
     }
+
+    localStorage.setItem('open_attachments', JSON.stringify(
+        [...document.querySelectorAll('.attachment-container')].filter(att => !att.classList.contains('hidden'))
+        .map(att => att.getAttribute('data-attachment-id'))
+    ));
+
     if (test_category) {
         if ((!form.prop('ignore-cat')) && form.find('.btn-selected').length === 0 && ($('.cat-buttons input').is(':checked') === false)) {
             alert('At least one category must be selected.');


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
- When a user opens attachments in a forum thread and posts a reply, the page reloads, and all attachments close automatically.
- Users have to manually reopen all attachments after each reply, which disrupts the experience.
- Issue reference: Fixes #11421
### What is the new behavior?
- Now, attachments remain open after posting a reply instead of closing due to a full page reload.
- The open attachments state is stored in localStorage before submission and restored when the page reloads.
- This improves the user experience by maintaining attachment visibility even after replying.
### Other information?
- Is this a breaking change? - No
- Affected files:
     site/public/js/forum.js
