### PR TITLE
[UI/UX:InstructorUI] Dark Mode for Customizing Categories

### DIFF
--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -61,17 +61,6 @@
                     No categories exist, please create one.
                 </span>
         {% endif %}
-    
-        <style>
-          {% for category in categories %}
-            .category-item-box {
-              color: var(--default-black);
-            }
-            [data-theme ="dark"] .category-item-box {
-              background: var(--btn-default-white);
-            }
-		  {% endfor %}
-        </style>
 
         <ul id="ui-category-list" style="padding-left: 0em;">
             {# TODO: scrollbar #}

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -61,13 +61,23 @@
                     No categories exist, please create one.
                 </span>
         {% endif %}
+    
+        <style>
+          {% for category in categories %}
+            .category-item-box {
+              color: var(--default-black);
+            }
+            [data-theme ="dark"] .category-item-box {
+              background: var(--btn-default-white);
+            }
+		  {% endfor %}
+        </style>
 
         <ul id="ui-category-list" style="padding-left: 0em;">
             {# TODO: scrollbar #}
             {% for category in categories %}
                 <li id="categorylistitem-{{ category.category_id }}" 
                     class="category-sortable category-item-box" 
-                    style="color: {{ category.color }};"
                     data-category_desc="{{ category.category_desc }}"
                     data-visible_date="{{ category.visible_date }}"
                     data-category_id="{{ category.category_id }}"

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -130,6 +130,14 @@
     margin-bottom: 60px;
 }
 
+.category-item-box {
+    color: var(--default-black);
+  }
+  
+  [data-theme ="dark"] .category-item-box {
+    background: var(--btn-default-white);
+  }
+
 /* stylelint-disable-next-line selector-id-pattern */
 #new_category_text {
     resize: none;

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -159,7 +159,7 @@
 }
 
 .category-button {
-    color: var(--standard-gray-black);
+    color: var(--default-black);
 }
 
 .edit-catergoty-name {

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -130,14 +130,6 @@
     margin-bottom: 60px;
 }
 
-.category-item-box {
-    color: var(--default-black);
-  }
-  
-  [data-theme ="dark"] .category-item-box {
-    background: var(--btn-default-white);
-  }
-
 /* stylelint-disable-next-line selector-id-pattern */
 #new_category_text {
     resize: none;
@@ -164,6 +156,11 @@
 
 .category-item-box {
     background-color: var(--standard-pale-gray);
+    color: var(--default-black);
+}
+
+[data-theme ="dark"] .category-item-box {
+    background: var(--btn-default-white);
 }
 
 .category-button {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1650,9 +1650,6 @@ function editCategory(category_id, category_desc, category_color, category_date,
                 // eslint-disable-next-line no-undef
                 removeMessagePopup('theid');
             }, 1000);
-            if (category_color !== null) {
-                $(`#categorylistitem-${category_id}`).css('color', category_color);
-            }
             if (category_desc !== null) {
                 $(`#categorylistitem-${category_id}`).find('.categorylistitem-desc span').text(category_desc);
             }


### PR DESCRIPTION
Currently, there is no dark mode implementation for customizing course categories in the discussion forum, causing it to stick out and making the delete icon invisible:
![main-category-lm](https://github.com/user-attachments/assets/0908902e-73ea-4472-9210-d920b517da96)
![main-category-dm](https://github.com/user-attachments/assets/fd2a77c6-776f-413f-99ce-f8ee9362f1e3)

Implemented dark mode for customizing course categories:
![pr-category-lm](https://github.com/user-attachments/assets/c3a144e7-a268-4322-af00-62cbcc8ff97b)
![pr-category-dm](https://github.com/user-attachments/assets/fbae5420-981b-4e15-8535-c27da9805424)

Notice that the text color no longer matches the category color. This is intentional as the contrast against the background would only be good in light mode.
