### PR TITLE
[Bugfix:Submission] Fix Duplicate Popups for Large Files

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -394,10 +394,6 @@ class SubmissionController extends AbstractController {
             $max_size = 10000000;
         }
 
-        if ($file_size > $max_size) {
-            return $this->uploadResult("File(s) uploaded too large.  Maximum size is " . ($max_size / 1000) . " kb. Uploaded file(s) was " . ($file_size / 1000) . " kb.", false);
-        }
-
         // creating uploads/bulk_pdf/gradeable_id directory
 
         $pdf_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "uploads", "bulk_pdf", $gradeable->getId());
@@ -1849,6 +1845,7 @@ class SubmissionController extends AbstractController {
                     file_put_contents($settings_file, FileUtils::encodeJson($settings));
                 }
             }
+            return $this->core->getOutput()->renderResultMessage($message, $success, false);
         }
         return $this->core->getOutput()->renderResultMessage($message, $success);
     }

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -938,8 +938,9 @@ function handleRegrade(versions_used, csrf_token, gradeable_id, user_id, regrade
                     window.location.reload();
                 }
                 else {
-                    alert(`ERROR! Please contact administrator with following error:\n\n${data['message']}`);
+                    displayMessage(data['message'], 'error');
                 }
+
             }
             catch (e) {
                 alert('Error parsing response from server. Please copy the contents of your Javascript Console and '
@@ -1126,7 +1127,7 @@ function handleSubmission(gradeable_status, remaining_late_days_for_gradeable, c
                         window.location.href = data['data'];
                     }
                     else {
-                        alert(`ERROR! Please contact administrator with following error:\n\n${data['message']}`);
+                        displayMessage(data['message'], 'error');
                     }
                 }
             }
@@ -1189,7 +1190,7 @@ function handleDownloadImages(csrf_token) {
                     window.location.href = return_url;
                 }
                 else {
-                    alert(`ERROR! Please contact administrator with following error:\n\n${data['message']}`);
+                    displayMessage(data['message'], 'error');
                 }
             }
             catch (e) {


### PR DESCRIPTION
fixes #10579

### What is the current behavior?
When a student submits a file that exceeds a gradeable's limit, a JavaScript alert is displayed. Then, when they submit a file with correct size, a Submitty popup error with the same message as the JS alert is displayed, alongside a Submitty success popup.

### What is the new behavior?
When a student submits a file that exceeds the gradeable's limit, a Submitty error popup is displayed. Only the Submitty success popup is displayed when a submission is successful.

### How to test
1) As a student, upload a file that exceeds a gradeable's limit and click submit. See Submitty popup error.
2) Upload a file within the gradeable's limit and click submit. See singular Submitty success popup.