### PR TITLE
[UI/UX:Submission] Default Instructor Submission Type

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -65,11 +65,11 @@
     {% endif %}
     {# Admin submission type selector #}
     {% if core.getUser().accessFullGrading() and bulk_upload_access %}
-        <form id="submission-form" method="post">
+        <form id="submission-form" method="POST">
             <fieldset id="submission-mode">
                 <legend> Select submission mode: </legend>
                 <label for="radio-normal">
-                    <input type='radio' id="radio-normal" name="submission-type">
+                    <input type='radio' id="radio-normal" name="submission-type" {% if not is_bulk_upload %} checked {% endif %} >
                     Normal Submission
                 </label>
                 <label for="radio-student">


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Inside of the submit box, if the instructor does not select anything it automatically goes to a normal instructor submission. However, this button is not checked

### What is the new behavior?
button is checked

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
