### PR TITLE
[Bugfix:Forum] Fix the Thread Lock Date error

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1017,7 +1017,7 @@ class ForumController extends AbstractController {
 
         if ($user->accessAdmin()) {
             $lock_thread_date_input = filter_input(INPUT_POST, "lock_thread_date", FILTER_UNSAFE_RAW);
-            if ($lock_thread_date_input !== false) {
+            if ($lock_thread_date_input !== false && $lock_thread_date_input !== "") {
                 $thread->setLockDate(DateUtils::parseDateTime($lock_thread_date_input, $user->getUsableTimeZone()));
             }
             else {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7343,10 +7343,14 @@ AND gc_id IN (
      */
     public function isThreadLocked(int $thread_id): bool {
         $this->course_db->query('SELECT lock_thread_date FROM threads WHERE id = ?', [$thread_id]);
-        if (empty($this->course_db->row()['lock_thread_date'])) {
+        $row = $this->course_db->row();
+        $lock_date = $row['lock_thread_date'] ?? null;
+        if ($lock_date === null) {
             return false;
         }
-        return $this->course_db->row()['lock_thread_date'] < date("Y-m-d H:i:S");
+        $current_date = new \DateTime();
+        $lock_date_time = new \DateTime($lock_date);
+        return $lock_date_time < $current_date;
     }
 
     /**

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -623,7 +623,7 @@ SQL;
                 $str = "";
                 $arr = [];
                 foreach ($categories_ids as $id) {
-                    if (!empty($str)) {
+                    if ($str !== '') {
                         $str .= ", ";
                     }
                     $str .= "({$thread_id}, ?)";

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -623,7 +623,7 @@ SQL;
                 $str = "";
                 $arr = [];
                 foreach ($categories_ids as $id) {
-                    if ($str !== '') {
+                    if (!empty($str)) {
                         $str .= ", ";
                     }
                     $str .= "({$thread_id}, ?)";
@@ -7345,7 +7345,7 @@ AND gc_id IN (
         $this->course_db->query('SELECT lock_thread_date FROM threads WHERE id = ?', [$thread_id]);
         $row = $this->course_db->row();
         $lock_date = $row['lock_thread_date'] ?? null;
-        if ($lock_date === null) {
+        if (empty($this->course_db->row()['lock_thread_date'])) {
             return false;
         }
         $current_date = new \DateTime();

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -36,6 +36,9 @@
                                 },
                                 {
                                     label: "End of time"
+                                },
+                                {
+                                    label: "Clear"
                                 }
                             ],
                             label: "or",
@@ -44,12 +47,16 @@
                                 switch (index) {
                                     case 0:
                                         date = new Date();
+                                        fp.setDate(date, true);
                                         break;
                                     case 1:
                                         date = new Date("9998-01-01T00:00:00");
+                                        fp.setDate(date, true);
+                                        break;
+                                    case 2:
+                                        fp.clear();
                                         break;
                                 }
-                                fp.setDate(date, true);
                             }
                         })
                     ],

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -87,6 +87,49 @@ const replyDisabled = (title, attachment) => {
     cy.contains('p', attachment).should('be.visible');
 };
 
+const setLockDateToPast = (title) => {
+    cy.get('[data-testid="thread-list-item"]').contains(title).click();
+    cy.get('[data-testid="thread-dropdown"]').first().click();
+    cy.get('[data-testid="edit-post-button"]').first().click();
+    cy.get('#lock_thread_date').clear().type('2023-01-01 00:00:00');
+    cy.get('[data-testid="forum-update-post"]').contains('Update Post').click();
+};
+
+const clearLockDate = (title) => {
+    cy.get('[data-testid="thread-list-item"]').contains(title).click();
+    cy.get('[data-testid="thread-dropdown"]').first().click();
+    cy.get('[data-testid="edit-post-button"]').first().click();
+    cy.get('#lock_thread_date').clear();
+    cy.get('[data-testid="forum-update-post"]').contains('Update Post').click();
+};
+
+describe('Forum Thread Lock Date Functionality', () => {
+    beforeEach(() => {
+        cy.login('instructor');
+        cy.visit(['sample', 'forum']);
+        cy.get('#nav-sidebar-collapse-sidebar').click();
+    });
+
+    it('Should prevent students from replying when lock date is in the past and allow replying when lock date is cleared', () => {
+        createThread(title1, content1, 'Comment');
+        setLockDateToPast(title1);
+        cy.login('student');
+        cy.visit(['sample', 'forum']);
+        cy.get('[data-testid="thread-list-item"]').contains(title1).click();
+        cy.get('[data-testid="forum-submit-reply-all"]').should('be.disabled');
+
+        cy.login('instructor');
+        cy.visit(['sample', 'forum']);
+        clearLockDate(title1);
+
+        cy.login('student');
+        cy.visit(['sample', 'forum']);
+        replyToThread(title1, reply1);
+
+        removeThread(title1);
+    });
+});
+
 describe('Should test creating, replying, merging, removing, and upducks in forum', () => {
     beforeEach(() => {
         cy.login('instructor');

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -91,7 +91,8 @@ const setLockDateToPast = (title) => {
     cy.get('[data-testid="thread-list-item"]').contains(title).click();
     cy.get('[data-testid="thread-dropdown"]').first().click();
     cy.get('[data-testid="edit-post-button"]').first().click();
-    cy.get('#lock_thread_date').clear().type('2023-01-01 00:00:00');
+    cy.get('#lock_thread_date').clear();
+    cy.get('#lock_thread_date').type('2023-01-01 00:00:00');
     cy.get('[data-testid="forum-update-post"]').contains('Update Post').click();
 };
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
By default, discussion forum threads have a NULL thread lock date, and any user can post to the thread.
If the instructor specifies a thread lock date, students should not be able to post to the thread after that date.

However, it seems that if the thread lock date is non-NULL, students are blocked from posting to the thread. Even if the date is far in the future.

Also, it's not possible to edit a thread and remove a thread lock date -- e.g., set it back to NULL. You can change the thread lock date to another date.
### What is the new behavior?
Thread Lock Date Validation: If the thread lock date is set to a valid future date, students should are able to post before that date
Thread Lock Date Removal: Now can edit a thread and set the thread lock date back to NULL should be restored.

### Other information?
Fixes #11499
