### PR TITLE
[Feature: Forum] Always show upducks in forum

### DIFF
--- a/site/app/templates/forum/displayThreadList.twig
+++ b/site/app/templates/forum/displayThreadList.twig
@@ -45,24 +45,26 @@
                     {% endif %}
                 </span>
             </div>
+
+            <span>
+                <i
+                    data-testid="thread-upduck-button"
+                    class="upduck-button text-decoration-none"
+                    title="Total upduck">
+                    <img
+                        id="ThreadsumDucksIcon_{{ thread.thread_id }}"
+                        src="{{ '/img/on-duck-button.svg' }}"
+                        alt="sum_like"
+                        width="30"
+                        height="30"
+                    >
+                </i>
+                <span data-testid="thread-like-count"
+                      id="Thread_likeCounter_{{ thread.thread_id }}"
+                      class="thread-like-counter">{{ thread.sum_ducks }}</span>
+            </span>
+
             {% if is_full_page is defined and is_full_page %}
-                <span>
-                    <i  
-                        data-testid="thread-upduck-button" 
-                        class="upduck-button text-decoration-none" 
-                        title="Total upduck">
-                        <img 
-                            id="ThreadsumDucksIcon_{{thread.thread_id}}" 
-                            src="{{'/img/on-duck-button.svg'}}" 
-                            alt="sum_like"
-                            width="30" 
-                            height="30"
-                        >
-                    </i>
-                    <span data-testid="thread-like-count" 
-                        id="Thread_likeCounter_{{thread.thread_id}}" 
-                        class="thread-like-counter">{{ thread.sum_ducks }}</span>
-                </span>
                 <div class="post-action-container" data-testid="post-action-container">
 
                     <span>

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -693,6 +693,7 @@ class ForumThreadView extends AbstractView {
                 "is_locked" => $thread->isLocked(),
                 "date" => $date_content,
                 "current_user_posted" => $thread->getAuthor()->getId() === $current_user,
+                "sum_ducks" => $thread->getSumUpducks(),
             ];
 
             if ($is_full_page) {
@@ -725,7 +726,6 @@ class ForumThreadView extends AbstractView {
                     "render_markdown" => $first_post->isRenderMarkdown(),
                     "author_info" => $author_info,
                     "deleted" => $first_post->isDeleted(),
-                    "sum_ducks" => $thread->getSumUpducks()
                 ]);
             }
             $thread_content[] = $thread_info;


### PR DESCRIPTION
### What is the current behavior?
Before the upduck count only start showing at the bottom of threadlist.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/c096f25d-57cd-4de1-b0a3-9f020e2b0a9a" />

### What is the new behavior?
Need advices on where to place the count. Barb mentioned a refactor of the current looks would be good to utilize the blank space more efficiently.

![image](https://github.com/user-attachments/assets/ef2e37f5-d678-481b-8e5e-abb99892b02b)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
