### PR TITLE
[Bugfix:TAGrading] Fix peer panel

### DIFF
--- a/site/public/js/ta-grading-rubric.js
+++ b/site/public/js/ta-grading-rubric.js
@@ -2450,7 +2450,7 @@ async function reloadPeerRubric(gradeable_id, anon_id) {
         alert(`Could not fetch gradeable rubric: ${err.message}`);
     }
     try {
-        await ajaxGetGradedGradeable(gradeable_id, anon_id, true);
+        graded_gradeable = await ajaxGetGradedGradeable(gradeable_id, anon_id, true);
     }
     catch (err) {
         alert(`Could not fetch graded gradeable: ${err.message}`);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Attempting to grade a gradeable with at least one peer component as part of the course staff will cause an alert and an error along with the peer panel failing to render.
![image](https://github.com/user-attachments/assets/62cef454-8ffc-4706-896f-5a53f167bdf2)


### What is the new behavior?
The errors no longer occur and the peer panel works as intended.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This was likely broken back in #11008, hopefully this is one of the last required fixes.
