### PR TITLE
[Refactor:System] Remove unused user connection management

### DIFF
--- a/site/app/libraries/socket/Server.php
+++ b/site/app/libraries/socket/Server.php
@@ -25,10 +25,6 @@ class Server implements MessageComponentInterface {
     /** @var array */
     private $sessions = [];
 
-    // Holds the mapping between User_ID (key) and Connection objects (value)
-    /** @var array  */
-    private $users = [];
-
     // Holds the set of PHPWebSocket clients that are currently connected
     /** @var array<int, bool> */
     private $php_websocket_clients = [];
@@ -151,10 +147,6 @@ class Server implements MessageComponentInterface {
      */
     private function setSocketClient(string $user_id, ConnectionInterface $conn): void {
         $this->sessions[$conn->resourceId] = $user_id;
-        if (!isset($this->users[$user_id])) {
-            $this->users[$user_id] = [];
-        }
-        $this->users[$user_id][] = $conn;
     }
 
     /**
@@ -257,12 +249,6 @@ class Server implements MessageComponentInterface {
         $user_id = $this->getSocketUserID($conn);
         if ($user_id) {
             unset($this->sessions[$conn->resourceId]);
-            $this->users[$user_id] = array_filter($this->users[$user_id], function ($client) use ($conn) {
-                return $client !== $conn;
-            });
-            if (empty($this->users[$user_id])) {
-                unset($this->users[$user_id]);
-            }
         }
     }
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -7803,7 +7803,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
+			count: 1
 			path: app/libraries/socket/Server.php
 
 		-
@@ -7833,11 +7833,6 @@ parameters:
 
 		-
 			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$sessions type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/libraries/socket/Server.php
-
-		-
-			message: "#^Property app\\\\libraries\\\\socket\\\\Server\\:\\:\\$users type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/libraries/socket/Server.php
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There is no change in behavior with this PR, but a private member property was removed since it is no longer used. The original purpose was for preventing rebroadcasting discussion forum events to the user that caused them, but now that client-side websocket broadcast is disabled it has no purpose.