### PR TITLE
[Bugfix:InstructorUI] Update users without preferred name 

### DIFF
--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -354,12 +354,12 @@ class UsersController extends AbstractController {
         $user->setNumericId(trim($_POST['user_numeric_id']));
 
         $user->setLegalGivenName(trim($_POST['user_givenname']));
-        if (isset($_POST['user_preferred_givenname'])) {
+        if (isset($_POST['user_preferred_givenname']) && trim($_POST['user_preferred_givenname']) !== "") {
             $user->setPreferredGivenName(trim($_POST['user_preferred_givenname']));
         }
 
         $user->setLegalFamilyName(trim($_POST['user_familyname']));
-        if (isset($_POST['user_preferred_familyname'])) {
+        if (isset($_POST['user_preferred_familyname']) && trim($_POST['user_preferred_familyname']) !== "") {
             $user->setPreferredFamilyName(trim($_POST['user_preferred_familyname']));
         }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
An instructor updating anything about a user (that has an empty preferred name) will cause a frog robot due to the new database constraints added in #11359. 

### What is the new behavior?
Preferred names are properly only passed when they are set and non empty when an instructor is updating a student.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
