### PR TITLE
[Bugfix:CourseMaterials] Enforce path length limit while editing courses.

### DIFF
--- a/site/app/controllers/course/CourseMaterialsController.php
+++ b/site/app/controllers/course/CourseMaterialsController.php
@@ -468,6 +468,14 @@ class CourseMaterialsController extends AbstractController {
                     return JsonResponse::getErrorResponse("Invalid path or filename");
                 }
 
+                if (strlen($file_name) > 255) {
+                    $excess_chars = strlen($file_name) - 255;
+                    return JsonResponse::getErrorResponse("Filename cannot have a string length of more than 255 chars. You need to remove $excess_chars characters.");
+                }
+                if (strlen($new_path) > 255) {
+                    $excess_chars = strlen($new_path) - 255;
+                    return JsonResponse::getErrorResponse("Path cannot have a string length of more than 255 chars. You need to remove $excess_chars characters.");
+                }
                 $requested_path = explode("/", $requested_path);
                 if (count($requested_path) > 1) {
                     $requested_path_directories = $requested_path;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] ~Tests for the changes have been added/updated (if possible)~ Not required
* [ ] ~Documentation has been updated/added if relevant~ Fixes bugs.
* [ ] ~Screenshots are attached to Github PR if visual/UI changes were made~ No visual changes

### What is the current behavior?
Please note: This fixes a related issue to #11468 , and needs to be merged along with issue #11470 
Gives an error when editing an already existing file in Course Materials, but the new file path length is larger than 255 characters. 

### Other information?
- Not a breaking change
- Tested with a few example files. 
