### PR TITLE
[Bugfix:] Regrade correct selected version

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1000,7 +1000,7 @@ class SubmissionController extends AbstractController {
                     $active_version = $i;
                 }
                 else {
-                    $active_version = $g->getAutoGradedGradeable()->getActiveVersion();
+                    $active_version = intval($_POST['version_to_regrade'] ?? $g->getAutoGradedGradeable()->getActiveVersion());
                 }
                 //create file name
                 $queue_file_helper = [$this->core->getConfig()->getTerm(), $this->core->getConfig()->getCourse(),

--- a/site/ts/twig/grading/electronic/AutogradingPanel.ts
+++ b/site/ts/twig/grading/electronic/AutogradingPanel.ts
@@ -59,10 +59,14 @@ $(() => {
     $('#autograding-results-regrade-all').on('click', () => {
         regrade(0, HIGHEST_VERSION, GRADEABLE_ID, USER_ID);
     });
-    $('.autograding-panel-regrade').on('click', () => {
-        const idValue = $('.autograding-panel-regrade').attr('id');
+    $('.autograding-panel-regrade').on('click', function () {
+        const idValue = $(this).attr('id');
         if (idValue) {
-            autogradingRegradeVersion(parseInt(idValue));
+            const match = idValue.match(/autograding-results-regrade-(\d+)/);
+            if (match) {
+                const version = parseInt(match[1]);
+                autogradingRegradeVersion(version);
+            }
         }
     });
 });


### PR DESCRIPTION
fixes #11477 

### What is the current behavior?
When clicking one of the non-active version of submission, autograding still runs on the actives one.
![image](https://github.com/user-attachments/assets/8e26a278-d4ca-43fd-a1a2-9bc2c67b0d01)

### What is the new behavior?
The grading_done.py monitors it correctly grades the selected version instead of the active one.
<img width="449" alt="image" src="https://github.com/user-attachments/assets/20067039-1bbe-42d2-ae88-5623d34caf93" />

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
