### PR TITLE
[Refactor:Submission] Split pdf image generation into new job

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_qr_split.py
@@ -7,6 +7,7 @@ import traceback
 import numpy
 from . import write_to_log as logger
 from . import submitty_ocr as scanner
+from . import generate_pdf_images
 
 # try importing required modules
 try:
@@ -102,12 +103,14 @@ def main(args):
                     logger.write_to_json(json_file, output)
                     with open(prev_file, 'wb') as out:
                         pdf_writer.write(out)
+                    generate_pdf_images.main(prev_file, [])
 
                 if id_index == 1:
                     # correct first pdf's page count and print file
                     output[prev_file]['page_count'] = page_count
                     with open(prev_file, 'wb') as out:
                         pdf_writer.write(out)
+                    generate_pdf_images.main(prev_file, [])
 
                 # start a new pdf and grab the cover
                 cover_writer = PdfWriter()
@@ -126,11 +129,6 @@ def main(args):
                 id_index += 1
                 page_count = 1
                 prev_file = output_filename
-
-                # save page as image, start indexing at 1
-                page.save(prev_file[:-4] + '_' + str(page_count).zfill(3) + '.jpg',
-                          "JPEG", quality=20, optimize=True)
-
             else:
                 # the first pdf page doesn't have a qr code
                 if i == 0:
@@ -156,10 +154,6 @@ def main(args):
                 # add pages to current split_pdf
                 page_count += 1
                 pdf_writer.add_page(pdfPages.pages[i])
-                # save page as image, start indexing at 1
-                page.save(prev_file[:-4] + '_' + str(page_count).zfill(3) + '.jpg',
-                          "JPEG", quality=20, optimize=True)
-
             i += 1
 
         buff += "Finished splitting into {} files\n".format(id_index)
@@ -176,6 +170,7 @@ def main(args):
 
         with open(prev_file, 'wb') as out:
             pdf_writer.write(out)
+        generate_pdf_images.main(prev_file, [])
         # write the buffer to the log file, so everything is on one line
         logger.write_to_log(log_file_path, buff)
     except Exception:

--- a/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/bulk_upload_split.py
@@ -7,6 +7,7 @@ import PyPDF2
 import traceback
 from PyPDF2 import PdfWriter
 from . import write_to_log as logger
+from . import generate_pdf_images
 
 try:
     from pdf2image import convert_from_bytes
@@ -61,15 +62,7 @@ def main(args):
                     i += 1
                 with open(output_filename, 'wb') as out:
                     pdf_writer.write(out)
-
-                # save pdfs as images (start indexing at one)
-                # open the file after writing it
-                with open(output_filename, 'rb') as out:
-                    pdf_images = convert_from_bytes(out.read(), dpi=200)
-                    for k in range(len(pdf_images)):
-                        pdf_images[k].save(output_filename[:-4] +
-                                           '_' + str(k + 1).zfill(3) + '.jpg',
-                                           "JPEG", quality=20, optimize=True)
+                generate_pdf_images.main(output_filename, [])
 
                 with open(cover_filename, 'wb') as out:
                     cover_writer.write(out)

--- a/sbin/submitty_daemon_jobs/submitty_jobs/generate_pdf_images.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/generate_pdf_images.py
@@ -1,0 +1,44 @@
+import os
+import traceback
+from typing import List, Sequence
+
+from pdf2image import convert_from_bytes
+from PIL import Image, ImageDraw
+from PyPDF2 import PdfReader
+
+
+class Redaction:
+    def __init__(self, page_number: int, coordinates: Sequence[float]):
+        self.page_number = page_number
+        self.coordinates = coordinates
+
+
+def main(pdf_file_path: str, redactions: List[Redaction]):
+    directory = os.path.dirname(pdf_file_path)
+    if directory:
+        os.chdir(os.path.dirname(pdf_file_path))
+    try:
+        pdfPages = PdfReader(pdf_file_path, strict=False)
+        with open(pdf_file_path, 'rb') as open_file:
+            imagePages = convert_from_bytes(
+                open_file.read(),
+                )
+        for page_number in range(len(pdfPages.pages)):
+            image_filename = pdf_file_path[:-4] + '_' + str(page_number + 1).zfill(3) + '.jpg'
+            imagePages[page_number].save(image_filename,
+                                         "JPEG", quality=20, optimize=True)
+            for redaction in redactions:
+                if redaction.page_number != page_number:
+                    continue
+                img = Image.open(image_filename)
+                draw = ImageDraw.Draw(img)
+                draw.rectangle(redaction.coordinates, fill="black")
+                img.save(image_filename,
+                         "JPEG", quality=20, optimize=True)
+    except Exception:
+        msg = "Failed when splitting pdf " + pdf_file_path
+        print(msg)
+        traceback.print_exc()
+        # print everything in the buffer just in case it didn't write
+        pass
+    pass

--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -14,6 +14,7 @@ import datetime
 from urllib.parse import unquote
 from . import bulk_qr_split
 from . import bulk_upload_split
+from . import generate_pdf_images 
 from . import INSTALL_DIR, DATA_DIR
 from . import write_to_log as logger
 from . import VERIFIED_ADMIN_USER
@@ -341,6 +342,17 @@ class BulkUpload(CourseJob):
             pass
 
         os.chdir(current_path)
+
+
+class GeneratePdfImages(AbstractJob):
+    def run_job(self):
+        pdf_file_path = self.job_details['pdf_file_path']
+        # optionally get redactions
+        redactions = self.job_details.get('redactions', [])
+        generate_pdf_images.main(pdf_file_path, [generate_pdf_images.Redaction(**r) for r in redactions])
+
+    def cleanup_job(self):
+        pass
 
 
 # pylint: disable=abstract-method

--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -14,7 +14,7 @@ import datetime
 from urllib.parse import unquote
 from . import bulk_qr_split
 from . import bulk_upload_split
-from . import generate_pdf_images 
+from . import generate_pdf_images
 from . import INSTALL_DIR, DATA_DIR
 from . import write_to_log as logger
 from . import VERIFIED_ADMIN_USER


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Pdf splitting and image generation is done in a single job

### What is the new behavior?
Pdf splitting now calls the GeneratePdfImages job to turn the split pdf into images.


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
This will be part of a series of PRs to eventually support redaction of tests for limited access graders, the job needs to be split to be able to rerun the image generation if the redaction list changes
