### PR TITLE
[Refactor:System] Fix websocket memory leak

### DIFF
--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -7822,11 +7822,6 @@ parameters:
 			path: app/libraries/socket/Server.php
 
 		-
-			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$clients type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/socket/Server.php
-
-		-
 			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$pages type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/libraries/socket/Server.php


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
As new users connect to the websocket server, every new page that gets connected to will be stored in memory until the server gets restarted which over time increases the memory usage of the websocket server process. 

### What is the new behavior?
When the last user of a page disconnects the page will also be removed from the clients array.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
