### PR TITLE
[Testing:Forum] Fix Upduck Cypress Inconsistency

### DIFF
--- a/site/.performance_warning_ignore.json
+++ b/site/.performance_warning_ignore.json
@@ -54,5 +54,7 @@
   "/courses/<term>/<course>/reports/summaries",
   "/courses/<term>/<course>/gradeable/<gradeable>/grading/csv",
   "/superuser/email/send",
-  "/superuser/email_status_page"
+  "/superuser/email_status_page",
+  "/courses/<term>/<course>/users/details",
+  "/courses/<term>/<course>/no_access"
 ]

--- a/site/cypress/e2e/Cypress-Feature/upduck_forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/upduck_forums.spec.js
@@ -3,14 +3,14 @@ import { buildUrl } from '../../support/utils';
 const title1 = 'Attachment contains secret';
 const title2 = 'Different Levels& display order';
 const title3 = 'Simple C++ threading example';
-const upduckWaitTime = 30000;
+const upduckWaitTime = 10000;
 
 const upduckPost = (thread_title, thread_number = 0, num_ducks = 0) => {
     cy.get('[data-testid="thread-list-item"]').contains(thread_title).click();
     cy.get('[data-testid="create-post-head"]').should('contain', thread_title);
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks);
     cy.get('[data-testid="upduck-button"]').eq(thread_number).click();
-    cy.wait('@upduck', { responseTimeout: upduckWaitTime });
+    cy.wait('@upduck', { requestTimeout: upduckWaitTime });
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks + 1);
 };
 
@@ -19,7 +19,7 @@ const removeUpduck = (thread_title, thread_number = 0, num_ducks = 1) => {
     cy.get('[data-testid="create-post-head"]').should('contain', thread_title);
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks);
     cy.get('[data-testid="upduck-button"]').eq(thread_number).click();
-    cy.wait('@upduck', { responseTimeout: upduckWaitTime });
+    cy.wait('@upduck', { requestTimeout: upduckWaitTime });
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks - 1);
 };
 
@@ -198,7 +198,7 @@ describe('Should test upducks relating to students, TAs, and instructors', () =>
 
         // Remove upducks
         cy.get('[data-testid="upduck-button"]').first().click();
-        cy.wait('@upduck', { responseTimeout: upduckWaitTime });
+        cy.wait('@upduck', { requestTimeout: upduckWaitTime });
         cy.logout();
         cy.login('student');
         cy.visit(['sample', 'forum']);

--- a/site/cypress/e2e/Cypress-Feature/upduck_forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/upduck_forums.spec.js
@@ -3,13 +3,14 @@ import { buildUrl } from '../../support/utils';
 const title1 = 'Attachment contains secret';
 const title2 = 'Different Levels& display order';
 const title3 = 'Simple C++ threading example';
+const upduckWaitTime = 30000;
 
 const upduckPost = (thread_title, thread_number = 0, num_ducks = 0) => {
     cy.get('[data-testid="thread-list-item"]').contains(thread_title).click();
     cy.get('[data-testid="create-post-head"]').should('contain', thread_title);
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks);
     cy.get('[data-testid="upduck-button"]').eq(thread_number).click();
-    cy.wait('@upduck', { responseTimeout: 15000 });
+    cy.wait('@upduck', { responseTimeout: upduckWaitTime });
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks + 1);
 };
 
@@ -18,7 +19,7 @@ const removeUpduck = (thread_title, thread_number = 0, num_ducks = 1) => {
     cy.get('[data-testid="create-post-head"]').should('contain', thread_title);
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks);
     cy.get('[data-testid="upduck-button"]').eq(thread_number).click();
-    cy.wait('@upduck', { responseTimeout: 15000 });
+    cy.wait('@upduck', { responseTimeout: upduckWaitTime });
     cy.get('[data-testid="like-count"]').eq(thread_number).should('have.text', num_ducks - 1);
 };
 
@@ -197,7 +198,7 @@ describe('Should test upducks relating to students, TAs, and instructors', () =>
 
         // Remove upducks
         cy.get('[data-testid="upduck-button"]').first().click();
-        cy.wait('@upduck', { responseTimeout: 15000 });
+        cy.wait('@upduck', { responseTimeout: upduckWaitTime });
         cy.logout();
         cy.login('student');
         cy.visit(['sample', 'forum']);


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Upducks are currently failing as the request is not fully sent

### What is the new behavior?
Adds a timeout for the request

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
