### PR TITLE
[UI/UX:Forum] Dark mode for cat-buttons

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1131,13 +1131,6 @@ div.full-height {
     opacity: 0.8;
 }
 
-[data-theme="dark"] {
-    .cat-buttons {
-        color: var(--btn-default-text) !important;
-        background-color: var(--btn-default-white) !important;
-    }
-}
-
 .peer-feedback-negative-unselected {
     margin-top: 5px;
     background-color: var(--default-white);

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1131,6 +1131,13 @@ div.full-height {
     opacity: 0.8;
 }
 
+[data-theme="dark"] {
+    .cat-buttons {
+        color: var(--btn-default-text) !important;
+        background-color: var(--btn-default-white) !important;
+    }
+}
+
 .peer-feedback-negative-unselected {
     margin-top: 5px;
     background-color: var(--default-white);

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1755,14 +1755,21 @@ function refreshCategories() {
 
 function changeColorClass() {
     const color = $(this).data('color');
+    const isDarkMode = $('[data-theme="dark"]').length > 0;
     $(this).css('border-color', color);
     if ($(this).hasClass('btn-selected')) {
         $(this).css('background-color', color);
         $(this).css('color', 'white');
     }
     else {
-        $(this).css('background-color', 'white');
-        $(this).css('color', color);
+        if (isDarkMode) {
+            $(this).css('background-color', 'var(--btn-default-white)');
+            $(this).css('color', 'var(--btn-default-text)');
+        }
+        else {
+            $(this).css('background-color', 'white');
+            $(this).css('color', color);
+        }
     }
 }
 


### PR DESCRIPTION
### What is the current behavior?
Currently there is no dark mode for cat-buttons in places such as create thread.
![image](https://github.com/user-attachments/assets/fdc3ff6b-20f2-4731-84ff-726207469788)

### What is the new behavior?
Modify js to apply inline css for dark mode as well.

https://github.com/user-attachments/assets/b69ff6ec-18f7-4263-9b4a-558b1a660f6f


