### PR TITLE
[Bugfix:TAGrading] Update pdf viewing permissions

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -85,6 +85,12 @@ class MiscController extends AbstractController {
         elseif (strpos($file_path, 'checkout') !== false) {
             $directory = 'checkout';
         }
+        elseif (strpos($file_path, 'results_public') !== false) {
+            $directory = 'results_public';
+        }
+        elseif (strpos($file_path, 'results') !== false) {
+            $directory = 'results';
+        }
         $check_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), $directory, $gradeable_id, $id);
 
         if ($gradeable->isGradeByRegistration()) {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently when a TA attempts to view a pdf from the results or results_public folder they see an error and have to download it instead.
Fixes #11750

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
PDFs in all folders are viewable

### What steps should a reviewer take to reproduce or test the bug or new feature?
- Use a gradeable config that will place a pdf in results or results_public
- Observe on main that the pdf is downloadable but not viewable.
- Switch to PR
- Observe that it is viewable now

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
