### PR TITLE
[Dependency] Upgrade Clang source to version 15.0.7

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -659,7 +659,7 @@ if [ ! -d "${clangsrc}" ]; then
     mkdir -p ${clangsrc}
 
     # clone the clang sources, circa Jan. 2023
-    git clone --depth 1 --recursive --branch llvmorg-15.0.7 https://github.com/llvm/llvm-project.git ${clangsrc}/source
+    git clone --depth 1 --branch llvmorg-13.0.1 https://github.com/llvm/llvm-project.git ${clangsrc}/source
     cp -R ${clangsrc}/source/llvm ${clangsrc}/llvm
     cp -R ${clangsrc}/source/clang ${clangsrc}/llvm/tools
     cp -R ${clangsrc}/source/clang-tools-extra ${clangsrc}/llvm/tools/clang/tools/

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -659,7 +659,7 @@ if [ ! -d "${clangsrc}" ]; then
     mkdir -p ${clangsrc}
 
     # clone the clang sources, circa Jan. 2023
-    git clone --depth 1 --branch llvmorg-15.0.7 https://github.com/llvm/llvm-project.git ${clangsrc}/source
+    git clone --depth 1 --recursive --branch llvmorg-15.0.7 https://github.com/llvm/llvm-project.git ${clangsrc}/source
     cp -R ${clangsrc}/source/llvm ${clangsrc}/llvm
     cp -R ${clangsrc}/source/clang ${clangsrc}/llvm/tools
     cp -R ${clangsrc}/source/clang-tools-extra ${clangsrc}/llvm/tools/clang/tools/

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -658,8 +658,8 @@ if [ ! -d "${clangsrc}" ]; then
 
     mkdir -p ${clangsrc}
 
-    # clone the clang sources, circa Nov. 2018
-    git clone --depth 1 --branch llvmorg-7.1.0 https://github.com/llvm/llvm-project.git ${clangsrc}/source
+    # clone the clang sources, circa Jan. 2023
+    git clone --depth 1 --branch llvmorg-15.0.7 https://github.com/llvm/llvm-project.git ${clangsrc}/source
     cp -R ${clangsrc}/source/llvm ${clangsrc}/llvm
     cp -R ${clangsrc}/source/clang ${clangsrc}/llvm/tools
     cp -R ${clangsrc}/source/clang-tools-extra ${clangsrc}/llvm/tools/clang/tools/

--- a/grading/Sample_CMakeLists.txt
+++ b/grading/Sample_CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.5)
 project (sample_assignment)
 
 ###################################################################################


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently the version of llvm that Submitty uses requires an older version of cmake than what is supplied by apt. The version of llvm was from Jan. 2018 (7.1.0) and there were no breaking changes until a version released in Feb. 2022 (13.0.1), so that is what was chosen here.  Sample_CMakeLists.txt also had to updated to move `cmake_minimum_required ` from 2.8 to 3.5 so that the newer version of cmake would accept it.

### Other information
- It is probably going to be a breaking change when cmake no longer supports 3.13.4, many of the directories will have to be moved around to support the new llvm directory structure.
- This PR will not pass the ansible install test since until #11585 is merged ansible will use the version of llvm specified by main.