### PR TITLE
[Bugfix:Developer] FIx Vue Install Script

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -102,6 +102,11 @@ if [ -d "${SUBMITTY_INSTALL_DIR}/site/ts" ]; then
     rm -r "${SUBMITTY_INSTALL_DIR}/site/ts"
 fi
 
+# Delete all vue code to prevent deleted vue files from being rendered
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/vue" ]; then
+    rm -r "${SUBMITTY_INSTALL_DIR}/site/vue"
+fi
+
 # copy the website from the repo. We don't need the tests directory in production and then
 # we don't want vendor as if it exists, it was generated locally for testing purposes, so
 # we don't want it


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When making new vue components, the old data stays. So, if you were to switch to a different branch, the vue data would continue to stay and affect the current code. This was apparent in #11738, where if you were to switch off the branch you would have an error in console.

In addition, when you look at whatever was loaded, in addition to the vue flies, the old files stayed. This caused a message of 31 modules loaded when you realistically should have around 15 on the main branch

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Removes the vue directory so that rsync syncs up the current vue files

### What steps should a reviewer take to reproduce or test the bug or new feature?
start with ~15 modules loaded
Visit #11738 
`submitty_install_site` 31 modules loaded
visit main
`submitty_install_site` 31 modules loaded <- should have only 15

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
N/A

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
