### PR TITLE
[Feature:System] Add IntroQuantumComputing to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ def mount_folders(config, mount_options, type = nil)
   group = 'vagrant'
   config.vm.synced_folder '.', '/usr/local/submitty/GIT_CHECKOUT/Submitty', create: true, owner: owner, group: group, mount_options: mount_options, smb_host: '10.0.2.2', smb_username: `whoami`.chomp, type: type
 
-  optional_repos = %w(AnalysisTools AnalysisToolsTS Lichen RainbowGrades Tutorial CrashCourseCPPSyntax LichenTestData DockerImages DockerImagesRPI)
+  optional_repos = %w(AnalysisTools AnalysisToolsTS Lichen RainbowGrades Tutorial CrashCourseCPPSyntax IntroQuantumComputing LichenTestData DockerImages DockerImagesRPI)
   optional_repos.each {|repo|
     repo_path = File.expand_path("../" + repo)
     if File.directory?(repo_path)


### PR DESCRIPTION
### What is the current behavior?
Currently, Vagrantfile mounts the following optional companion repositories to a shared directory in the VM: AnalysisTools, AnalysisToolsTS, Lichen, RainbowGrades, Tutorial, CrashCourseCPPSyntax, LichenTestData, DockerImages, DockerImagesRPI.

### What is the new behavior?
The file mounts an additional companion repository, IntroQuantumComputing, if found in the same directory.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
I reloaded the VM to apply the changes in the Vagrantfile and changed a folder name locally to ensure the changes were applied in the mirrored directory. 