### PR TITLE
[Dependency] Fix CI failures due to python dependencies

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -60,11 +60,11 @@ runs:
     - name: Install Test-specific python dependencies
       run: |
         # Install for local
-        python3 -m pip install --upgrade pip setuptools wheel
+        python3 -m pip install --upgrade pip setuptools wheel packaging
         pip3 -V
         pip3 install selenium websocket_client
         # Install globally
-        sudo python3 -m pip install --upgrade pip setuptools wheel
+        sudo python3 -m pip install --upgrade pip setuptools wheel packaging
         sudo pip3 -V
       shell: bash
     - name: Install python dependencies


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently multiple CI are failing ([test1](https://github.com/Submitty/Submitty/actions/runs/13535792102/job/37827165110), [test2](https://github.com/Submitty/Submitty/actions/runs/13535563458/job/37826507269), [test3](https://github.com/Submitty/Submitty/actions/runs/13481272252/job/37814494803)). This is likely due to a recent update to the setuptools from v75.8.0 to v75.8.1 ([changes](https://github.com/pypa/setuptools/compare/v75.8.0...v75.8.1?diff=unified&w=)).

### What is the new behavior?
The issue is fixed by updating `packaging` when installing python dependencies (both locally and globally)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
