### PR TITLE
[Bugfix:Submission] Prevent Grade Inquiry Text Across Pages

### DIFF
--- a/site/app/templates/submission/grade_inquiry/Discussion.twig
+++ b/site/app/templates/submission/grade_inquiry/Discussion.twig
@@ -124,3 +124,8 @@
         {% endfor %}
     </div>
 {% endif %}
+<script>
+    window.course = "{{ course }}";
+    window.term = "{{ term }}";
+    window.gradeable_id = "{{ g_id }}";
+</script>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -398,8 +398,9 @@
 
     // set for all but vcs as it has no box submission
     window.num_submission_boxes = {{ is_vcs ? 0 : part_names | length }};
-    window.gradeable_id = "{{ gradeable_id }}";
     window.course = "{{ course }}";
+    window.term = "{{ term }}";
+    window.gradeable_id = "{{ gradeable_id }}";
 
     function makeSubmission(user_id, highest_version, is_pdf, path, git_user_id, git_repo_id, merge_previous=false, clobber=false) {
         // submit the selected pdf

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -399,7 +399,7 @@
     // set for all but vcs as it has no box submission
     window.num_submission_boxes = {{ is_vcs ? 0 : part_names | length }};
     window.gradeable_id = "{{ gradeable_id }}";
-    window.course_id = "{{ course_path|split('/')|slice(5,6)|join('-') }}";
+    window.course = "{{ course }}";
 
     function makeSubmission(user_id, highest_version, is_pdf, path, git_user_id, git_repo_id, merge_previous=false, clobber=false) {
         // submit the selected pdf

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -399,6 +399,7 @@
     // set for all but vcs as it has no box submission
     window.num_submission_boxes = {{ is_vcs ? 0 : part_names | length }};
     window.gradeable_id = "{{ gradeable_id }}";
+    window.course_id = "{{ course_path|split('/')|slice(5,6)|join('-') }}";
 
     function makeSubmission(user_id, highest_version, is_pdf, path, git_user_id, git_repo_id, merge_previous=false, clobber=false) {
         // submit the selected pdf

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -560,7 +560,8 @@ class HomeworkView extends AbstractView {
         $recent_version_url = $graded_gradeable ? $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : null;
         $numberUtils = new NumberUtils();
         return $output . $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
-            'course' => $this->core->getConfig()->getTerm() . '-' . $this->core->getConfig()->getCourse(),
+            'course' => $this->core->getConfig()->getCourse(),
+            'term' => $this->core->getConfig()->getTerm(),
             'using_subdirectory' => $gradeable->isUsingSubdirectory(),
             'vcs_subdirectory' => $gradeable->getVcsSubdirectory(),
             'vcs_partial_path' => $vcs_partial_path ,
@@ -1412,6 +1413,8 @@ class HomeworkView extends AbstractView {
         $components_twig_array[] = ['id' => 0, 'title' => 'All'];
 
         return $this->core->getOutput()->renderTwigTemplate('submission/grade_inquiry/Discussion.twig', [
+            'course' => $this->core->getConfig()->getCourse(),
+            'term' => $this->core->getConfig()->getTerm(),
             'grade_inquiries' => $grade_inquiries_twig_array,
             'grade_inquiry_url' => $grade_inquiry_url,
             'change_request_status_url' => $change_request_status_url,

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -560,7 +560,7 @@ class HomeworkView extends AbstractView {
         $recent_version_url = $graded_gradeable ? $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : null;
         $numberUtils = new NumberUtils();
         return $output . $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
-            'course_path' => $this->core->getConfig()->getCoursePath(),
+            'course' => $this->core->getConfig()->getTerm() . '-' . $this->core->getConfig()->getCourse(),
             'using_subdirectory' => $gradeable->isUsingSubdirectory(),
             'vcs_subdirectory' => $gradeable->getVcsSubdirectory(),
             'vcs_partial_path' => $vcs_partial_path ,

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -560,6 +560,7 @@ class HomeworkView extends AbstractView {
         $recent_version_url = $graded_gradeable ? $this->core->buildCourseUrl(['gradeable', $gradeable->getId()]) . '/' . $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() : null;
         $numberUtils = new NumberUtils();
         return $output . $this->core->getOutput()->renderTwigTemplate('submission/homework/SubmitBox.twig', [
+            'course_path' => $this->core->getConfig()->getCoursePath(),
             'using_subdirectory' => $gradeable->isUsingSubdirectory(),
             'vcs_subdirectory' => $gradeable->getVcsSubdirectory(),
             'vcs_partial_path' => $vcs_partial_path ,

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -1,9 +1,15 @@
 /* global buildCourseUrl, WebSocketClient */
 /* exported loadDraft, initGradingInquirySocketClient, onComponentTabClicked, onGradeInquirySubmitClicked, onReady, onReplyTextAreaKeyUp */
 
+function getDraftContentKeyPrefix() {
+    const gradeable_id = window.gradeable_id;
+    const course = window.location.pathname.split('/').slice(2, 4).join('-');
+
+    return `${course}-draftContent-${gradeable_id}-`;
+}
+
 function loadDraft() {
-    const gradeableId = $('#gradeable_id').val();
-    const draftContentKeyPrefix = `draftContent-${gradeableId}-`;
+    const draftContentKeyPrefix = getDraftContentKeyPrefix();
     const draftContentRaw = localStorage.getItem(draftContentKeyPrefix);
     const draftContent = draftContentRaw ? JSON.parse(draftContentRaw) : {};
 
@@ -69,9 +75,7 @@ function onComponentTabClicked(tab) {
 
 function onReplyTextAreaKeyUp(textarea) {
     const reply_text_area = $(textarea);
-    const gradeableId = $('#gradeable_id').val();
     const componentId = reply_text_area.closest('.reply-text-form').find('#gc_id').val();
-    const draftContentKeyPrefix = `draftContent-${gradeableId}-`;
     const uniqueKey = `reply-text-area-${componentId}`;
 
     const must_have_text_buttons = $('.gi-submit:not(.gi-ignore-disabled)');
@@ -79,6 +83,7 @@ function onReplyTextAreaKeyUp(textarea) {
     const must_be_empty_buttons = $('.gi-submit-empty:not(.gi-ignore-disabled)');
     must_be_empty_buttons.prop('disabled', reply_text_area.val() !== '');
 
+    const draftContentKeyPrefix = getDraftContentKeyPrefix();
     const draftContentRaw = localStorage.getItem(draftContentKeyPrefix);
     const draftContent = draftContentRaw ? JSON.parse(draftContentRaw) : {};
 
@@ -109,6 +114,7 @@ function onGradeInquirySubmitClicked(button) {
 
     // if grader clicks Close Grade Inquiry button with text in text area we want to confirm that they want to close the grade inquiry
     // and ignore their response
+    const draftContentKeyPrefix = getDraftContentKeyPrefix();
     const text_area = $(`#reply-text-area-${component_id}`);
     const submit_button_id = button_clicked.attr('id');
     if (submit_button_id && submit_button_id === 'grading-close') {
@@ -118,6 +124,7 @@ function onGradeInquirySubmitClicked(button) {
             }
             else {
                 text_area.val('');
+                localStorage.removeItem(draftContentKeyPrefix);
             }
         }
     }
@@ -140,9 +147,8 @@ function onGradeInquirySubmitClicked(button) {
                 const json = JSON.parse(response);
 
                 if (json['status'] === 'success') {
-                    if (json['data']['type'] === 'new_post') {
-                        text_area.val('');
-                    }
+                    text_area.val('');
+                    localStorage.removeItem(draftContentKeyPrefix);
                 }
                 else {
                     alert(json['message']);

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -1,16 +1,14 @@
 /* global buildCourseUrl, WebSocketClient */
 /* exported loadDraft, initGradingInquirySocketClient, onComponentTabClicked, onGradeInquirySubmitClicked, onReady, onReplyTextAreaKeyUp */
 
-function getDraftContentKeyPrefix() {
-    const course = window.course;
-    const gradeable_id = window.gradeable_id;
+function getLocalStorageKey(key) {
+    const { course, term, gradeable_id } = window;
 
-    return `${course}-draftContent-${gradeable_id}-`;
+    return `${course}-${term}-${gradeable_id}-${key}`;
 }
 
 function loadDraft() {
-    const draftContentKeyPrefix = getDraftContentKeyPrefix();
-    const draftContentRaw = localStorage.getItem(draftContentKeyPrefix);
+    const draftContentRaw = localStorage.getItem(getLocalStorageKey('draftContent'));
     const draftContent = draftContentRaw ? JSON.parse(draftContentRaw) : {};
 
     const elements = $('.markdown-textarea.fill-available');
@@ -27,11 +25,12 @@ function loadDraft() {
 
 function onReady() {
     // open last opened grade inquiry or open first component with grade inquiry
-    const component_selector = localStorage.getItem('selected_tab');
+    const selectedTabKey = getLocalStorageKey('selectedTab');
+    const component_selector = localStorage.getItem(selectedTabKey);
     const first_unresolved_component = $('.component-unresolved').first();
     if (component_selector !== null) {
         $(component_selector).click();
-        localStorage.removeItem('selected_tab');
+        localStorage.removeItem(selectedTabKey);
     }
     else if (first_unresolved_component.length) {
         first_unresolved_component.click();
@@ -83,12 +82,12 @@ function onReplyTextAreaKeyUp(textarea) {
     const must_be_empty_buttons = $('.gi-submit-empty:not(.gi-ignore-disabled)');
     must_be_empty_buttons.prop('disabled', reply_text_area.val() !== '');
 
-    const draftContentKeyPrefix = getDraftContentKeyPrefix();
-    const draftContentRaw = localStorage.getItem(draftContentKeyPrefix);
+    const draftContentKey = getLocalStorageKey('draftContent');
+    const draftContentRaw = localStorage.getItem(draftContentKey);
     const draftContent = draftContentRaw ? JSON.parse(draftContentRaw) : {};
 
     draftContent[uniqueKey] = reply_text_area.val();
-    localStorage.setItem(draftContentKeyPrefix, JSON.stringify(draftContent));
+    localStorage.setItem(draftContentKey, JSON.stringify(draftContent));
 
     if (reply_text_area.val() === '') {
         $('.gi-show-empty').show();
@@ -106,7 +105,7 @@ function onGradeInquirySubmitClicked(button) {
     const button_clicked = $(button);
     const component_selected = $('.btn-selected');
     const component_id = component_selected.length ? component_selected.data('component_id') : 0;
-    localStorage.setItem('selected_tab', `.component-${component_id}`);
+    localStorage.setItem(getLocalStorageKey('selectedTab'), `.component-${component_id}`);
     const form = $(`#reply-text-form-${component_id}`);
     if (form.data('submitted') === true) {
         return;
@@ -114,7 +113,7 @@ function onGradeInquirySubmitClicked(button) {
 
     // if grader clicks Close Grade Inquiry button with text in text area we want to confirm that they want to close the grade inquiry
     // and ignore their response
-    const draftContentKeyPrefix = getDraftContentKeyPrefix();
+    const draftContentKey = getLocalStorageKey('draftContent');
     const text_area = $(`#reply-text-area-${component_id}`);
     const submit_button_id = button_clicked.attr('id');
     if (submit_button_id && submit_button_id === 'grading-close') {
@@ -124,7 +123,7 @@ function onGradeInquirySubmitClicked(button) {
             }
             else {
                 text_area.val('');
-                localStorage.removeItem(draftContentKeyPrefix);
+                localStorage.removeItem(draftContentKey);
             }
         }
     }
@@ -148,7 +147,7 @@ function onGradeInquirySubmitClicked(button) {
 
                 if (json['status'] === 'success') {
                     text_area.val('');
-                    localStorage.removeItem(draftContentKeyPrefix);
+                    localStorage.removeItem(draftContentKey);
                 }
                 else {
                     alert(json['message']);
@@ -241,7 +240,7 @@ function newDiscussionRender(discussion) {
     // save the selected component before updating regrade discussion
     const component_selected = $('.btn-selected');
     const component_id = component_selected.length ? component_selected.data('component_id') : 0;
-    localStorage.setItem('selected_tab', `.component-${component_id}`);
+    localStorage.setItem(getLocalStorageKey('selectedTab'), `.component-${component_id}`);
 
     // TA (access grading)
     if ($('#gradeInquiryBoxSection').length === 0) {

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -2,10 +2,10 @@
 /* exported loadDraft, initGradingInquirySocketClient, onComponentTabClicked, onGradeInquirySubmitClicked, onReady, onReplyTextAreaKeyUp */
 
 function getDraftContentKeyPrefix() {
+    const course_id = window.course_id;
     const gradeable_id = window.gradeable_id;
-    const course = window.location.pathname.split('/').slice(2, 4).join('-');
 
-    return `${course}-draftContent-${gradeable_id}-`;
+    return `${course_id}-draftContent-${gradeable_id}-`;
 }
 
 function loadDraft() {

--- a/site/public/js/grade-inquiry.js
+++ b/site/public/js/grade-inquiry.js
@@ -2,10 +2,10 @@
 /* exported loadDraft, initGradingInquirySocketClient, onComponentTabClicked, onGradeInquirySubmitClicked, onReady, onReplyTextAreaKeyUp */
 
 function getDraftContentKeyPrefix() {
-    const course_id = window.course_id;
+    const course = window.course;
     const gradeable_id = window.gradeable_id;
 
-    return `${course_id}-draftContent-${gradeable_id}-`;
+    return `${course}-draftContent-${gradeable_id}-`;
 }
 
 function loadDraft() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When a user types into the text area within the grade inquiry section, the key is based on a component with the ID tied to the current gradable, which doesn't exist. Thus, the key is the same for all pages.

![image](https://github.com/user-attachments/assets/d71733e9-8474-4541-b60b-802c1210110d)


### What is the new behavior?

All draft content keys related to grade inquiry text areas are tied to the specific course and are gradable. This local storage instance is also cleared now for successful submissions.

![image](https://github.com/user-attachments/assets/3faa4fe4-6f71-40f8-86e8-ffceb3090586)


### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Testing requires a gradable to have an open grade inquiry window, and any unsaved changes should not propagate to other locations now.

Fixes #11230
