### PR TITLE
[Bugfix:Autograding] Multiple docker debugging errors

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -152,7 +152,7 @@ class Container():
         }
 
         if error_log not in docker_error_data:
-            docker_error_data.append(error_log) 
+            docker_error_data.append(error_log)
 
         with open(os.path.join(docker_error_path, "docker_error.json"), "w") as json_file:
             json.dump(docker_error_data, json_file, indent=4)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -8,6 +8,7 @@ from pwd import getpwnam
 from timeit import default_timer as timer
 import shutil
 import docker
+from datetime import datetime
 
 from submitty_utils import dateutils
 from . import secure_execution_environment, rlimit_utils
@@ -133,7 +134,7 @@ class Container():
     def log_docker_error(self, message):
         docker_error_path = os.path.join(
                 '/var/local/submitty/autograding_tmp', self.full_name.split("_")[0], 'tmp/TMP_SUBMISSION/tmp_logs')
-        
+
         docker_error_file = os.path.join(docker_error_path, "docker_error.json")
         docker_error_data = []
         if os.path.exists(docker_error_file):
@@ -145,11 +146,14 @@ class Container():
             except json.JSONDecodeError:
                 docker_error_data = []
 
-        docker_error_data.append({
+        error_log = {
             "image": f'{self.image}',
             "machine": f'{self.full_name.split("_")[0]}',
-            "error": message
-        })
+            "error": message,
+        }
+
+        if error_log not in docker_error_data:
+            docker_error_data.append(error_log) 
 
         with open(os.path.join(docker_error_path, "docker_error.json"), "w") as json_file:
             json.dump(docker_error_data, json_file, indent=4)

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -115,12 +115,24 @@ class Container():
 
             docker_error_path = os.path.join(
                 '/var/local/submitty/autograding_tmp', self.full_name.split("_")[0], 'tmp/TMP_SUBMISSION/tmp_logs')
+        
+            docker_error_file = os.path.join(docker_error_path, "docker_error.json")
+            docker_error_data = []
+            if os.path.exists(docker_error_file):
+                try:
+                    with open(docker_error_file, "r") as json_file:
+                        docker_error_data = json.load(json_file)
+                        if not isinstance(docker_error_data, list):
+                            docker_error_data = []
+                except json.JSONDecodeError:
+                    docker_error_data = []
 
-            docker_error_data = {
+            docker_error_data.append({
                 "image": f'{self.image}',
                 "machine": f'{self.full_name.split("_")[0]}',
                 "error": f'image {self.image} could not be created in {self.full_name}'
-            }
+            })
+
             with open(os.path.join(docker_error_path, "docker_error.json"), "w") as json_file:
                 json.dump(docker_error_data, json_file, indent=4)
 

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -8,7 +8,6 @@ from pwd import getpwnam
 from timeit import default_timer as timer
 import shutil
 import docker
-from datetime import datetime
 
 from submitty_utils import dateutils
 from . import secure_execution_environment, rlimit_utils

--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -11,7 +11,7 @@
                         <li>
                             <strong>Image:</strong> {{ error.image }}<br>
                             <strong>Machine:</strong> {{ error.machine }}<br>
-                            <strong>Error:</strong> {{ error.error }}
+                            <strong>Error:</strong> {{ error.error }}<br>
                         </li>
                     {% endfor %}
                 </ul>

--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -7,8 +7,12 @@
             {% if docker_error_data is not null %}
                 <p>Error Details:</p>
                 <ul>
-                    {% for key, value in docker_error_data %}
-                        <li>{{ key }}: {{ value }}</li>
+                    {% for error in docker_error_data %}
+                        <li>
+                            <strong>Image:</strong> {{ error.image }}<br>
+                            <strong>Machine:</strong> {{ error.machine }}<br>
+                            <strong>Error:</strong> {{ error.error }}
+                        </li>
                     {% endfor %}
                 </ul>
             {% endif %}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes #11645
Currently, if there is a required docker image for an gradeable is missing, autograding submissions notify both students and instructors in the autograding results box. However, if multiple images are required and are missing, the subsequent errors overwrite the details of the previous error. 

### What is the new behavior?
The subsequent errors are appended to a list of errors and looped through to display each image error.

### Other information?
Current behavior
![before](https://github.com/user-attachments/assets/89ffa3b9-8b5f-4e42-862a-d3859e8d21a8)

New behavior
![after](https://github.com/user-attachments/assets/4a96ea15-6bd1-4a67-a6c7-f72011a82397)
