### PR TITLE
[Bugfix:forum] adjusting the color of deleted posts

### DIFF
--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -131,7 +131,7 @@
 
     /* discussion forum */
     --deleted-and-unviewed-thread: #acc0d7;
-    --deleted-discussion-post-grey: #8b8b8b;
+    --deleted-discussion-post-grey: #8d8d8d;
     --important-post: #ffd700; /* is also for star color */
     --attachment-box-color: #f5f5f5;
     --file-upload-table-hover: #d1d1d1;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -131,7 +131,7 @@
 
     /* discussion forum */
     --deleted-and-unviewed-thread: #acc0d7;
-    --deleted-discussion-post-grey: #dcdcdc;
+    --deleted-discussion-post-grey: #8b8b8b;
     --important-post: #ffd700; /* is also for star color */
     --attachment-box-color: #f5f5f5;
     --file-upload-table-hover: #d1d1d1;


### PR DESCRIPTION
### What is the current behavior?

Closes #11165

the current behavior makes the deleted posts too bright in dark mode.    
![Screenshot 2025-02-12 012901](https://github.com/user-attachments/assets/21c06acd-c1b8-4a23-b681-32020cc83fd2)

### What is the new behavior?

using the adjusted color for better representation 
![Screenshot 2025-02-12 144438](https://github.com/user-attachments/assets/4eb8a8f9-94d7-4e06-80aa-74259edcd6bc)


### Other information?

i also tested for light mode 
![Screenshot 2025-02-12 145318](https://github.com/user-attachments/assets/20998182-95f0-4d63-939c-e9852f98e0fe)

