### PR TITLE
[Feature:RainbowGrades] Default to Nightly Build

### DIFF
--- a/site/app/controllers/admin/ConfigurationController.php
+++ b/site/app/controllers/admin/ConfigurationController.php
@@ -21,8 +21,8 @@ class ConfigurationController extends AbstractController {
     // The message that should be returned to the user if they fail the required validation to enable the nightly
     // rainbow grades build checkbox
     const FAIL_AUTO_RG_MSG = 'You may not enable automatic rainbow grades generation until you have supplied a ' .
-    'customization.json file.  To have one generated for you, you may use the Web-Based Rainbow Grades Generation inside the Grade ' .
-    'Reports tab.  You may also manually create the file and upload it to your course\'s rainbow_grades directory.';
+    'customization.json file.  To have one generated for you, you may use the Grades Configuration tab. ' .
+    'You may also manually create the file and upload it to your course\'s rainbow_grades directory.';
     const NO_SELF_REGISTER = 0; // Self registration disabled
     const REQUEST_SELF_REGISTER = 1; // Self registration allowed, users request and instructors can approve
     const ALL_SELF_REGISTER = 2; // Self registration allowed, and all users who register are automatically added
@@ -169,23 +169,7 @@ class ConfigurationController extends AbstractController {
             }
         }
         elseif ($name === 'auto_rainbow_grades') {
-            // Special validation for auto_rainbow_grades checkbox
-            // Get a new customization json object
-            $customization_json = new RainbowCustomizationJSON($this->core);
-
-            // If a manual_customization.json does not exist, then check for the presence of a regular one
-            if (!$customization_json->doesManualCustomizationExist()) {
-                // Attempt to populate it from the customization.json in the course rainbow_grades directory
-                // If no file exists do not allow user to enable this check mark until one is supplied
-                try {
-                    $customization_json->loadFromJsonFile();
-                }
-                catch (\Exception $e) {
-                    return MultiResponse::JsonOnlyResponse(
-                        JsonResponse::getFailResponse(ConfigurationController::FAIL_AUTO_RG_MSG)
-                    );
-                }
-            }
+            // Validation for auto_rainbow_grades checkbox
 
             $entry = $entry === "true";
         }

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -246,7 +246,8 @@
                         <br>
                         <span class="option-alt">
                             With a valid customization.json Rainbow Grades configuration,<br>
-                            a Submitty cron job will update Rainbow Grades every night at approximately 2am.
+                            a Submitty cron job will update Rainbow Grades every night at approximately 2am.<br>
+                            The job will not run if this course is archived.
                         </span>
                     </label>
                 </div>

--- a/site/config/course_template.json
+++ b/site/config/course_template.json
@@ -20,7 +20,7 @@
         "grade_inquiry_message": "Warning: Frivolous grade inquiries may lead to grade deductions or lost late days",
         "seating_only_for_instructor": false,
         "room_seating_gradeable_id": "",
-        "auto_rainbow_grades": false,
+        "auto_rainbow_grades": true,
         "queue_enabled": false,
         "queue_message": "",
         "queue_announcement_message": "",


### PR DESCRIPTION
Removes validation for nightly build checkbox, since customization.json is not needed.

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
On course creation, Automatic Nightly Processing for Rainbow Grades Generation is off by default.

### What is the new behavior?
On course creation, Automatic Nightly Processing for Rainbow Grades Generation will be on by default.
![image](https://github.com/user-attachments/assets/53ba15b0-55ed-4448-87c9-c412a04dc914)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
