### PR TITLE
[Dependency] Switch to maintained markdown provider

### DIFF
--- a/site/app/templates/misc/Markdown.twig
+++ b/site/app/templates/misc/Markdown.twig
@@ -1,4 +1,4 @@
 <div
   class="markdown {{ class is defined ? class }}"
   style="{{ style is defined ? style : '' }}"
->{{ content | markdown }}</div>
+>{{ content | markdown_to_html }}</div>

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -174,7 +174,7 @@
                                            disabled = "disabled"
                                        {% endif %}
                                 />
-                                {{ cell.choices[idx].description | markdown }}
+                                {{ cell.choices[idx].description | markdown_to_html }}
                             </label>
                         {% endfor %}
                     {% else %}

--- a/site/composer.json
+++ b/site/composer.json
@@ -20,7 +20,6 @@
     }
   },
   "require": {
-    "aptoma/twig-markdown": "3.4.1",
     "browscap/browscap-php": "7.5.0",
     "cboden/ratchet": "0.4.4",
     "doctrine/annotations": "1.14.3",
@@ -38,6 +37,7 @@
     "symfony/http-foundation": "6.4.14",
     "symfony/routing": "6.1.11",
     "textalk/websocket": "1.6.3",
+    "twig/markdown-extra": "^3.20",
     "twig/twig": "3.20.0"
   },
   "require-dev": {

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,71 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a951dbeeeb945f07b2acc0a9dd59323",
+    "content-hash": "c96db8265a9e47cd551727ef194d6f4b",
     "packages": [
-        {
-            "name": "aptoma/twig-markdown",
-            "version": "3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aptoma/twig-markdown.git",
-                "reference": "849248b26f0079f380e6559017e69114c57ef52a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aptoma/twig-markdown/zipball/849248b26f0079f380e6559017e69114c57ef52a",
-                "reference": "849248b26f0079f380e6559017e69114c57ef52a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "twig/twig": "^2.7.0|^3.0"
-            },
-            "require-dev": {
-                "erusev/parsedown": "^1.6",
-                "guzzlehttp/guzzle": "^7.2",
-                "http-interop/http-factory-guzzle": "^1.0",
-                "knplabs/github-api": "~3.0",
-                "league/commonmark": "~0.5",
-                "michelf/php-markdown": "~1",
-                "php": "^7.2.5|^8.0",
-                "phpunit/phpunit": "~6.0|~5.0|~8.0"
-            },
-            "suggest": {
-                "knplabs/github-api": "Needed for using GitHub's Markdown engine provided through their API.",
-                "michelf/php-markdown": "Original Markdown engine with MarkdownExtra."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Aptoma": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gunnar Lium",
-                    "email": "gunnar@aptoma.com"
-                },
-                {
-                    "name": "Joris Berthelot",
-                    "email": "joris@berthelot.tel"
-                }
-            ],
-            "description": "Twig extension to work with Markdown content",
-            "keywords": [
-                "markdown",
-                "twig"
-            ],
-            "support": {
-                "issues": "https://github.com/aptoma/twig-markdown/issues",
-                "source": "https://github.com/aptoma/twig-markdown/tree/3.4.1"
-            },
-            "time": "2021-12-14T11:12:21+00:00"
-        },
         {
             "name": "brick/math",
             "version": "0.12.1",
@@ -5349,6 +5286,78 @@
             "time": "2022-11-07T18:59:33+00:00"
         },
         {
+            "name": "twig/markdown-extra",
+            "version": "v3.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/markdown-extra.git",
+                "reference": "f4616e1dd375209dacf6026f846e6b537d036ce4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/f4616e1dd375209dacf6026f846e6b537d036ce4",
+                "reference": "f4616e1dd375209dacf6026f846e6b537d036ce4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "twig/twig": "^3.13|^4.0"
+            },
+            "require-dev": {
+                "erusev/parsedown": "dev-master as 1.x-dev",
+                "league/commonmark": "^1.0|^2.0",
+                "league/html-to-markdown": "^4.8|^5.0",
+                "michelf/php-markdown": "^1.8|^2.0",
+                "symfony/phpunit-bridge": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Twig\\Extra\\Markdown\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Markdown",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "html",
+                "markdown",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/markdown-extra/tree/v3.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-31T20:45:36+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v3.20.0",
             "source": {
@@ -7850,13 +7859,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)

* [ ] Documentation has been updated/added if relevant

* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

The previous Markdown handling relied on https://github.com/aptoma/twig-markdown extension, which is no longer maintained.

### What is the new behavior?

Updated to use https://github.com/twigphp/markdown-extra for improved Markdown processing in output and templates.

### Other information?

No breaking changes introduced.