### PR TITLE
Fixed notebook_itempool_random cpp code (#11418)

### DIFF
--- a/more_autograding_examples/cpp_provided_code/config/config.json
+++ b/more_autograding_examples/cpp_provided_code/config/config.json
@@ -14,13 +14,13 @@
             "title" : "Compilation",
             "command" : "clang++ -Wall -o a.out *cpp",
             "executable_name" : "a.out",
-            "points" : 2
+            "points" : 1
         },
 
         {
             "title" : "Testing",
             "command" : "./a.out",
-            "points" : 5,
+            "points" : 4,
             "validation" : [
                 {
                     "method" : "diff",


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
- Currently, when an instructor submits C++ code for the notebook_itempool_random gradeable, it awards 5/1 points for compilation and 1/4 points for code execution.

- This behavior is incorrect and does not match the expected grading scheme.
- Issue reference: #11418 
### What is the new behavior?
- Now when an instructor submits C++ code for the notebook_itempool_random gradeable, it awards 1/1 points for compilation and 1/4 points for code execution.
### Other information?
Is this a breaking change? - No