### PR TITLE
[Bugfix:InstructorUI] Fixed Email Status Button Alignment

### DIFF
--- a/site/public/css/email-status.css
+++ b/site/public/css/email-status.css
@@ -9,7 +9,6 @@
 .button-container {
     position: relative;
     margin: auto;
-    display: inline-flex;
 }
 
 .expand {


### PR DESCRIPTION
Addresses a UI bug from bumping the Stylelint version.

When resolving Stylelint errors, I changed the styling of the buttons on the email status page from inline-flexbox (which doesn't exist), to inline-flex. This caused the buttons to no longer be right-aligned:

![broken stylelint email status](https://github.com/user-attachments/assets/8a57cb53-c6d7-4cf4-ab27-c25e8712d373)

By removing the rule, it is now fixed:

![fixed stylelint email status](https://github.com/user-attachments/assets/73185108-84ea-4fac-8728-77ae99d1da8f)
