### PR TITLE
[Bugfix:InstructorUI] Fix for stats page from robot

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1446,7 +1446,7 @@ class ForumController extends AbstractController {
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
 
             // user has only upducks and no posts
-            if(!isset($users[$user]["given_name"])) {
+            if (!isset($users[$user]["given_name"])) {
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["given_name"] = htmlspecialchars($u -> getDisplayedGivenName());

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1445,8 +1445,9 @@ class ForumController extends AbstractController {
             $user = $upducks[$i]["user_id"];
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
 
-            // user has only upducks and no posts
-            if (!isset($users[$user]["given_name"])) {
+            // user has only upducks and no posts, need to set some information
+            if (!isset($users[$user]["given_name"]) || !isset($users[$user]["family_name"]) || !isset($users[$user]["total_threads"]) || !isset($users[$user]["num_deleted_posts"])) {
+                $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["given_name"] = htmlspecialchars($u -> getDisplayedGivenName());

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1409,6 +1409,7 @@ class ForumController extends AbstractController {
         $output['expiration'] = $result["pinned_expiration"];
     }
 
+    // TODO: getPosts and getUpducks() are single use queries that should be used together to achieve the same effect
     #[Route("/courses/{_semester}/{_course}/forum/stats")]
     public function showStats() {
         $posts = $this->core->getQueries()->getPosts();
@@ -1443,6 +1444,15 @@ class ForumController extends AbstractController {
         for ($i = 0; $i < $num_users_with_upducks; $i++) {
             $user = $upducks[$i]["user_id"];
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
+
+            // user has only upducks and no posts
+            if(!isset($users[$user]["given_name"])) {
+                $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
+                $u = $this->core->getQueries()->getSubmittyUser($user);
+                $users[$user]["given_name"] = htmlspecialchars($u -> getDisplayedGivenName());
+                $users[$user]["family_name"] = htmlspecialchars($u -> getDisplayedFamilyName());
+                $users[$user]["total_threads"] = 0;
+            }
         }
         ksort($users);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'statPage', $users);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1443,10 +1443,8 @@ class ForumController extends AbstractController {
         }
         for ($i = 0; $i < $num_users_with_upducks; $i++) {
             $user = $upducks[$i]["user_id"];
-            $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
-
             // user has only upducks and no posts, need to set some information
-            if (!isset($users[$user]["given_name"]) || !isset($users[$user]["family_name"]) || !isset($users[$user]["total_threads"]) || !isset($users[$user]["num_deleted_posts"])) {
+            if (!isset($users[$user])) {
                 $u = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
                 $u = $this->core->getQueries()->getSubmittyUser($user);
@@ -1454,6 +1452,7 @@ class ForumController extends AbstractController {
                 $users[$user]["family_name"] = htmlspecialchars($u -> getDisplayedFamilyName());
                 $users[$user]["total_threads"] = 0;
             }
+            $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
         }
         ksort($users);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'statPage', $users);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1422,9 +1422,9 @@ class ForumController extends AbstractController {
             $content = $posts[$i]["content"];
             if (!isset($users[$user])) {
                 $users[$user] = [];
-                $u = $this->core->getQueries()->getSubmittyUser($user);
-                $users[$user]["given_name"] = htmlspecialchars($u -> getDisplayedGivenName());
-                $users[$user]["family_name"] = htmlspecialchars($u -> getDisplayedFamilyName());
+                $user_obj = $this->core->getQueries()->getSubmittyUser($user);
+                $users[$user]["given_name"] = htmlspecialchars($user_obj->getDisplayedGivenName());
+                $users[$user]["family_name"] = htmlspecialchars($user_obj->getDisplayedFamilyName());
                 $users[$user]["posts"] = [];
                 $users[$user]["id"] = [];
                 $users[$user]["timestamps"] = [];
@@ -1445,11 +1445,10 @@ class ForumController extends AbstractController {
             $user = $upducks[$i]["user_id"];
             // user has only upducks and no posts, need to set some information
             if (!isset($users[$user])) {
-                $u = $this->core->getQueries()->getSubmittyUser($user);
+                $user_obj = $this->core->getQueries()->getSubmittyUser($user);
                 $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
-                $u = $this->core->getQueries()->getSubmittyUser($user);
-                $users[$user]["given_name"] = htmlspecialchars($u -> getDisplayedGivenName());
-                $users[$user]["family_name"] = htmlspecialchars($u -> getDisplayedFamilyName());
+                $users[$user]["given_name"] = htmlspecialchars($user_obj->getDisplayedGivenName());
+                $users[$user]["family_name"] = htmlspecialchars($user_obj->getDisplayedFamilyName());
                 $users[$user]["total_threads"] = 0;
             }
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1409,7 +1409,7 @@ class ForumController extends AbstractController {
         $output['expiration'] = $result["pinned_expiration"];
     }
 
-    // TODO: getPosts and getUpducks() are single use queries that should be used together to achieve the same effect
+    // TODO: getPosts() and getUpducks() are single use queries that should be used together to achieve the same effect
     #[Route("/courses/{_semester}/{_course}/forum/stats")]
     public function showStats() {
         $posts = $this->core->getQueries()->getPosts();

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -30,7 +30,11 @@
                     <td>{{ user.details_total_threads }}</td>
                     <td>{{ user.num_deleted }}</td>
                     <td data-testid="upduck-stat" class="upduck_stat">{{ user.total_upducks }}</td>
-                    <td><button class="btn btn-default" data-action = "expand" data-posts="{{ user.posts }}" data-id="{{ user.ids }}" data-timestamps="{{ user.timestamps }}" data-thread_id="{{ user.thread_ids }}" data-thread_titles="{{ user.thread_titles }}">Expand</button></td>
+                    {% if user.posts %}
+                        <td><button class="btn btn-default" data-action = "expand" data-posts="{{ user.posts }}" data-id="{{ user.ids }}" data-timestamps="{{ user.timestamps }}" data-thread_id="{{ user.thread_ids }}" data-thread_titles="{{ user.thread_titles }}">Expand</button></td>
+                    {% else %}
+                        <td>No Posts</td>
+                    {% endif %}
                 </tr>
                 </tbody>
             {% endfor %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -1130,14 +1130,14 @@ class ForumThreadView extends AbstractView {
         foreach ($users as $user => $details) {
             $given_name = $details["given_name"];
             $family_name = $details["family_name"];
-            $post_count = count($details["posts"]);
-            $posts = json_encode($details["posts"]);
-            $ids = json_encode($details["id"]);
-            $timestamps = json_encode($details["timestamps"]);
-            $thread_ids = json_encode($details["thread_id"]);
-            $thread_titles = json_encode($details["thread_title"]);
-            $num_deleted = ($details["num_deleted_posts"]);
-            $total_upducks = ($details["total_upducks"]);
+            $post_count = isset($details["posts"]) ? count($details["posts"]) : 0;
+            $posts = isset($details["posts"]) ? json_encode($details["posts"]) : null;
+            $ids = isset($details["id"]) ? json_encode($details["id"]) : null;
+            $timestamps = isset($details["timestamp"]) ? json_encode($details["timestamps"]) : null;
+            $thread_ids = isset($details["thread_id"]) ? json_encode($details["thread_id"]) : null;
+            $thread_titles = isset($details["thread_title"]) ? json_encode($details["thread_title"]) : null;
+            $num_deleted = $details["num_deleted_posts"];
+            $total_upducks = $details["total_upducks"];
 
             $userData[] = [
                 "family_name" => $family_name,


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently, when a student upducks a post but have no posts themselves, the stats page crashes.

### What is the new behavior?
Temporarily set some fields and others to null, this entire page needs an overhaul as explain in the todo comment

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
