### PR TITLE
[Bugfix:InstructorUI] check uploaded files near size limits

### DIFF
--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -588,7 +588,8 @@ class FileUtils {
             $type = mime_content_type($tmp_name);
             $zip_status = FileUtils::getZipFileStatus($tmp_name);
             $errors = [];
-                        //check if its a zip file
+
+            //check if its a zip file
             $is_zip = $type === 'application/zip';
             if ($is_zip) {
                 $zip_status = FileUtils::getZipFileStatus($tmp_name);

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -581,7 +581,6 @@ class FileUtils {
                     'is_zip' => false,            //unknown at this point also
                     'success' => false,
                 ];
-
             }
 
             $tmp_name = $file['tmp_name'];

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -574,7 +574,7 @@ class FileUtils {
             if ($file['error'] !== UPLOAD_ERR_OK) {
                 return [
                     'name' => $name,
-                    'type' => 'Unknown',
+                    'type' => null,
                     'error' => ErrorMessages::uploadErrors($file['error']),
                     'size' => $file['size'] ?? 0, //this may or may not be set as well
                     'is_zip' => false,            //unknown at this point also

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -572,7 +572,6 @@ class FileUtils {
 
             //if the error flag is set for this file, no guarantee tmp_name points to a valid file, exit early
             if ($file['error'] !== UPLOAD_ERR_OK) {
-                $errors[] = ErrorMessages::uploadErrors($file['error']);
                 return [
                     'name' => $name,
                     'type' => 'Unknown',

--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -569,16 +569,27 @@ class FileUtils {
         $validator = function ($file) {
             $max_size = Utils::returnBytes(ini_get('upload_max_filesize'));
             $name = $file['name'];
+
+            //if the error flag is set for this file, no guarantee tmp_name points to a valid file, exit early
+            if ($file['error'] !== UPLOAD_ERR_OK) {
+                $errors[] = ErrorMessages::uploadErrors($file['error']);
+                return [
+                    'name' => $name,
+                    'type' => 'Unknown',
+                    'error' => ErrorMessages::uploadErrors($file['error']),
+                    'size' => $file['size'] ?? 0, //this may or may not be set as well
+                    'is_zip' => false,            //unknown at this point also
+                    'success' => false,
+                ];
+
+            }
+
             $tmp_name = $file['tmp_name'];
 
             $type = mime_content_type($tmp_name);
             $zip_status = FileUtils::getZipFileStatus($tmp_name);
             $errors = [];
-            if ($file['error'] !== UPLOAD_ERR_OK) {
-                $errors[] = ErrorMessages::uploadErrors($file['error']);
-            }
-
-            //check if its a zip file
+                        //check if its a zip file
             $is_zip = $type === 'application/zip';
             if ($is_zip) {
                 $zip_status = FileUtils::getZipFileStatus($tmp_name);

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -587,7 +587,7 @@ STRING;
         $this->assertEquals(
             $stat[1],
             ['name' => 'bad2.txt',
-             'type' => 'text/plain',
+             'type' => 'Unknown',
              'error' => 'No file was uploaded.',
              'size' => 100,
              'is_zip' => false,
@@ -606,7 +606,7 @@ STRING;
         $this->assertEquals(
             $stat[1],
             ['name' => 'bad2.txt',
-             'type' => 'text/plain',
+             'type' => 'Unknown',
              'error' => 'No file was uploaded.',
              'size' => 100,
              'is_zip' => false,
@@ -617,7 +617,7 @@ STRING;
         $this->assertEquals(
             $stat[2],
             ['name' => 'bad3.txt',
-             'type' => 'text/plain',
+             'type' => 'Unknown',
              'error' => 'Unknown error code.',
              'size' => 100,
              'is_zip' => false,

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -572,7 +572,7 @@ STRING;
         $this->assertEquals(
             $stat[0],
             ['name' => 'bad.txt',
-             'type' => 'Unknown',
+             'type' => null,
              'error' => 'The file was only partially uploaded',
              'size' => 100,
              'is_zip' => false,
@@ -587,7 +587,7 @@ STRING;
         $this->assertEquals(
             $stat[1],
             ['name' => 'bad2.txt',
-             'type' => 'Unknown',
+             'type' => null,
              'error' => 'No file was uploaded.',
              'size' => 100,
              'is_zip' => false,
@@ -606,7 +606,7 @@ STRING;
         $this->assertEquals(
             $stat[1],
             ['name' => 'bad2.txt',
-             'type' => 'Unknown',
+             'type' => null,
              'error' => 'No file was uploaded.',
              'size' => 100,
              'is_zip' => false,
@@ -617,7 +617,7 @@ STRING;
         $this->assertEquals(
             $stat[2],
             ['name' => 'bad3.txt',
-             'type' => 'Unknown',
+             'type' => null,
              'error' => 'Unknown error code.',
              'size' => 100,
              'is_zip' => false,

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -572,7 +572,7 @@ STRING;
         $this->assertEquals(
             $stat[0],
             ['name' => 'bad.txt',
-             'type' => 'text/plain',
+             'type' => 'Unknown',
              'error' => 'The file was only partially uploaded',
              'size' => 100,
              'is_zip' => false,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

Fixes #11380
### What is the current behavior?
When a file is uploaded to php with a size >= `upload_max_filesize`, the `$_FILES` array still exists, however most of the data is junk. As a result the `$_FILES[file_index]['tmp_name']` which normally points to the tmp area the uploaded file lives in is not guaranteed to exist, which caused the file mine check to fail because it was empty.

see steps to reproduce: https://github.com/Submitty/Submitty/issues/11380#issuecomment-2641893026

### What is the new behavior?
The validation logic will now check if the error flag is set and exit immediately if it is

### Other information?
