### PR TITLE
[Bugfix:Autograding] Extend docker error to TAGrading

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -27,7 +27,26 @@
     {% if num_visible_testcases > 0 %}
         {# check if instructor grades exist and change title, display hidden points when TA grades are released (if hidden tests exist) #}
 
-
+        {% if docker_error %}
+            <div style="background-color: var(--standard-light-red);">
+                <div class="error-container">
+                    <p class="error-header">Docker Image not present on machine. Please contact your instructor about this.</p>
+                    {% if docker_error_data is not null %}
+                        <p class="error-details">Error Details:</p>
+                        <ul class="error-listing">
+                            {% for error in docker_error_data %}
+                                <li class="error-content">
+                                    <strong>Image:</strong> {{ error.image }}<br>
+                                    <strong>Machine:</strong> {{ error.machine }}<br>
+                                    <strong>Error:</strong> {{ error.error }}<br>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+        
         <div class="box submission-page-total-header key_to_click" tabindex="0"
             {% if nonhidden_earned >= nonhidden_max and nonhidden_max > 0 %}
                 onclick="addConfetti();"

--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -1,25 +1,7 @@
 <div class="content">
     <div class="sub">
         {# Actual results #}
-        {% if docker_error %}
-            <div style="background-color: var(--standard-light-red);">
-                <div class="error-container">
-                    <p class="error-header">Docker Image not present on machine. Please contact your instructor about this.</p>
-                    {% if docker_error_data is not null %}
-                        <p class="error-details">Error Details:</p>
-                        <ul class="error-listing">
-                            {% for error in docker_error_data %}
-                                <li class="error-content">
-                                    <strong>Image:</strong> {{ error.image }}<br>
-                                    <strong>Machine:</strong> {{ error.machine }}<br>
-                                    <strong>Error:</strong> {{ error.error }}<br>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                </div>
-            </div>
-        {% elseif in_queue or in_progress_grading %}
+        {% if in_queue or in_progress_grading %}
             {% if in_progress_grading %}
                 <p class="red-message">
                     This submission is currently being graded.

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -33,6 +33,9 @@ class AutoGradingView extends AbstractView {
         $any_visible_hidden = false;
         $num_visible_testcases = 0;
 
+        $docker_error = $version_instance->dockerErrorFileExists();
+        $docker_error_data = $docker_error ? $version_instance->getDockerErrorFileData() : null;
+
         // This variable should be false if autograding results
         // (files/database values) exist, but true if the assignment
         // is in the queue or something went wrong with autograding
@@ -100,6 +103,7 @@ class AutoGradingView extends AbstractView {
             $queueData['check_refresh_submission_url'] = $this->core->buildCourseUrl([ 'gradeable', $gradeable->getId(), $version_instance->getVersion(), 'check_refresh' ]);
         }
 
+        $this->core->getOutput()->addInternalCss('autograding-results-box.css');
         return $this->core->getOutput()->renderTwigTemplate("autograding/AutoResults.twig", array_merge($queueData, [
             'gradeable_id' => $gradeable->getId(),
             'submitter_id' => $graded_gradeable->getSubmitter()->getAnonId($graded_gradeable->getGradeableId()),
@@ -117,7 +121,9 @@ class AutoGradingView extends AbstractView {
             'is_ta_grade_released' => $gradeable->isTaGradeReleased(),
             'display_version' => $version_instance->getVersion(),
             'is_ta_grading' => $gradeable->isTaGrading(),
-            'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails()
+            'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),
+            'docker_error' => $docker_error,
+            'docker_error_data' => $docker_error_data,
         ]));
     }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1073,8 +1073,6 @@ class HomeworkView extends AbstractView {
 
 
         $param = array_merge($param, [
-            'docker_error' => $version_instance->dockerErrorFileExists(),
-            'docker_error_data' => null,
             'gradeable_id' => $gradeable->getId(),
             'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),
             'incomplete_autograding' => $version_instance !== null ? !$version_instance->isAutogradingComplete() : false,
@@ -1084,16 +1082,8 @@ class HomeworkView extends AbstractView {
             'show_incentive_message' => $show_incentive_message
         ]);
 
-        if ($param['docker_error']) {
-            $docker_error_data = $version_instance->getDockerErrorFileData();
-            if ($docker_error_data !== null) {
-                $param['docker_error_data'] = $docker_error_data;
-            }
-        }
-
         $this->core->getOutput()->addInternalJs('confetti.js');
         $this->core->getOutput()->addInternalJs('submission-page.js');
-        $this->core->getOutput()->addInternalCss('autograding-results-box.css');
         return $this->core->getOutput()->renderTwigTemplate('submission/homework/AutogradingResultsBox.twig', $param);
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [x] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Currently, having a missing docker image error only displays this error for students on the homework submission side and does not display on the page for TAGrading.

### What is the new behavior?
I reverted the changes to display the error in AutogradingResultsBox.twig and only added it to AutoResults.twig. The docker error now successfully shows for both TA grading and for student submissions.

### Other information?
Before:
![image](https://github.com/user-attachments/assets/98242ab0-87d9-414d-8f7f-efac3c5feb19)
![image](https://github.com/user-attachments/assets/1e126527-d478-44f4-9f91-c7643f4b91be)

After:
![image](https://github.com/user-attachments/assets/f1e22295-eee7-49c6-b151-c7e5b4f7cebb)
![image](https://github.com/user-attachments/assets/0f37595e-b388-4a69-8e48-a66584cbd628)

<!-- How did you test -->
To test, I used the Docker Choice of Language gradeable in the development course. I removed necessary docker images and submitted to the gradeable.