### PR TITLE
[Bugfix:InstructorUI] Syllabus Bucket Validation Checks

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -76,7 +76,7 @@ class AdminGradeableController extends AbstractController {
             'external_repo' => '',
             'using_subdirectory' => 'false',
             'vcs_subdirectory' => '',
-            'syllabus_bucket' => 'Homework',
+            'syllabus_bucket' => 'homework',
             'autograding_config_path' => ''
         ];
 
@@ -150,7 +150,7 @@ class AdminGradeableController extends AbstractController {
             $values['late_submission_allowed'] = $dates['late_submission_allowed'] ?? 'true';
             $values['late_days'] = $dates['late_days'] ?? 0;
         }
-        $values['syllabus_bucket'] = $_POST['syllabus_bucket'] ?? 'Homework';
+        $values['syllabus_bucket'] = $_POST['syllabus_bucket'] ?? 'homework';
         try {
             $build_result = $this->createGradeable($_POST['id'], $values);
             // Finally, redirect to the edit page
@@ -1119,6 +1119,10 @@ class AdminGradeableController extends AbstractController {
         ];
         foreach ($front_page_property_names as $prop) {
             $gradeable_create_data[$prop] = $details[$prop] ?? '';
+        }
+
+        if (!array_key_exists($details['syllabus_bucket'], self::syllabus_buckets)) {
+            throw new \InvalidArgumentException('Syllabus bucket must be one of the following: ' . implode(', ', self::syllabus_buckets));
         }
 
         $repo_name = '';

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1121,7 +1121,7 @@ class AdminGradeableController extends AbstractController {
             $gradeable_create_data[$prop] = $details[$prop] ?? '';
         }
 
-        if (!array_key_exists($details['syllabus_bucket'], self::syllabus_buckets)) {
+        if (!in_array($details['syllabus_bucket'], self::syllabus_buckets)) {
             throw new \InvalidArgumentException('Syllabus bucket must be one of the following: ' . implode(', ', self::syllabus_buckets));
         }
 
@@ -1484,6 +1484,10 @@ class AdminGradeableController extends AbstractController {
 
             if ($prop === 'grade_inquiry_per_component_allowed' && $post_val === true && !$gradeable->isGradeInquiryPerComponentAllowed()) {
                 $this->core->getQueries()->revertInquiryComponentId($gradeable);
+            }
+
+            if ($prop === 'syllabus_bucket' && !in_array($post_val, self::syllabus_buckets)) {
+                $errors['syllabus_bucket'] = 'Syllabus bucket must be one of the following: ' . implode(', ', self::syllabus_buckets);
             }
 
             // Try to set the property

--- a/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
@@ -48,7 +48,7 @@ describe('Tests cases revolving around gradeable access and submition', () => {
                         grade_inquiry_per_component_allowed: false,
                     },
                     ta_grading: false,
-                    syllabus_bucket: 'Homework',
+                    syllabus_bucket: 'homework',
                 },
                 headers: {
                     Authorization: key,
@@ -80,7 +80,7 @@ describe('Tests cases revolving around gradeable access and submition', () => {
                         grade_inquiry_per_component_allowed: false,
                     },
                     ta_grading: false,
-                    syllabus_bucket: 'Homework',
+                    syllabus_bucket: 'homework',
                 },
                 headers: {
                     Authorization: key,
@@ -110,7 +110,7 @@ describe('Tests cases revolving around gradeable access and submition', () => {
                         grade_inquiry_per_component_allowed: false,
                     },
                     ta_grading: false,
-                    syllabus_bucket: 'Homework',
+                    syllabus_bucket: 'homework',
                 },
                 headers: {
                     Authorization: key,

--- a/site/cypress/fixtures/json_ui.json
+++ b/site/cypress/fixtures/json_ui.json
@@ -16,7 +16,7 @@
   "grading_inquiry": true,
   "grade_inquiry_per_component_allowed": false,
   "ta_grading": true,
-  "syllabus_bucket": "Homework",
+  "syllabus_bucket": "homework",
   "dates": {
     "ta_view_start_date": "2024-1-11 23:59:59.00",
     "submission_open_date": "2024-1-15 23:59:59.00",

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -788,7 +788,7 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 3
+			count: 5
 			path: app/controllers/admin/AdminGradeableController.php
 
 		-


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

Instructors may assign incorrect or arbitrary values to the assignment syllabus bucket within the creation and/or update request, which is an issue as when they do provide an invalid syllabus bucket, the grades configuration page triggers a site error, causing Rainbow Grades to break. There is a clear error in the upload gradable JSON example, `/site/cypress/fixtures/json_ui.json`, where the syllabus bucket for homework is capitalized, but the backend expects the value to be lowercase.

![image](https://github.com/user-attachments/assets/5bdf671e-f79d-4ea9-98ae-0e658b307e8b)


### What is the new behavior?

The backend validates the syllabus bucket both during initial creation and when updates are made through the updates route. If an invalid syllabus bucket is detected, an error message is displayed to the instructor. Additionally, modifying the input value of the syllabus bucket on the front end, such as through DOM manipulation, triggers a save error.

![image](https://github.com/user-attachments/assets/4cb81f90-87a6-4b44-9ab8-8ca5815b860d)


### Other information?

To test, upload a gradable through the JSON feature (located at the top right of the construction page) using the existing example in site/cypress/fixtures/json_ui.json. This should trigger an error on the current branch while being successful on the main branch, which addresses the broken Grades Configuration page. This fixes the invalid syllabus bucket example introduced in #10100.
