### PR TITLE
[Bugfix:Forum] Fix Upduck Count Stat

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1432,7 +1432,7 @@ class ForumController extends AbstractController {
             $users[$user]["thread_title"][] = $this->core->getQueries()->getThreadTitle($posts[$i]["thread_id"]);
         }
         for ($i = 0; $i < $num_users_with_upducks; $i++) {
-            $user = $upducks[$i]["author_user_id"];
+            $user = $upducks[$i]["user_id"];
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
         }
         ksort($users);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -756,18 +756,18 @@ SQL;
     public function getUpDucks(): array {
         $this->course_db->query("
             SELECT 
-                p.author_user_id, 
-                COUNT(f.*) AS upducks 
+                f.user_id,
+                COUNT(*) AS upducks 
             FROM 
-                posts p 
+                forum_upducks f
             JOIN 
-                forum_upducks f 
+                posts p
             ON 
-                p.id = f.post_id 
+                f.post_id = p.id
             WHERE 
                 p.deleted = FALSE 
             GROUP BY 
-                p.author_user_id 
+                f.user_id
             ORDER BY 
                 upducks DESC
         ");

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -208,7 +208,7 @@ describe('Should test creating, replying, merging, removing, and upducks in foru
         checkThreadduck(1, 3);
         checkThreadduck(0, 4);
 
-        checkStatsUpducks('Instructor, Quinn', 9);
+        checkStatsUpducks('Instructor, Quinn', 6);
 
         // Tutorial into Questions
         mergeThreads(title3, title2, merged1);


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The current query to get all upduck is wrong. This could be simply observed by logging in as instructor and upducking a post not by instructor. This would cause the upduck count not go up

http://localhost:1511/courses/s25/sample/forum/stats

This is 1/2 of fixing the forums, the other one is below:
#11441 

### What is the new behavior?
Fixes the query and the related cypress tests

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This is the first part of many changes to the forums and upduck tests.
