### PR TITLE
[Bugfix:Developer] Update install_site for vite

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -379,7 +379,6 @@ echo "Running esbuild"
 chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
 chmod a+x ${NODE_FOLDER}/vite/bin/vite.js
-chmod a+x ${NODE_FOLDER}/vite/node_modules/esbuild/bin/esbuild
 chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod +w "${SUBMITTY_INSTALL_DIR}/site/vue"
@@ -389,7 +388,6 @@ chmod a-x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
 chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod a-x ${NODE_FOLDER}/vite/bin/vite.js
-chmod a-x ${NODE_FOLDER}/vite/node_modules/esbuild/bin/esbuild
 chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
 chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Vite has updated the esbuild binary once again (first one was #11241) and now uses it from `node_modules/esbuild/bin/esbuild` rather than `node_modules/vite/node_modules/esbuild/bin/esbuild` and therefore every run of install_site produces the error `chmod: cannot access '/usr/local/submitty/site/node_modules/vite/node_modules/esbuild/bin/esbuild': No such file or directory`
 
### What is the new behavior?
Only the correct esbuild binary is chmod-ed

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
