### PR TITLE
[Bugfix:InstructorUI] Aligned Notification Headers

### DIFF
--- a/site/app/templates/NotificationSettings.twig
+++ b/site/app/templates/NotificationSettings.twig
@@ -30,22 +30,20 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="row">
-                <div class="heading col-md-4"></div>
+            <div class="row row-spacing">
+                <div class="heading col-md-4">
+                    <h2 class="notification-settings-header">Forum</h2>
+                </div>
                 <div class="heading col-md-3">
-                    <h2>Notification Settings</h2>
+                    <h2 class="notification-settings-header">Notification Settings</h2>
                 </div>
                 {% if email_enabled %}
                     <div class="heading col-md-5">
-                        <h2>Email Settings</h2>
+                        <h2 class="notification-settings-header">Email Settings</h2>
                     </div>
                 {% endif %}
             </div>
-
-            <div class="heading">
-                <h2>Forum</h2>
-                <hr>
-            </div>
+            <div><hr></div>
             <div class="option row">
                 <div class="option-desc col-md-4">
                     <span>
@@ -161,8 +159,8 @@
                 </div>
             {% endif %}
 
-            <div class="heading">
-                <h2>Grade Inquiry</h2>
+            <div class="heading row-spacing">
+                <h2 class="notification-settings-header">Grade Inquiry</h2>
                 <hr>
             </div>
 
@@ -226,8 +224,8 @@
                 {% endif %}
             </div>
 
-            <div class="heading">
-                <h2>Team</h2>
+            <div class="heading row-spacing">
+                <h2 class="notification-settings-header">Team</h2>
                 <hr>
             </div>
 
@@ -290,7 +288,7 @@
         
             {% if is_instructor and is_self_registration %}
                 <div class="heading">
-                    <h2>Registration</h2>
+                    <h2 class="notification-settings-header">Registration</h2>
                     <hr>
                 </div>
                 <div class="option row">

--- a/site/public/css/notifications.css
+++ b/site/public/css/notifications.css
@@ -76,6 +76,15 @@
     margin: 5px;
 }
 
+.row-spacing {
+    padding-top: 20px;
+}
+
+.notification-settings-header {
+    /* stylelint-disable-next-line declaration-no-important */
+    margin-bottom: 0px !important; /* Overrides .content h2 { in server.css*/
+}
+
 @media (min-width: 768px) {
     #notification-header {
         display: table-row;

--- a/site/public/css/notifications.css
+++ b/site/public/css/notifications.css
@@ -82,7 +82,7 @@
 
 .notification-settings-header {
     /* stylelint-disable-next-line declaration-no-important */
-    margin-bottom: 0px !important; /* Overrides .content h2 { in server.css*/
+    margin-bottom: 0 !important; /* Overrides .content h2 { in server.css */
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
### What is the current behavior?
The column headers on the notification settings page are misaligned:
![misaligned email notification headers](https://github.com/user-attachments/assets/84efe082-4acf-49a3-911f-aaa26497d6ef)

### What is the new behavior?
![Aligned Notification Settings Header](https://github.com/user-attachments/assets/d764947c-a087-4b9a-8605-c380a4bcc35d)

### Other information?
- This is not a breaking change
- Had to include an instance of !important due to a style overriding the header spacing in server.css. Fixing the chain of specificity is beyond the scope of this PR.