### PR TITLE
[Bugfix:Submission] Move Queue Text to global AutoResults

### DIFF
--- a/site/app/templates/autograding/AutoResults.twig
+++ b/site/app/templates/autograding/AutoResults.twig
@@ -1,9 +1,15 @@
 {% import 'functions/Badge.twig' as Badge %}
 
-{% if in_queue %}
-    <p class="red-message" id="auto-results-queue-msg">
-        This submission is currently in the autograding queue at position {{ queue_pos }} of {{ queue_total }}.
-    </p>
+{% if in_queue or in_progress_grading %}
+    {% if in_progress_grading %}
+        <p class="red-message">
+            This submission is currently being graded.
+        </p>
+    {% else %}
+        <p class="red-message">
+            This submission is currently in the queue to be graded. Your submission is number {{ queue_pos }} out of {{ queue_total }}.
+        </p>
+    {% endif %}
     <script>
         checkRefreshPage("{{ check_refresh_submission_url|e('js') }}", "{{ submitter_id }}");
     </script>

--- a/site/app/templates/submission/homework/AutogradingResultsBox.twig
+++ b/site/app/templates/submission/homework/AutogradingResultsBox.twig
@@ -1,17 +1,7 @@
 <div class="content">
     <div class="sub">
-        {# Actual results #}
-        {% if in_queue or in_progress_grading %}
-            {% if in_progress_grading %}
-                <p class="red-message">
-                    This submission is currently being graded.
-                </p>
-            {% else %}
-                <p class="red-message">
-                    This submission is currently in the queue to be graded. Your submission is number {{ queue_pos }} out of {{ queue_total }}.
-                </p>
-            {% endif %}
-        {% elseif results is not defined %}
+        {# Error #}
+        {% if results is not defined and not in_queue and not in_progress_grading %}
             <p class="red-message">
                 Something went wrong when grading this submission. Please contact your instructor about this.
             </p>
@@ -21,7 +11,9 @@
                     const loadAttempt = Number(params.get('loadAttempt') ?? '0');
                     if (loadAttempt < 3) {
                         params.set('loadAttempt', loadAttempt + 1);
-                        window.location.search = params.toString();
+                        setTimeout(() => {
+                            window.location.search = params.toString();
+                        }, 1500);
                     }
                 })();
             </script>

--- a/site/app/views/AutoGradingView.php
+++ b/site/app/views/AutoGradingView.php
@@ -94,13 +94,16 @@ class AutoGradingView extends AbstractView {
             }
         }
 
-        $queueData = [ 'in_queue' => false ];
+        $queueData = [
+            'in_queue' => false,
+            'check_refresh_submission_url' => $this->core->buildCourseUrl([ 'gradeable', $gradeable->getId(), $version_instance->getVersion(), 'check_refresh' ]),
+            'in_progress_grading' => $version_instance->isGrading()
+        ];
 
         if ($version_instance->isQueued()) {
             $queueData['in_queue'] = true;
             $queueData['queue_pos'] = $version_instance->getQueuePosition();
             $queueData['queue_total'] = $this->core->getGradingQueue()->getQueueCount();
-            $queueData['check_refresh_submission_url'] = $this->core->buildCourseUrl([ 'gradeable', $gradeable->getId(), $version_instance->getVersion(), 'check_refresh' ]);
         }
 
         $this->core->getOutput()->addInternalCss('autograding-results-box.css');
@@ -123,7 +126,7 @@ class AutoGradingView extends AbstractView {
             'is_ta_grading' => $gradeable->isTaGrading(),
             'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),
             'docker_error' => $docker_error,
-            'docker_error_data' => $docker_error_data,
+            'docker_error_data' => $docker_error_data
         ]));
     }
 

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -1030,16 +1030,8 @@ class HomeworkView extends AbstractView {
                     'results' => 0,
                 ]);
             }
-
-            if ($version_instance->isQueued()) {
-                $param = array_merge($param, [
-                    'queue_pos' => $version_instance->getQueuePosition(),
-                    'queue_total' => $this->core->getGradingQueue()->getQueueCount()
-                ]);
-            }
         }
 
-        $check_refresh_submission_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), $display_version, 'check_refresh']);
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('mermaid', 'mermaid.min.js'));
 
 
@@ -1078,7 +1070,6 @@ class HomeworkView extends AbstractView {
             'hide_test_details' => $gradeable->getAutogradingConfig()->getHideTestDetails(),
             'incomplete_autograding' => $version_instance !== null ? !$version_instance->isAutogradingComplete() : false,
             'display_version' => $display_version,
-            'check_refresh_submission_url' => $check_refresh_submission_url,
             'show_testcases' => $show_testcases,
             'show_incentive_message' => $show_incentive_message
         ]);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently the user has two different texts that show them the same text that they are somewhere in the queue. This is because the instructor view has the queue in addition to the student queue. If the submission is currently getting graded, then we can call the server to check for results, which was not happening

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The code only appears once, in addition to currently grading checking for the refresh.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Submit a gradeable
Refresh until you see it is being graded
page would not refresh

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
N/A 

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
I added a delay to autoresultsbox because there is a race condition that there might be a status if we press submit. 
#5899  explains it better. The delay was added because we might refresh 3 times very quickly and not catch the new queue state. I thought 1.5 seconds was a reasonable amount of time.
