### PR TITLE
[Bugfix:Forum] Upduck Web Socket Bug Fix

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1471,7 +1471,7 @@ class ForumController extends AbstractController {
             return JsonResponse::getErrorResponse('Catch Fail in Query');
         }
 
-        $source = hash('sha3-224', $_POST['current_user']); 
+        $source = hash('sha3-224', $_POST['current_user']);
         $this->sendSocketMessage([
             'type' => 'edit_likes',
             'post_id' => $_POST['post_id'],

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1471,18 +1471,19 @@ class ForumController extends AbstractController {
             return JsonResponse::getErrorResponse('Catch Fail in Query');
         }
 
+        $source = hash('sha3-224', $_POST['current_user']); 
         $this->sendSocketMessage([
             'type' => 'edit_likes',
             'post_id' => $_POST['post_id'],
             'status' => $output['status'],
             'likesCount' => $output['likesCount'],
             'likesFromStaff' => $output['likesFromStaff'],
-            'source' => $_POST['current_user']
+            'source' => $source
         ]);
 
         return JsonResponse::getSuccessResponse([
             'status' => $output['status'], // 'like' or 'unlike'
-            'source' => $_POST['current_user'], // user who toggled the like
+            'source' => $source, // user who toggled the like
             'likesCount' => $output['likesCount'], // Total likes count
             'likesFromStaff' => $output['likesFromStaff'] // Likes from staff
         ]);

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1476,11 +1476,13 @@ class ForumController extends AbstractController {
             'post_id' => $_POST['post_id'],
             'status' => $output['status'],
             'likesCount' => $output['likesCount'],
-            'likesFromStaff' => $output['likesFromStaff']
+            'likesFromStaff' => $output['likesFromStaff'],
+            'source' => $_POST['current_user']
         ]);
 
         return JsonResponse::getSuccessResponse([
             'status' => $output['status'], // 'like' or 'unlike'
+            'source' => $_POST['current_user'], // user who toggled the like
             'likesCount' => $output['likesCount'], // Total likes count
             'likesFromStaff' => $output['likesFromStaff'] // Likes from staff
         ]);

--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -1,5 +1,5 @@
 {% set show_unresolve = false %}
-<data id="current-thread" value="{{ post_data[0].thread_id }}" data-user="{{ post_data[0].current_user }}"></data>
+<data id="current-thread" value="{{ post_data[0].thread_id }}"></data>
 <a class="skip-btn" href="#thread_box_link_{{thread_id != "" ? thread_id : first_post_id}}">Back to thread list</a>
 <a class="skip-btn key_to_click" href="#reply_box_{{post_box_id}}" onclick="$('#reply_box_{{post_box_id}}').focus(); return false;">Skip to reply</a>
 {% for post_d in  post_data %}

--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -1,5 +1,5 @@
 {% set show_unresolve = false %}
-<data id="current-thread" value="{{ post_data[0].thread_id }}"></data>
+<data id="current-thread" value="{{ post_data[0].thread_id }}" data-user="{{ post_data[0].current_user }}"></data>
 <a class="skip-btn" href="#thread_box_link_{{thread_id != "" ? thread_id : first_post_id}}">Back to thread list</a>
 <a class="skip-btn key_to_click" href="#reply_box_{{post_box_id}}" onclick="$('#reply_box_{{post_box_id}}').focus(); return false;">Skip to reply</a>
 {% for post_d in  post_data %}

--- a/site/app/templates/forum/ShowForumThreads.twig
+++ b/site/app/templates/forum/ShowForumThreads.twig
@@ -106,7 +106,7 @@
                     }
                 });
             </script>
-            <div id="posts_list" style="overflow-y: auto; height:100%;" class="col-9">
+            <div id="posts_list" style="overflow-y: auto; height:100%;" class="col-9" data-user="{{ generate_post_content.anon_user_id }}">
 
                 {% include "forum/GeneratePostList.twig" with {
                     "userGroup" : generate_post_content.userGroup,

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -410,6 +410,7 @@ class ForumThreadView extends AbstractView {
     public function generatePostList(Thread $thread, bool $includeReply, string $display_option, array $merge_thread_options, bool $render = true): array|string {
         $first = true;
         $post_data = [];
+        $anon_user_id = hash('sha3-224', $this->core->getUser()->getId());
         $csrf_token = $this->core->getCsrfToken();
         $GLOBALS['totalAttachments'] = 0;
         $user = $this->core->getUser();
@@ -481,6 +482,7 @@ class ForumThreadView extends AbstractView {
             "form_action_link" => $form_action_link,
             "merge_thread_content" => $merge_thread_content,
             "csrf_token" => $csrf_token,
+            "anon_user_id" => $anon_user_id,
             "activeThreadTitle" => "({$thread->getId()}) " . $thread->getTitle(),
             "post_box_id" => $post_box_id,
             "total_attachments" => $GLOBALS['totalAttachments'],

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -722,7 +722,8 @@ function initSocketClient() {
                     likesCount: msg.likesCount,
                     likesFromStaff: msg.likesFromStaff,
                     status: msg.status,
-                }, 'ws');
+                    source: msg.source,
+                });
                 break;
             default:
                 console.log('Undefined message received.');
@@ -1281,7 +1282,7 @@ function toggleLike(post_id, current_user) {
                 return;
             }
             else {
-                updateLikesDisplay(post_id, json.data, 'ajax');
+                updateLikesDisplay(post_id, json.data);
             }
         },
         error: function (err) {
@@ -1290,7 +1291,7 @@ function toggleLike(post_id, current_user) {
     });
 }
 
-function updateLikesDisplay(post_id, data, source) {
+function updateLikesDisplay(post_id, data) {
     const likes = data['likesCount'];
     const liked = data['status'] === 'like';
     const staffLiked = data['likesFromStaff'];
@@ -1300,9 +1301,10 @@ function updateLikesDisplay(post_id, data, source) {
 
     // eslint-disable-next-line no-useless-concat
     const likeIconSrc = document.getElementById(`likeIcon_${post_id}`);
+    const user = document.getElementById('current-thread').dataset.user;
     let likeIconSrcElement = likeIconSrc.src;
 
-    if (source === 'ajax') {
+    if (user === data['source']) {
         const from = liked ? 'light-mode-off-duck.svg' : 'on-duck-button.svg';
         const to = liked ? 'on-duck-button.svg' : 'light-mode-off-duck.svg';
         likeIconSrcElement = likeIconSrcElement.replace(from, to);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1301,7 +1301,7 @@ function updateLikesDisplay(post_id, data) {
 
     // eslint-disable-next-line no-useless-concat
     const likeIconSrc = document.getElementById(`likeIcon_${post_id}`);
-    const user = document.getElementById('current-thread').dataset.user;
+    const user = document.getElementById('posts_list').dataset.user;
     let likeIconSrcElement = likeIconSrc.src;
 
     if (user === data['source']) {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -722,7 +722,7 @@ function initSocketClient() {
                     likesCount: msg.likesCount,
                     likesFromStaff: msg.likesFromStaff,
                     status: msg.status,
-                });
+                }, 'ws');
                 break;
             default:
                 console.log('Undefined message received.');
@@ -1281,7 +1281,7 @@ function toggleLike(post_id, current_user) {
                 return;
             }
             else {
-                updateLikesDisplay(post_id, json.data);
+                updateLikesDisplay(post_id, json.data, 'ajax');
             }
         },
         error: function (err) {
@@ -1290,9 +1290,9 @@ function toggleLike(post_id, current_user) {
     });
 }
 
-function updateLikesDisplay(post_id, data) {
+function updateLikesDisplay(post_id, data, source) {
     const likes = data['likesCount'];
-    const liked = data['status'];
+    const liked = data['status'] === 'like';
     const staffLiked = data['likesFromStaff'];
 
     const likeCounterElement = document.getElementById(`likeCounter_${post_id}`);
@@ -1302,11 +1302,10 @@ function updateLikesDisplay(post_id, data) {
     const likeIconSrc = document.getElementById(`likeIcon_${post_id}`);
     let likeIconSrcElement = likeIconSrc.src;
 
-    if (liked === 'unlike') {
-        likeIconSrcElement = likeIconSrcElement.replace('on-duck-button.svg', 'light-mode-off-duck.svg');
-    }
-    else if (liked === 'like') {
-        likeIconSrcElement = likeIconSrcElement.replace('light-mode-off-duck.svg', 'on-duck-button.svg');
+    if (source === 'ajax') {
+        const from = liked ? 'light-mode-off-duck.svg' : 'on-duck-button.svg';
+        const to = liked ? 'on-duck-button.svg' : 'light-mode-off-duck.svg';
+        likeIconSrcElement = likeIconSrcElement.replace(from, to);
     }
 
     if (staffLiked > 0) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
If two people connect to the same thread page, and one toggles their like status, both pages will display the same status (like/unliked), regardless of the user's prior state.

### What is the new behavior?
The upduck status (like/unliked) will only update for the person submitting the request on the front end, but all users will still see other respective updates (like count, instructor-like status, etc.)

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Fixes #11371
