### PR TITLE
[Refactor: System] Remove deprecated doctrine access

### DIFF
--- a/site/app/repositories/SessionRepository.php
+++ b/site/app/repositories/SessionRepository.php
@@ -11,7 +11,7 @@ class SessionRepository extends EntityRepository {
      * @return Session|null
      */
     public function getActiveSessionById(string $session_id): ?Session {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb = $qb->select('s')
             ->from('app\entities\Session', 's')
             ->where('s.session_id = :session_id')
@@ -26,7 +26,7 @@ class SessionRepository extends EntityRepository {
      * @return Session[]
      */
     public function getAllByUser(string $user_id): array {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb = $qb->select('s')
             ->from('app\entities\Session', 's')
             ->where('s.user_id = :user_id')
@@ -41,7 +41,7 @@ class SessionRepository extends EntityRepository {
      * @param string $session_id
      */
     public function removeUserSessionsExcept(string $user_id, string $session_id): void {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb = $qb->delete('app\entities\Session', 's')
             ->where('s.user_id = :user_id')
             ->setParameter('user_id', $user_id)
@@ -54,7 +54,7 @@ class SessionRepository extends EntityRepository {
      * Remove all the expired sessions for all users
      */
     public function removeExpiredSessions(): void {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb = $qb->delete('app\entities\Session', 's')
             ->where('s.session_expires < CURRENT_TIMESTAMP()');
         $qb->getQuery()->execute();

--- a/site/app/repositories/VcsAuthTokenRepository.php
+++ b/site/app/repositories/VcsAuthTokenRepository.php
@@ -12,7 +12,7 @@ class VcsAuthTokenRepository extends EntityRepository {
      * @return VcsAuthToken[]
      */
     public function getAllByUser(string $user_id, bool $expired = false): array {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb = $qb->select('g')
             ->from('\app\entities\VcsAuthToken', 'g');
         if (!$expired) {

--- a/site/app/repositories/banner/BannerImageRepository.php
+++ b/site/app/repositories/banner/BannerImageRepository.php
@@ -15,7 +15,7 @@ class BannerImageRepository extends EntityRepository {
     public function getValidBannerImages(): array {
         $currentDate = new \DateTime();
 
-        return $this->_em->createQuery('
+        return $this->getEntityManager()->createQuery('
             SELECT b
             FROM app\entities\banner\BannerImage b
             WHERE

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -13,7 +13,7 @@ class EmailRepository extends EntityRepository {
         $result = [];
 
         foreach ($subjects as $subject) {
-            $qb = $this->_em->createQueryBuilder();
+            $qb = $this->getEntityManager()->createQueryBuilder();
             $qb ->select('e')
                 ->from('app\entities\email\EmailEntity', 'e');
             if ($semester && $course) {
@@ -40,7 +40,7 @@ class EmailRepository extends EntityRepository {
         else {
             $dql = 'SELECT e.subject, e.created, COUNT(e) FROM app\entities\email\EmailEntity e GROUP BY e.subject, e.created ORDER BY e.created DESC';
         }
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $page = 1;
         $count = 0;
         $subject = 0;
@@ -64,7 +64,7 @@ class EmailRepository extends EntityRepository {
         else {
             $dql = 'SELECT e.subject, e.created, COUNT(e) FROM app\entities\email\EmailEntity e GROUP BY e.subject, e.created ORDER BY e.created DESC';
         }
-        $q = $this->_em->createQuery($dql);
+        $q = $this->getEntityManager()->createQuery($dql);
         $curr_page = 1;
         $count = 0;
         $subject_count = 0;

--- a/site/app/repositories/forum/PostRepository.php
+++ b/site/app/repositories/forum/PostRepository.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Query\Expr;
 
 class PostRepository extends EntityRepository {
     public function getPostWithHistory(int $post_id): ?Post {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('post')
             ->addSelect('history')
             ->addSelect('attachments')
@@ -28,7 +28,7 @@ class PostRepository extends EntityRepository {
     }
 
     public function getPostDetail(int $post_id): ?Post {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('post')
             ->from(Post::class, 'post')
             ->addSelect('history')

--- a/site/app/repositories/forum/ThreadRepository.php
+++ b/site/app/repositories/forum/ThreadRepository.php
@@ -16,7 +16,7 @@ class ThreadRepository extends EntityRepository {
      */
     private function getThreadBlock(string $user_id, int $block_number): array {
         $block_size = 30;
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('thread')
             ->from(Thread::class, 'thread')
             ->leftJoin('thread.favorers', 'favorers', Join::WITH, 'favorers.user_id = :user_id')
@@ -43,7 +43,7 @@ class ThreadRepository extends EntityRepository {
         }
         $block = $this->getThreadBlock($user_id, $block_number);
 
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('thread')
             ->from(Thread::class, 'thread')
         // AddSelect allows us to join server-side, reducing the number of database queries.
@@ -104,7 +104,7 @@ class ThreadRepository extends EntityRepository {
 
 
     public function getThreadDetail(int $thread_id, string $order_posts_by = 'tree', bool $get_deleted = false): ?Thread {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('thread')
             ->from(Thread::class, 'thread')
             ->addSelect('post')
@@ -168,7 +168,7 @@ class ThreadRepository extends EntityRepository {
      * @return Thread[]
      */
     public function getMergeThreadOptions(Thread $thread): array {
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('thread')
             ->from(Thread::class, 'thread')
             ->addSelect('post')
@@ -189,7 +189,7 @@ class ThreadRepository extends EntityRepository {
         if (count($thread_ids) === 0 || count($user_ids) === 0) {
             return [];
         }
-        $qb = $this->_em->createQueryBuilder();
+        $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('thread')
             ->from(Thread::class, 'thread')
             ->addSelect('post')

--- a/site/app/repositories/poll/OptionRepository.php
+++ b/site/app/repositories/poll/OptionRepository.php
@@ -11,7 +11,7 @@ class OptionRepository extends EntityRepository {
      * Return a mapping of option id -> # responses for the specified poll
      */
     public function findByPollWithResponseCounts(int $poll_id): ?array {
-        $query_results = $this->_em
+        $query_results = $this->getEntityManager()
             ->createQuery('
                 SELECT o.id AS option_id, COUNT(DISTINCT r.student_id) AS num_responses FROM app\entities\poll\Option o
                 LEFT JOIN o.user_responses r
@@ -32,7 +32,7 @@ class OptionRepository extends EntityRepository {
      * Return whether given response is in given poll
      */
     public function existsByPollAndResponse(int $poll_id, string $response): bool {
-        $query_results = $this->_em
+        $query_results = $this->getEntityManager()
             ->createQuery('
                 SELECT o.id
                 FROM app\entities\poll\Option o

--- a/site/app/repositories/poll/PollRepository.php
+++ b/site/app/repositories/poll/PollRepository.php
@@ -13,7 +13,7 @@ class PollRepository extends EntityRepository {
      * @return Poll[]
      */
     public function findAllByStudentIDWithAllOptions(string $user_id): array {
-        return $this->_em
+        return $this->getEntityManager()
             ->createQuery('
                 SELECT p, r, o FROM app\entities\poll\Poll p
                 LEFT JOIN p.responses r WITH r.student_id = :user_id
@@ -29,7 +29,7 @@ class PollRepository extends EntityRepository {
      * Find single poll and hydrate all options and the specific responses for the specified student
      */
     public function findByStudentID(string $user_id, int $poll_id): ?Poll {
-        $result = $this->_em
+        $result = $this->getEntityManager()
             ->createQuery('
                 SELECT p, r, o FROM app\entities\poll\Poll p
                 LEFT JOIN p.responses r WITH r.student_id = :user_id
@@ -49,7 +49,7 @@ class PollRepository extends EntityRepository {
      * Find a single poll specified by ID and hydrate options
      */
     public function findByIDWithOptions(int $poll_id): ?Poll {
-        $result = $this->_em
+        $result = $this->getEntityManager()
             ->createQuery('
                 SELECT p, o FROM app\entities\poll\Poll p
                 LEFT JOIN p.options o
@@ -67,7 +67,7 @@ class PollRepository extends EntityRepository {
      * @return Poll[]
      */
     public function findAllWithAllResponses(): array {
-        return $this->_em
+        return $this->getEntityManager()
             ->createQuery('
                 SELECT p, r FROM app\entities\poll\Poll p
                 LEFT JOIN p.responses r
@@ -81,7 +81,7 @@ class PollRepository extends EntityRepository {
      * @return array<array{poll: Poll, num_responses: int}>
      */
     public function findAllWithNumResponses(): array {
-        return $this->_em
+        return $this->getEntityManager()
             ->createQuery('
                 SELECT p AS poll, COUNT(DISTINCT r.student_id) AS num_responses
                 FROM app\entities\poll\Poll p


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Throughout Submitty we access `EntityRepository::_em` however accessing it directly was deprecated as of [doctrine/orm version 2.0](https://github.com/doctrine/orm/blob/3.3.x/UPGRADE.md#entityrepository-deprecates-access-to-protected-variables).

### What is the new behavior?
All uses of `EntityRepository::_em` have been updated to the new syntax of `EntityRepository::getEntityManager()`

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
