### PR TITLE
[Bugfix:Developer] Fix Dev Install Script

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -705,6 +705,7 @@ ${DB_COURSE_USER}
 ${DB_COURSE_PASSWORD}
 America/New_York
 en_US
+100
 ${SUBMISSION_URL}
 
 


### PR DESCRIPTION
### What is the current behavior?
Vagrant up fails because a PR added a new parameter to CONFIGURE_SUBMITTY.py, but didn't add the parameter to all the required install scripts. 
### What is the new behavior?
[Vagrant up](https://github.com/Submitty/Submitty/actions/runs/15522688862/job/43698042151) passes.
