### PR TITLE
[Bugfix:System] Handle Undefined Course in Email Subject

### DIFF
--- a/site/app/models/Email.php
+++ b/site/app/models/Email.php
@@ -71,7 +71,8 @@ class Email extends AbstractModel {
     //inject course label into subject
     private function formatSubject(string $subject): string {
         $course = $this->core->getConfig()->getCourse();
-        return "[Submitty $course]: " . $subject;
+        $label = $course ? "[Submitty $course]" : "[Submitty]";
+        return "$label: $subject";
     }
 
     //inject a "do not reply" note in the footer of the body

--- a/site/tests/app/models/EmailTester.php
+++ b/site/tests/app/models/EmailTester.php
@@ -148,12 +148,12 @@ class EmailTester extends \PHPUnit\Framework\TestCase {
     }
 
         public function testHeaderWithUndefinedCourse(): void {
-        $email = new Email($this->core, [
-            'to_user_id' => 'person',
-            'subject' => 'some email',
-            'body' => 'email body',
-        ]);
+            $no_course_email = new Email($this->core, [
+                'to_user_id' => 'person',
+                'subject' => 'some email',
+                'body' => 'email body',
+            ]);
 
-        $this->assertSame('[Submitty]: some email', $email->getSubject());
+        $this->assertSame('[Submitty]: some email', $no_course_email->getSubject());
     }
 }

--- a/site/tests/app/models/EmailTester.php
+++ b/site/tests/app/models/EmailTester.php
@@ -146,4 +146,14 @@ class EmailTester extends \PHPUnit\Framework\TestCase {
 
         $this->assertSame($expected_body, $email_missing->getBody());
     }
+
+        public function testHeaderWithUndefinedCourse(): void {
+        $email = new Email($this->core, [
+            'to_user_id' => 'person',
+            'subject' => 'some email',
+            'body' => 'email body',
+        ]);
+
+        $this->assertSame('[Submitty]: some email', $email->getSubject());
+    }
 }

--- a/site/tests/app/models/EmailTester.php
+++ b/site/tests/app/models/EmailTester.php
@@ -144,16 +144,7 @@ class EmailTester extends \PHPUnit\Framework\TestCase {
 
         $expected_body = 'email body' . "\n\n--\nNOTE: This is an automated email notification, which is unable to receive replies.";
 
+        $this->assertSame('[Submitty]: some email', $email_missing->getSubject());
         $this->assertSame($expected_body, $email_missing->getBody());
-    }
-
-        public function testHeaderWithUndefinedCourse(): void {
-            $no_course_email = new Email($this->core, [
-                'to_user_id' => 'person',
-                'subject' => 'some email',
-                'body' => 'email body',
-            ]);
-
-        $this->assertSame('[Submitty]: some email', $no_course_email->getSubject());
     }
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
fixes #11731
When Submitty sends an email, it assumes a course is defined and associated with the sender. If no course is defined, an extra space appears in the email subject line where the course label would normally go:

```
reply-to: do-not-reply@vagrant
Subject: [Submitty ]: Submitty Email Verification
```

### What is the New Behavior?
Email header logic now checks if the course is defined to prevent the unnecessary space:

```
reply-to: do-not-reply@vagrant
Subject: [Submitty]: Submitty Email Verification
```

### Other information
This is not a breaking change.