### PR TITLE
[Testing:Developer] Fix warning on installing vagrant

### DIFF
--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: brew install vagrant
+      - run: brew install --cask vagrant
       - name: install virtual box 7.0.20
         run: |
           curl -LO https://download.virtualbox.org/virtualbox/7.0.20/VirtualBox-7.0.20-163906-OSX.dmg


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When vagrant is installed in the workflow, the following is outputted:

```
Run brew install vagrant
Error: Failed to load formula: vagrant
hashicorp/tap/vagrant: formula requires at least a URL

Warning: Treating vagrant as a cask.
==> Downloading https://releases.hashicorp.com/vagrant/2.4.3/vagrant_2.4.3_darwin_amd64.dmg
==> Installing Cask vagrant
==> Running installer for vagrant with sudo; the password may be necessary.
installer: Package name is Vagrant
installer: Installing at base path /
installer: The install was successful.
🍺  vagrant was successfully installed!
```

where both the error and warning are logged to the summary of the image.

### What is the new behavior?

That we install vagrant per the [docs](https://formulae.brew.sh/cask/vagrant), using the `--cask` flag, which should avoid the error/warning.