### PR TITLE
[UI/UX:Forum] Fix forum pin thread

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -197,7 +197,7 @@
             <label class="inline-block" for="Announcement">{{ announcement_text }}</label>
         {% endif %}
         {% if show_expiration is defined and show_expiration and core.getUser().accessFullGrading() %}
-            <div class = "pin-expiration-date">
+            <div id="pin-expiration-date">
               <label class="inline-block" for="expirationDate" style="margin-left: 15px;">{{ "Expiration Date" }}</label>
               <input type="date" class="date_picker" name="expirationDate" id="expirationDate" value="{{ expiration_placeholder is defined ? expiration_placeholder : '' }}"/>
             </div>
@@ -236,24 +236,24 @@
             if($(".thread-announcement-checkbox").prop("checked")){
                 $(".thread-announcement-checkbox").prop("checked", true);
                 $(".pinThread-checkbox").prop("checked", true);
-                $(".pin-expiration-date").show();
+                $("#pin-expiration-date").show();
                 $("#thread_status").val(0);
             } else {
                 $(".thread-announcement-checkbox").prop("checked", false);
                 $(".pinThread-checkbox").prop("checked", false);
-                $(".pin-expiration-date").hide();
+                $("#pin-expiration-date").hide();
             }
         });
 
         $(".pinThread-checkbox").click(function (){
             if($(".pinThread-checkbox").prop("checked")){
                 $(".pinThread-checkbox").prop("checked", true);
-                $(".pin-expiration-date").show();
+                $("#pin-expiration-date").show();
                 $("#thread_status").val(0);
             } else {
                 $(".pinThread-checkbox").prop("checked", false);
                 $(".thread-announcement-checkbox").prop("checked", false);
-                $(".pin-expiration-date").hide();
+                $("#pin-expiration-date").hide();
             }
         });
 

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -197,7 +197,7 @@
             <label class="inline-block" for="Announcement">{{ announcement_text }}</label>
         {% endif %}
         {% if show_expiration is defined and show_expiration and core.getUser().accessFullGrading() %}
-            <div class = "expiration inline-block" style="display: none;">
+            <div class = "pin-expiration-date">
               <label class="inline-block" for="expirationDate" style="margin-left: 15px;">{{ "Expiration Date" }}</label>
               <input type="date" class="date_picker" name="expirationDate" id="expirationDate" value="{{ expiration_placeholder is defined ? expiration_placeholder : '' }}"/>
             </div>
@@ -236,25 +236,24 @@
             if($(".thread-announcement-checkbox").prop("checked")){
                 $(".thread-announcement-checkbox").prop("checked", true);
                 $(".pinThread-checkbox").prop("checked", true);
-                $(".expiration").show();
+                $(".pin-expiration-date").show();
                 $("#thread_status").val(0);
             } else {
                 $(".thread-announcement-checkbox").prop("checked", false);
                 $(".pinThread-checkbox").prop("checked", false);
-                $(".expiration").hide();
+                $(".pin-expiration-date").hide();
             }
         });
 
         $(".pinThread-checkbox").click(function (){
-            $(".expiration").toggleClass("display-inline");
             if($(".pinThread-checkbox").prop("checked")){
                 $(".pinThread-checkbox").prop("checked", true);
-                $(".expiration").show();
+                $(".pin-expiration-date").show();
                 $("#thread_status").val(0);
             } else {
                 $(".pinThread-checkbox").prop("checked", false);
                 $(".thread-announcement-checkbox").prop("checked", false);
-                $(".expiration").hide();
+                $(".pin-expiration-date").hide();
             }
         });
 

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -187,14 +187,14 @@
         <div class="new-thread-settings-wrapper">
         {% if show_anon %}
             <input type="checkbox" class="thread-anon-checkbox" data-testid="thread-anon-checkbox" {% if anon_edit_post_id is defined and anon_edit_post_id %} id="{{ anon_edit_post_id }}"{% endif %} aria-label="Anonymous (to class)?" name="Anon" value="Anon" data-ays-ignore="true"/>
-            <label>Anonymous (to class)? </label>
+            <label>Anonymous (to class) </label>
         {% endif %}
         {% if show_announcement is defined and show_announcement and core.getUser().accessFullGrading() %}
-            {% set announcement_text = email_enabled ? "Pin Thread?(w/email & notification)" : "Pin Thread?(w/ notification)" %}
+            {% set announcement_text = email_enabled ? "Notify students (w/email)" : "Notify students" %}
+            <input type="checkbox" class="pinThread-checkbox" name="pinThread" id="pinThread" value="pinThread" data-ays-ignore="true"/>
+            <label class="inline-block" for="pinThread">{{ "Pin Thread" }}</label>
             <input type="checkbox" id="Announcement" class="thread-announcement-checkbox" name="Announcement" value="Announcement" data-ays-ignore="true"/>
             <label class="inline-block" for="Announcement">{{ announcement_text }}</label>
-            <input type="checkbox" class="pinThread-checkbox" name="pinThread" id="pinThread" value="pinThread" data-ays-ignore="true"/>
-            <label class="inline-block" for="pinThread">{{ "Pin Thread" }}</label>       
         {% endif %}
         {% if show_expiration is defined and show_expiration and core.getUser().accessFullGrading() %}
             <div class = "expiration inline-block" style="display: none;">
@@ -236,13 +236,11 @@
             if($(".thread-announcement-checkbox").prop("checked")){
                 $(".thread-announcement-checkbox").prop("checked", true);
                 $(".pinThread-checkbox").prop("checked", true);
-                $(".pinThread-checkbox").prop('disabled', true);
                 $(".expiration").show();
                 $("#thread_status").val(0);
             } else {
                 $(".thread-announcement-checkbox").prop("checked", false);
                 $(".pinThread-checkbox").prop("checked", false);
-                $(".pinThread-checkbox").prop('disabled', false);
                 $(".expiration").hide();
             }
         });
@@ -255,6 +253,7 @@
                 $("#thread_status").val(0);
             } else {
                 $(".pinThread-checkbox").prop("checked", false);
+                $(".thread-announcement-checkbox").prop("checked", false);
                 $(".expiration").hide();
             }
         });

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -595,6 +595,7 @@
     flex-wrap: nowrap;
     align-items: center;
     gap: 5px;
+    height: 30px;
 }
 
 .email-announcement-checkbox {

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -595,10 +595,10 @@
     flex-wrap: nowrap;
     align-items: center;
     gap: 5px;
-    height: 30px;
+    min-height: 30px;
 }
 
-.pin-expiration-date {
+#pin-expiration-date {
     display: flex;
     align-items: center;
     gap: 6px;

--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -598,9 +598,10 @@
     height: 30px;
 }
 
-.email-announcement-checkbox {
-    margin-right: 18px;
-    display: inline-block;
+.pin-expiration-date {
+    display: flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .thread-attachment-container,

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -908,7 +908,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 $('#thread_status').val(thread_status);
                 $('#lock_thread_date').val(thread_lock_date);
                 if (Date.parse(expiration) > new Date()) {
-                    $('.pin-expiration-date').show();
+                    $('#pin-expiration-date').show();
                 }
                 $('#expirationDate').val(json.expiration);
                 // Categories
@@ -926,7 +926,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             else {
                 $('#title').prop('disabled', true);
                 $('.edit_thread').hide();
-                $('.pin-expiration-date').hide();
+                $('#pin-expiration-date').hide();
                 $('#label_lock_thread').hide();
                 $('#thread_form').prop('ignore-cat', true);
                 $('#category-selection-container').hide();
@@ -2591,17 +2591,17 @@ function restoreCreateThreadFromLocal() {
         });
 
         // Optional fields
-        $('.pin-expiration-date').hide();
+        $('#pin-expiration-date').hide();
         if (Object.prototype.hasOwnProperty.call(data, 'lockDate')) {
             $('#lock_thread_date').val(data.lockDate);
         }
         if (data.isAnnouncement) {
             $('#Announcement').prop('checked', data.isAnnouncement);
-            $('.pin-expiration-date').show();
+            $('#pin-expiration-date').show();
         }
         if (data.pinThread) {
             $('#pinThread').prop('checked', data.pinThread);
-            $('.pin-expiration-date').show();
+            $('#pin-expiration-date').show();
         }
         if (Object.prototype.hasOwnProperty.call(data, 'expiration')) {
             $('#expirationDate').val(data.expiration);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -908,7 +908,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
                 $('#thread_status').val(thread_status);
                 $('#lock_thread_date').val(thread_lock_date);
                 if (Date.parse(expiration) > new Date()) {
-                    $('.expiration').show();
+                    $('.pin-expiration-date').show();
                 }
                 $('#expirationDate').val(json.expiration);
                 // Categories
@@ -926,7 +926,7 @@ function showEditPostForm(post_id, thread_id, shouldEditThread, render_markdown,
             else {
                 $('#title').prop('disabled', true);
                 $('.edit_thread').hide();
-                $('.expiration').hide();
+                $('.pin-expiration-date').hide();
                 $('#label_lock_thread').hide();
                 $('#thread_form').prop('ignore-cat', true);
                 $('#category-selection-container').hide();
@@ -2591,17 +2591,17 @@ function restoreCreateThreadFromLocal() {
         });
 
         // Optional fields
-        $('.expiration').hide();
+        $('.pin-expiration-date').hide();
         if (Object.prototype.hasOwnProperty.call(data, 'lockDate')) {
             $('#lock_thread_date').val(data.lockDate);
         }
         if (data.isAnnouncement) {
             $('#Announcement').prop('checked', data.isAnnouncement);
-            $('.expiration').show();
+            $('.pin-expiration-date').show();
         }
         if (data.pinThread) {
             $('#pinThread').prop('checked', data.pinThread);
-            $('.expiration').show();
+            $('.pin-expiration-date').show();
         }
         if (Object.prototype.hasOwnProperty.call(data, 'expiration')) {
             $('#expirationDate').val(data.expiration);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Current UI for pinning thread / notifying students on creation is slightly confusing
![1](https://github.com/user-attachments/assets/933a114d-9ec2-4323-ac03-c576ed1ad56d)

### What is the new behavior?
Changed checkbox logic to be more clear (pin thread is independent, but notify students needs pin thread to be selected)
Fixed styling for the expiration date div so it looks nicer and doesn't shift elements slightly
Fixed a bug where after reloading, the pin thread box could be unchecked while leaving the notify box on
![2](https://github.com/user-attachments/assets/3802f58f-c3e0-41d4-bcd2-7d290c13f7fc)
Closes #11169 

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Expiration date div has been renamed from "expiration" to "pin-expiration-date"
Tested on chrome browser
