### PR TITLE
[Bugfix:RainbowGrades] Set placeholders by expected items

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -272,11 +272,9 @@
                                                 </div>
                                                 <div id="gradeable-percents-div-{{ bucket }}-{{ gradeable["id"] }}">
                                                     <input type="text"
-                                                           {% set default_percent = ((1 / gradeables|length) * 100)|round(1, 'floor') %}
                                                            class="gradeable-custom-item-input"
                                                            aria-label="{{gradeable["title"]}} percent"
-                                                           placeholder="{{ default_percent }}"
-                                                           value="{{ gradeable["override_percent"] ? gradeable["percent"] : default_percent }}"
+                                                           value="{{ gradeable["override_percent"] ? gradeable["percent"] : "" }}"
                                                            id="percents-{{ gradeable["id"] }}"
                                                            onblur="ClampPercents(this); ClampPerGradeablePercents(this, '{{ bucket }}')">
                                                     <span>%</span>

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -1103,21 +1103,24 @@ $(document).ready(() => {
         });
     }
 
-    // Set placeholder values of Per Gradeable Percents to (1 / # items in bucket)
-    const bucketItemCounts = $('input[id^="config-count-{bucket}"]');
+    // Set placeholder values of Per Gradeable Percents to (1 / # items in bucket), with one decimal place
+    const bucketItemCounts = $('input[id^="config-count-"]');
     bucketItemCounts.each((index, bucketItemCountDOMElement) => {
-        const bucketItemCount = bucketItemCountDOMElement[0];
-        const bucket = bucketItemCount.id.match(/^config-count-(.+)$/)[1];
-        const gradeablePercentInputs = $(`div[id^="gradeable-percents-div-${bucket}"]`).children().first();
-        gradeablePercentInputs.each((index, gradeablePercentInputDOMElement) => {
-            const gradeablePercentInput = gradeablePercentInputDOMElement[0];
-            gradeablePercentInput.attr('placeholder', ((1 / bucketItemCount.val()) * 100)|round(1, 'floor'));
+        const bucketItemCount = $(bucketItemCountDOMElement);
+        const bucket = bucketItemCount.prop('id').match(/^config-count-(.+)$/)[1];
+        const gradeablePercents = $(`div[id^="gradeable-percents-div-${bucket}-"]`);
+        gradeablePercents.each((index, gradeablePercentDOMElement) => {
+            const gradeablePercentInput = $(gradeablePercentDOMElement).find('input');
+            gradeablePercentInput.attr('placeholder', Math.floor(1 / parseFloat(bucketItemCount.val()) * 1000) / 10);
+            if (gradeablePercentInput.val() === '') {
+                gradeablePercentInput.val(gradeablePercentInput.attr('placeholder'));
+            }
         });
         bucketItemCount.change((event) => {
             event.stopPropagation();
-            gradeablePercentInputs.each((index, gradeablePercentInputDOMElement) => {
-                const gradeablePercentInput = gradeablePercentInputDOMElement[0];
-                gradeablePercentInput.attr('placeholder', ((1 / bucketItemCount.val()) * 100)|round(1, 'floor'));
+            gradeablePercents.each((index, gradeablePercentDOMElement) => {
+                const gradeablePercentInput = $(gradeablePercentDOMElement).find('input');
+                gradeablePercentInput.attr('placeholder', Math.floor(1 / parseFloat(bucketItemCount.val()) * 1000) / 10);
             });
         });
     });

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -1116,8 +1116,7 @@ $(document).ready(() => {
                 gradeablePercentInput.val(gradeablePercentInput.attr('placeholder'));
             }
         });
-        bucketItemCount.change((event) => {
-            event.stopPropagation();
+        bucketItemCount.on('blur', () => {
             gradeablePercents.each((index, gradeablePercentDOMElement) => {
                 const gradeablePercentInput = $(gradeablePercentDOMElement).find('input');
                 gradeablePercentInput.attr('placeholder', Math.floor(1 / parseFloat(bucketItemCount.val()) * 1000) / 10);

--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -1103,6 +1103,25 @@ $(document).ready(() => {
         });
     }
 
+    // Set placeholder values of Per Gradeable Percents to (1 / # items in bucket)
+    const bucketItemCounts = $('input[id^="config-count-{bucket}"]');
+    bucketItemCounts.each((index, bucketItemCountDOMElement) => {
+        const bucketItemCount = bucketItemCountDOMElement[0];
+        const bucket = bucketItemCount.id.match(/^config-count-(.+)$/)[1];
+        const gradeablePercentInputs = $(`div[id^="gradeable-percents-div-${bucket}"]`).children().first();
+        gradeablePercentInputs.each((index, gradeablePercentInputDOMElement) => {
+            const gradeablePercentInput = gradeablePercentInputDOMElement[0];
+            gradeablePercentInput.attr('placeholder', ((1 / bucketItemCount.val()) * 100)|round(1, 'floor'));
+        });
+        bucketItemCount.change((event) => {
+            event.stopPropagation();
+            gradeablePercentInputs.each((index, gradeablePercentInputDOMElement) => {
+                const gradeablePercentInput = gradeablePercentInputDOMElement[0];
+                gradeablePercentInput.attr('placeholder', ((1 / bucketItemCount.val()) * 100)|round(1, 'floor'));
+            });
+        });
+    });
+
     // Per Gradeable Percents checked on-ready if at least one Per Gradeable Percents is checked
     const enablePerGradeablePercents = $('#enable-per-gradeable-percents');
     const perGradeablePercentsCheckboxes = $('input[id^="per-gradeable-percents-checkbox-"]');


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Placeholders for Per Gradeable Percents are assigned based on the number of items that are currently in the bucket.

### What is the new behavior?
Placeholders for Per Gradeable Percents are assigned based on the number of items that are expected.
https://github.com/user-attachments/assets/d5024686-9fad-4efa-9d74-864e71c7b765

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
