### PR TITLE
[Bugfix:Developer] Add Instructor back to tutorial

### DIFF
--- a/.setup/data/users/instructor.yml
+++ b/.setup/data/users/instructor.yml
@@ -17,3 +17,5 @@ courses:
     user_group: 1
   archived:
     user_group: 1
+  tutorial:
+    user_group: 1


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Tutorial was not added to instructor.yml files

### What is the new behavior?
Tutorial is now added back to instructor

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
