### PR TITLE
[Bugfix:Developer] Add Missing Down Migration to Late Days

### DIFF
--- a/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
+++ b/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
@@ -40,4 +40,8 @@ def down(config, database, semester, course):
     :param course: Code of course being migrated
     :type course: str
     """
+    # database.execute("""
+    #     ALTER TABLE electronic_gradeable
+    #     DROP CONSTRAINT late_days_positive
+    # """)
     pass

--- a/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
+++ b/migration/migrator/migrations/course/20240816095713_late_days_constraint.py
@@ -40,8 +40,8 @@ def down(config, database, semester, course):
     :param course: Code of course being migrated
     :type course: str
     """
-    # database.execute("""
-    #     ALTER TABLE electronic_gradeable
-    #     DROP CONSTRAINT late_days_positive
-    # """)
+    database.execute("""
+        ALTER TABLE electronic_gradeable
+        DROP CONSTRAINT late_days_positive
+    """)
     pass


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
close #11536 Cannot run down migration for late day constraint because of missing down migration

### What is the new behavior?
drop the constraint during down migration

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
