### PR TITLE
[Bugfix:TAGrading] Fully discard changes on click

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2855,10 +2855,9 @@ async function closeComponentInstructorEdit(component_id, saveChanges) {
  * @return {void}
  */
 async function closeComponentGrading(component_id, saveChanges) {
-    GRADED_COMPONENTS_LIST[component_id] = getGradedComponentFromDOM(component_id);
-    COMPONENT_RUBRIC_LIST[component_id] = getComponentFromDOM(component_id);
-
     if (saveChanges) {
+        GRADED_COMPONENTS_LIST[component_id] = getGradedComponentFromDOM(component_id);
+        COMPONENT_RUBRIC_LIST[component_id] = getComponentFromDOM(component_id);
         await saveComponent(component_id);
     }
     // Finally, render the graded component in non-edit mode with the mark list hidden


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When clicking to discard changes the component will be closed and the changes will not be saved, but they are still reflected locally until refresh.

### What is the new behavior?
When discard is clicked the local data is also reset to show the component in the state it was before the grader opened it.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Fixes #10717