### PR TITLE
[Bugfix:InstructorUI] Correct machine on docker error

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -112,7 +112,7 @@ class Container():
                     name=self.full_name
                 )
         except docker.errors.ImageNotFound:
-            self.log_docker_error(f'image is not available')
+            self.log_docker_error('image is not available')
             self.log_function(f'ERROR: The image {self.image} is not available on this worker')
             client.close()
             raise

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -112,7 +112,7 @@ class Container():
                     name=self.full_name
                 )
         except docker.errors.ImageNotFound:
-            self.log_docker_error(f'image could not be created in {self.full_name}')
+            self.log_docker_error(f'image is not available')
             self.log_function(f'ERROR: The image {self.image} is not available on this worker')
             client.close()
             raise
@@ -131,8 +131,19 @@ class Container():
         client.close()
 
     def log_docker_error(self, message):
+        untrusted = self.full_name.split("_")[0]
         docker_error_path = os.path.join(
-                '/var/local/submitty/autograding_tmp', self.full_name.split("_")[0], 'tmp/TMP_SUBMISSION/tmp_logs')
+                '/var/local/submitty/autograding_tmp', untrusted, 'tmp/TMP_SUBMISSION/tmp_logs')
+
+        queue_file = os.path.join('/var/local/submitty/autograding_tmp', untrusted, 'tmp/TMP_SUBMISSION/queue_file.json')
+
+        machine = 'unknown'
+        with open(queue_file, 'r') as f:
+            try:
+                queue_file = json.load(f)
+                machine = queue_file["which_machine"]
+            except json.JSONDecodeError:
+                queue_file = {}
 
         docker_error_file = os.path.join(docker_error_path, "docker_error.json")
         docker_error_data = []
@@ -147,8 +158,8 @@ class Container():
 
         error_log = {
             "image": f'{self.image}',
-            "machine": f'{self.full_name.split("_")[0]}',
-            "error": message,
+            "machine": f'{machine}',
+            "error": f'{message} on machine {machine}',
         }
 
         if error_log not in docker_error_data:


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Fixes #11725
Currently, the value for the machine incorrectly displays the container as the machine. We want users/instructors to know which exact machine is missing the images.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Before
![452027974-98242ab0-87d9-414d-8f7f-efac3c5feb19](https://github.com/user-attachments/assets/bb285a9b-5a88-41b4-9345-4048d4b38d1b)

After
![image](https://github.com/user-attachments/assets/1bae183f-298f-47c4-a543-57e891d2f0c9)

### What steps should a reviewer take to reproduce or test the bug or new feature?
Submit example submissions to a course where you don't have a docker image for. For example, Docker Choice Of Language uses rust:latest, clang:latest, gcc:latest.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
Cypress tests have not been created yet for autograding, it is in progress.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
