### PR TITLE
[Bugfix:Forum] Preserve thread highlight and scroll after reload

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1258,6 +1258,8 @@ function modifyThreadList(currentThreadId, currentCategoriesId, course, loadFirs
             Cookies.remove('forum_thread_status', { path: '/' });
         },
     });
+
+    highlightAndScrollToCurrentThread();
 }
 
 function toggleLike(post_id, current_user) {
@@ -2135,6 +2137,8 @@ function loadThreadHandler() {
             },
         });
     });
+    
+    highlightAndScrollToCurrentThread();
 }
 
 function showAttachmentsOnload() {
@@ -2730,4 +2734,17 @@ function showUpduckUsers(post_id, csrf_token) {
             }
         },
     });
+}
+
+// Highlights and scrolls to the current thread if it exists.
+function highlightAndScrollToCurrentThread() {
+    const activeThreadId = $('#current-thread').val();
+    if (activeThreadId) {
+        const activeThread = $(`[data-thread_id='${activeThreadId}'] .thread_box`);
+        if (activeThread.length) {
+            $('.thread_box').removeClass('active');
+            activeThread.addClass('active');
+            scrollThreadListTo(activeThread[0]);
+        }
+    }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes #11590 

Currently, when viewing a forum thread, refreshing the page or applying thread filters would lose the highlight and scroll position of the selected thread (especially if the selected thread is an older thread, and below the top ~20 threads). The user would have to manually find and reselect their thread, making it difficult for users to review posts.

### What is the new behavior?

- The selected thread remains highlighted after page reloads.
- The page scrolls the selected thread into view automatically after reloading or filtering.
- Improves user experience by maintaining thread context.


https://github.com/user-attachments/assets/125dddc5-11e9-4256-a1e4-28119cd10c39
https://github.com/user-attachments/assets/bf97ca0c-6256-4308-bedc-9cd2667547cc

