### PR TITLE
[Bugfix:System] Disable Client-Side WebSocket Broadcast

### DIFF
--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -120,8 +120,12 @@ class Server implements MessageComponentInterface {
      * Push a given message to all-but-sender connections on the same course and page
      */
     private function broadcast(ConnectionInterface $from, string $content, string $page_name): void {
-        if (!array_key_exists($page_name, $this->clients)) return; // Ignore broadcast requests for non-existent pages
-        if (!$this->isWebSocketClient($from)) return; // Ignore client-side broadcast requests
+        if (!array_key_exists($page_name, $this->clients)) {
+            return; // Ignore broadcast requests for non-existing pages
+        }
+        elseif (!$this->isWebSocketClient($from)) {
+            return; // Ignore client-side broadcast requests
+        }
 
         foreach ($this->clients[$page_name] as $client) {
             if ($client !== $from) {

--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -67,6 +67,19 @@ class Server implements MessageComponentInterface {
     }
 
     /**
+     * This function checks if a given connection is the PHP WebSocket client
+     * @param ConnectionInterface $conn
+     * @return bool
+     */
+    private function isWebSocketClient(ConnectionInterface $conn): bool {
+        $headers = $conn->httpRequest->getHeaders();
+        $user_agent = $headers['User-Agent'][0] ?? '';
+        $session_secret = $headers['Session-Secret'][0] ?? '';
+
+        return $user_agent === 'websocket-client-php' && $session_secret === $this->core->getConfig()->getSecretSession();
+    }
+
+    /**
      * This function checks if a given connection object is authenticated
      * It uses the submitty_session cookie in the header data to work
      * @param ConnectionInterface $conn
@@ -75,11 +88,10 @@ class Server implements MessageComponentInterface {
     private function checkAuth(ConnectionInterface $conn): bool {
         // The httpRequest property does exist on connections...
         $request = $conn->httpRequest;
-        $user_agent = $request->getHeader('User-Agent')[0] ?? '';
 
-        if ($user_agent === 'websocket-client-php') {
+        if ($this->isWebSocketClient($conn)) {
             $this->log("New connection {$conn->resourceId} --> websocket-client-php");
-            return $request->getHeader('Session-Secret')[0] === $this->core->getConfig()->getSecretSession();
+            return true;
         }
 
         $cookieString = $request->getHeader("cookie")[0] ?? '';
@@ -108,6 +120,9 @@ class Server implements MessageComponentInterface {
      * Push a given message to all-but-sender connections on the same course and page
      */
     private function broadcast(ConnectionInterface $from, string $content, string $page_name): void {
+        if (!array_key_exists($page_name, $this->clients)) return; // Ignore broadcast requests for non-existent pages
+        if (!$this->isWebSocketClient($from)) return; // Ignore client-side broadcast requests
+
         foreach ($this->clients[$page_name] as $client) {
             if ($client !== $from) {
                 $client->send($content);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Client-side broadcasting of WebSocket messages to others connected to the same page is allowed on the backend server, which is a security risk.


### What is the new behavior?

Any client-side attempts to broadcast a message to others through the backend WebSocket server will be ignored. An additional check for missing pages on a broadcast request has also been implemented to address the error below that I found within the logs (`sudo journalctl -u submitty_websocket_server -f`). All standard WebSocket behaviors (discussion forum, simple grading, etc.) should remain stable.

```bash
PHP Warning:  Undefined array key "s25-sample-discussion_forum" in /usr/local/submitty/site/app/libraries/socket/Server.php on line 131
```

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

This addresses the final issue on #10296. The updates will require the WebSocket server to restart with the proper changes, which can be done with the commands below.
```bash
$submitty_install_site
$sudo systemctl restart submitty_websocket_server
```

Within the discussion forum on the main branch, if you run the following command in the browser console, any connected clients will see a new thread appear on their end (limit to your current max post ID). On this branch, the request is ignored entirely.

```js
window.socketClient.send({"type": "new_thread","thread_id": 35,"page": "s25-sample-discussion_forum"});
```

