### PR TITLE
[UI/UX:InstructorUI] Hide Numeric/Checkpoint Message

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -61,14 +61,15 @@
             <label for="date_released">Grades Released Date (grades will be visible to students)</label>
         
             <br />
-
+            
+            {% if not gradeable.isStudentView() %}
             <p style="max-width:600px; {{ rainbow_grades_summary != true ? 'color: var(--danger-red);' : '' }}" id="checkpoint-numeric-gradeables-message">
                 Note: Released Grades for checkpoint and numeric gradeables are available to students only through Rainbow Grades.
                 {{  rainbow_grades_summary != true ? 'Please visit the Course Settings page to enable Rainbow Grades Summary for students.' : '' }}
             </p>
+            {% endif %}
         </div>
     </div>
-    <br />
 
     <div class="electronic_file electronic_file_dates">
         <div class="grade_inquiry_date" {{ grade_inquiry_allowed != true ? 'hidden' : '' }}>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The released checkpoint and numeric gradeables message reminding instructors that scores are strictly available on Rainbow Grades is displayed on all assignments, which can be confusing.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/0bf12f40-c8c0-4a9c-939b-44c0dc7cee49" />


### What is the new behavior?

The released checkpoint and numeric gradeables message are now strictly displayed for those specific assignment types, as shown below.

Checkpoint/numeric gradeables:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/5b3b5bf5-8ab5-4f97-95ce-e5ddef998265" />


All other gradeables:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/1e379ca1-fc86-4c10-a0a0-70c5cd855068" />



### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
