### PR TITLE
[UI/UX:InstructorUI] Released Grades Warning

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -556,6 +556,7 @@ class AdminGradeableController extends AbstractController {
             'allow_custom_marks' => $gradeable->getAllowCustomMarks(),
             'has_custom_marks' => $hasCustomMarks,
             'is_bulk_upload' => $gradeable->isBulkUpload(),
+            'rainbow_grades_summary' => $this->core->getConfig()->displayRainbowGradesSummary()
         ]);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -77,7 +77,7 @@
                             {% endif %}
                             {% if g_info.is_student_view != true and rainbow_grades_summary != true and info.section_id == "graded"  %}
                                 <span style="color: var(--danger-red); font-weight: bold; font-style: italic;">
-                                    NOTE: This gradeable is not visible to students as Rainbow Grades is not enabled.
+                                    NOTE: Scores are not visible to students as Rainbow Grades summaries are not enabled.
                                 </span>
                             {% endif %}
                         </div>

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -75,8 +75,10 @@
                                     <i class="fas fa-external-link-alt"></i>
                                 </a>
                             {% endif %}
-                            {% if g_info.is_student_view != true %}
-                                <span class="fa-solid fa-eye-slash" style="{{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }} padding-left: 5px;"></span>
+                            {% if g_info.is_student_view != true and rainbow_grades_summary != true and info.section_id == "graded"  %}
+                                <span style="color: var(--danger-red); font-weight: bold; font-style: italic;">
+                                    NOTE: This gradeable is not visible to students as Rainbow Grades is not enabled.
+                                </span>
                             {% endif %}
                         </div>
                     </div>

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -75,6 +75,9 @@
                                     <i class="fas fa-external-link-alt"></i>
                                 </a>
                             {% endif %}
+                            {% if g_info.is_student_view != true %}
+                                <span class="fa-solid fa-eye-slash" style="{{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }} padding-left: 5px;"></span>
+                            {% endif %}
                         </div>
                     </div>
                     {% for button in g_info.buttons %}

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -64,9 +64,7 @@
 
             <p style="max-width:600px; {{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }}" id="checkpoint-numeric-gradeables-message">
                 Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades.
-                {% if rainbow_grades_summary != true %}
-                    This gradeable is not visible to students as Rainbow Grades is not enabled.
-                {% endif %}
+                {{  rainbow_grades_summary != true ? 'Please visit the Course Settings page to enable Rainbow Grades Summary for students.' : '' }}
             </p>
         </div>
     </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -64,6 +64,9 @@
 
             <p style="max-width:600px; {{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }}" id="checkpoint-numeric-gradeables-message">
                 Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades.
+                {% if rainbow_grades_summary != true %}
+                    This gradeable is not visible to students as Rainbow Grades is not enabled.
+                {% endif %}
             </p>
         </div>
     </div>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -62,7 +62,7 @@
         
             <br />
 
-            <p style="max-width:600px;" id="checkpoint-numeric-gradeables-message">
+            <p style="max-width:600px; {{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }}" id="checkpoint-numeric-gradeables-message">
                 Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades.
             </p>
         </div>

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -196,7 +196,8 @@ class NavigationView extends AbstractView {
                     "edit_buttons" => $this->getAllEditButtons($gradeable),
                     "delete_buttons" => $this->getAllDeleteButtons($gradeable),
                     "buttons" => $buttons,
-                    "has_build_error" => $gradeable->anyBuildErrors()
+                    "has_build_error" => $gradeable->anyBuildErrors(),
+                    "is_student_view" => $gradeable->isStudentView()
                 ];
 
                 if (count($buttons) > $max_buttons) {
@@ -227,7 +228,8 @@ class NavigationView extends AbstractView {
             "seating_only_for_instructor" => $this->core->getConfig()->isSeatingOnlyForInstructor(),
             "gradeable_title" => $gradeable_title,
             "seating_config" => $seating_config,
-            "date_time_format" => $this->core->getConfig()->getDateTimeFormat()->getFormat('gradeable')
+            "date_time_format" => $this->core->getConfig()->getDateTimeFormat()->getFormat('gradeable'),
+            "rainbow_grades_summary" => $this->core->getConfig()->displayRainbowGradesSummary()
         ]);
     }
 

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -172,10 +172,12 @@ table#grader-history td {
 
 #checkpoint-numeric-gradeables-message {
     font-style: italic;
+    font-weight: bold;
 }
 
 #late-days-message {
     font-style: italic;
+    font-weight: bold;
 }
 
 #timezone-container {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Many instructors have reported confusion regarding checkpoints and numeric gradables not being available to students. The current message on the dates page lacks clarity and visibility. A clearer message should be displayed for instructors who have yet to enable Rainbows Grades summaries.

<img width="1378" alt="image" src="https://github.com/user-attachments/assets/79aef77c-05e8-4002-bf56-300bfe2d1483" />



### What is the new behavior?

A strong warning message displays for instructors who have yet to configure Rainbow Grade's summaries on the gradeables list and gradable dates configuration page, as shown below.

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/34300e63-d5b0-4f04-ae2b-1001496b38d7" />

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/946e0864-866b-4cd0-8d59-52b97e21fd2c" />



### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
