### PR TITLE
[Bugfix:TAGrading] Set only updated scores in components

### DIFF
--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -257,7 +257,8 @@ class SimpleGraderController extends AbstractController {
             if ($data === '' || (!$component->isText() && $data === '0')) {
                 $ta_graded_gradeable->deleteGradedComponent($component);
                 continue;
-            } else {
+            }
+            else {
                 $component_grade = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
                 $component_grade->setGrader($grader);
             }

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -244,21 +244,22 @@ class SimpleGraderController extends AbstractController {
         $return_data = [];
 
         foreach ($gradeable->getComponents() as $component) {
-            $data = $_POST['scores'][$component->getId()];
-            if (!isset($data)) {
+            if (!array_key_exists($component->getId(), $_POST['scores'])) {
                 continue;
             }
-            $original_data = $_POST['old_scores'][$component->getId()];
-            if (!isset($original_data)) {
-                return JsonResponse::getFailResponse("Save error: old score not set");
+            $data = $_POST['scores'][$component->getId()];
+            if (!array_key_exists($component->getId(), $_POST['old_scores'])) {
+                return JsonResponse::getFailResponse("Save error: old score data missing");
             }
+            $original_data = $_POST['old_scores'][$component->getId()];
 
-            $component_grade = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
-            $component_grade->setGrader($grader);
 
             if ($data === '' || (!$component->isText() && $data === '0')) {
                 $ta_graded_gradeable->deleteGradedComponent($component);
                 continue;
+            } else {
+                $component_grade = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
+                $component_grade->setGrader($grader);
             }
             if ($component->isText()) {
                 $component_grade->setComment($data);

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -244,8 +244,14 @@ class SimpleGraderController extends AbstractController {
         $return_data = [];
 
         foreach ($gradeable->getComponents() as $component) {
-            $data = $_POST['scores'][$component->getId()] ?? '';
-            $original_data = $_POST['old_scores'][$component->getId()] ?? '';
+            $data = $_POST['scores'][$component->getId()];
+            if (!isset($data)) {
+                continue;
+            }
+            $original_data = $_POST['old_scores'][$component->getId()];
+            if (!isset($original_data)) {
+                return JsonResponse::getFailResponse("Save error: old score not set");
+            }
 
             $component_grade = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
             $component_grade->setGrader($grader);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
We have a problem with checkpoint (e.g., cs1 & ds lab) gradeables. I've tested with both Mac Chrome and Mac Firefox.

When I click on 2 checkpoints for the same person, it displays both checkpoints, but when I reload the page, only the 2nd checkpoint is stored.

### What is the new behavior?
All checkpoints will persist the state that they should be in after reloading.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Issues caused by #11360
[Zulip discussion about this](https://submitty.zulipchat.com/#narrow/channel/409312-RPI-Developers/topic/URGENT.20LAB.20GRADABLE.20BUGFIX.20NEEDED)
