### PR TITLE
[BugFix:TAGrading] Fix inline opening of binary files.

### DIFF
--- a/site/public/js/ta-grading.js
+++ b/site/public/js/ta-grading.js
@@ -1596,11 +1596,24 @@ function openFrame(html_file, url_file, num, pdf_full_panel = true, panel = 'sub
         else if (url_file.includes('attachments')) {
             directory = 'attachments';
         }
+        function isNotRenderable(fileName) {
+            const fileExtension = fileName.split('.').pop();
+            if(fileExtension == fileName) return false;
+            const notSupportedExtensions = ['pptx', 'ppt', 'docx', 'doc', 'xlsx', 'xls', 'zip', 'rar', '7z'];
+            return notSupportedExtensions.includes(fileExtension);
+        }
         // handle pdf
         if (pdf_full_panel && url_file.substring(url_file.length - 3) === 'pdf') {
             viewFileFullPanel(html_file, url_file, 0, panel).then(() => {
                 loadPDFToolbar();
             });
+        }
+        else if (isNotRenderable(url_file)) {
+            const frameHtml = `
+                This file type is not supported for rendering. Please download the file and view it on your local machine.
+            `;
+            iframe.html(frameHtml);
+            iframe.addClass('open');
         }
         else {
             const forceFull = url_file.substring(url_file.length - 3) === 'pdf' ? 500 : -1;


### PR DESCRIPTION
* ~[ ] Tests for the changes have been added/updated (if possible)~ Tests not added/changed. 
* ~[ ] Documentation has been updated/added if relevant~ Fixes bugs
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Rendering of binary file as is. 

### What is the new behavior?
![image](https://github.com/user-attachments/assets/200ee5c8-4d6a-4346-9ca1-5669bfc2e827)
Fixes #11009. Displays a message informing the user, to download the submission on to their computer, to view the file. 

### Other information?
This is not a breaking a change. 
Currently disallowed file types are: `'pptx', 'ppt', 'docx', 'doc', 'xlsx', 'xls', 'zip', 'rar', '7z'` which can be modified if needed. 

