### PR TITLE
[Bugfix:InstructorUI] Fix When Default Section is Null

### DIFF
--- a/.setup/bin/sample_courses/models/course/course_create.py
+++ b/.setup/bin/sample_courses/models/course/course_create.py
@@ -112,7 +112,15 @@ class Course_create:
                 course=self.code,
                 registration_section_id=str(section),
             )
-
+        table = Table("courses", submitty_metadata, autoload=True)
+        print("(tables loaded)...")
+        if self.self_registration_type != 0:
+            print("Setting course default section id to 1")
+            submitty_conn.execute(
+                table.update()
+                .where(table.c.course == self.code)
+                .values(default_section_id=1)
+            )
         print("Creating rotating sections ", end="")
         table = Table("sections_rotating", self.metadata, autoload=True)
         print("(tables loaded)...")

--- a/site/app/controllers/SelfRejoinController.php
+++ b/site/app/controllers/SelfRejoinController.php
@@ -27,7 +27,8 @@ class SelfRejoinController extends AbstractController {
             'noAccessCourse',
             $this->canRejoinCourse($user_id, $course, $term),
             $this->core->buildCourseUrl(["rejoin_course"]),
-            $this->core->getQueries()->getSelfRegistrationType($term, $course)
+            $this->core->getQueries()->getSelfRegistrationType($term, $course),
+            $this->core->getQueries()->getDefaultRegistrationSection($term, $course)
         );
     }
 

--- a/site/app/controllers/course/CourseRegistrationController.php
+++ b/site/app/controllers/course/CourseRegistrationController.php
@@ -37,7 +37,8 @@ class CourseRegistrationController extends AbstractController {
         if ($this->core->getQueries()->getSelfRegistrationType($term, $course) === ConfigurationController::NO_SELF_REGISTER) {
             $this->core->addErrorMessage('Self registration is not allowed.');
             return new RedirectResponse($this->core->buildUrl(['home']));
-        } elseif ($this->core->getQueries()->getDefaultRegistrationSection($term, $course) === null) {
+        }
+        elseif ($this->core->getQueries()->getDefaultRegistrationSection($term, $course) === null) {
             $this->core->addErrorMessage('Default section ID is not set, alert your instructor.');
             return new RedirectResponse($this->core->buildUrl(['home']));
         }

--- a/site/app/controllers/course/CourseRegistrationController.php
+++ b/site/app/controllers/course/CourseRegistrationController.php
@@ -37,7 +37,7 @@ class CourseRegistrationController extends AbstractController {
         if ($this->core->getQueries()->getSelfRegistrationType($term, $course) === ConfigurationController::NO_SELF_REGISTER) {
             $this->core->addErrorMessage('Self registration is not allowed.');
             return new RedirectResponse($this->core->buildUrl(['home']));
-        } else  if ($this->core->getQueries()->getDefaultRegistrationSection($term, $course) === null) {
+        } elseif ($this->core->getQueries()->getDefaultRegistrationSection($term, $course) === null) {
             $this->core->addErrorMessage('Default section ID is not set, alert your instructor.');
             return new RedirectResponse($this->core->buildUrl(['home']));
         }

--- a/site/app/controllers/course/CourseRegistrationController.php
+++ b/site/app/controllers/course/CourseRegistrationController.php
@@ -37,6 +37,9 @@ class CourseRegistrationController extends AbstractController {
         if ($this->core->getQueries()->getSelfRegistrationType($term, $course) === ConfigurationController::NO_SELF_REGISTER) {
             $this->core->addErrorMessage('Self registration is not allowed.');
             return new RedirectResponse($this->core->buildUrl(['home']));
+        } else  if ($this->core->getQueries()->getDefaultRegistrationSection($term, $course) === null) {
+            $this->core->addErrorMessage('Default section ID is not set, alert your instructor.');
+            return new RedirectResponse($this->core->buildUrl(['home']));
         }
         else {
             $this->registerCourseUser($term, $course);

--- a/site/app/templates/admin/Configuration.twig
+++ b/site/app/templates/admin/Configuration.twig
@@ -317,7 +317,7 @@
                         id="all-self-registration"
                         data-testid="all-self-registration"
                         value="true"
-                        {{ fields['self_registration_type'] == constant('app\\controllers\\admin\\ConfigurationController::ALL_SELF_REGISTER') ? 'checked' : '' }}
+                        {{ fields['self_registration_type'] == all_self_register ? 'checked' : '' }}
                         onclick="return confirmSelfRegistration(this, {{ fields['registration_sections'] is empty ? 'true' : 'false' }})"
                     />
                     <div>
@@ -333,6 +333,9 @@
                         <br/>
                         <span class="option-title">Default Section</span>
                         <select name="default_section_id" id="default-section-id" data-testid="default-section-id" >
+                            {% if fields['default_section'] is null %}
+                                <option value="" selected> NULL </option>
+                            {% endif %}
                             {% for section in fields['registration_sections'] %}
                                 <option 
                                     value="{{ section['sections_registration_id'] }}" 

--- a/site/app/templates/error/NoAccessCourse.twig
+++ b/site/app/templates/error/NoAccessCourse.twig
@@ -1,5 +1,5 @@
 <div class="content" data-testid="no-access-message">
-    {% if self_registration_type != constant('app\\controllers\\admin\\ConfigurationController::ALL_SELF_REGISTER') %}
+    {% if self_registration_type != all_self_register %}
         You don't have access to this course. <br />
         This is <b>{{course_name}}</b> for <b>{{semester}}</b>. <br/>
         If you think this is a mistake,
@@ -16,6 +16,9 @@
             please contact your instructor to gain access. <br/>
             Click <a href="{{main_url}}"> here </a> to back to homepage and see your courses list.
         {% endif %}
+    {% elseif default_section_id is null %}
+        The course <b>{{ course_name }} {{ course_name != course_id ? '(' ~ course_id ~ ') ' : '' }}</b>for <b>{{ semester }}</b> is open to self registration, however the instructor has not set a default section id.
+        <br/>Please alert your instructor.
     {% else %}
         The course <b>{{ course_name }} {{ course_name != course_id ? '(' ~ course_id ~ ') ' : '' }}</b>for <b>{{ semester }}</b> is open to self registration <br />
         You may select below to add yourself to the course. <br/>

--- a/site/app/views/ErrorView.php
+++ b/site/app/views/ErrorView.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\views;
+use app\controllers\admin\ConfigurationController;
 
 class ErrorView extends AbstractView {
     public function exceptionPage($error_message) {
@@ -36,7 +37,7 @@ class ErrorView extends AbstractView {
      * @param string $readd_url URL to the rejoin course function.
      * @return string The Twig HTML for this page.
      */
-    public function noAccessCourse(bool $can_rejoin_course, string $readd_url, int $self_registration_type): string {
+    public function noAccessCourse(bool $can_rejoin_course, string $readd_url, int $self_registration_type, ?int $default_section_id): string {
         return $this->core->getOutput()->renderTwigTemplate("error/NoAccessCourse.twig", [
             "course_name" => $this->core->getDisplayedCourseName(),
             "semester" => $this->core->getFullSemester(),
@@ -48,7 +49,9 @@ class ErrorView extends AbstractView {
             "register_url" => $this->core->buildCourseUrl(['register']),
             "user" => $this->core->getUser(),
             "csrf_token" => $this->core->getCsrfToken(),
-            "self_registration_type" => $self_registration_type
+            "self_registration_type" => $self_registration_type,
+            "all_self_register" => ConfigurationController::ALL_SELF_REGISTER,
+            "default_section_id" => $default_section_id
         ]);
     }
 

--- a/site/app/views/ErrorView.php
+++ b/site/app/views/ErrorView.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace app\views;
+
 use app\controllers\admin\ConfigurationController;
 
 class ErrorView extends AbstractView {

--- a/site/app/views/admin/ConfigurationView.php
+++ b/site/app/views/admin/ConfigurationView.php
@@ -3,6 +3,7 @@
 namespace app\views\admin;
 
 use app\views\AbstractView;
+use app\controllers\admin\ConfigurationController;
 
 class ConfigurationView extends AbstractView {
     public function viewConfig(
@@ -26,7 +27,8 @@ class ConfigurationView extends AbstractView {
             "email_room_seating_url" => $this->core->buildCourseUrl(['email_room_seating']),
             "manage_categories_url" => $this->core->buildCourseUrl(['forum', 'categories']),
             "csrf_token" => $csrf_token,
-            "sections_url" => $this->core->buildCourseUrl(['sections'])
+            "sections_url" => $this->core->buildCourseUrl(['sections']),
+            "all_self_register" => ConfigurationController::ALL_SELF_REGISTER
         ]);
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
The sample course 'testing' currently is supposed to allow for self registration, however in doing so it does not set the default section id, and breaks the functionality somewhat, as users who register are put in the null section. 
Related to https://github.com/Submitty/Submitty/issues/11471. This does not fix the issue as described, users who are set to the null section will not be able to register, but it gives the users a warning message, and displays a different default section to instructors. 

### What is the new behavior?
The sample course scripts now accurately set the default section, and if an instructor uses the create_course.sh script, and does not set a default section, it will now display a different message to the students, and not allow them to register. Also, the place to set the default section now shows 'NULL' if the section is null, instead of showing the first given section. 
