### PR TITLE
[Bugfix:InstructorUI] Detect Invalid Autograding config.json

### DIFF
--- a/more_autograding_examples/matlab/config/config.json
+++ b/more_autograding_examples/matlab/config/config.json
@@ -11,6 +11,10 @@
       "submission_to_runner" : [ "*.m"],
       "work_to_details" : ["*.png"]
   },
+  "autograding" : {
+      "submission_to_runner" : [ "*.m"],
+      "work_to_details" : ["*.png"]
+  },
   "allow_system_calls" : [
         "ALLOW_SYSTEM_CALL_CATEGORY_COMMUNICATIONS_AND_NETWORKING_INTERPROCESS_COMMUNICATION",
         "ALLOW_SYSTEM_CALL_CATEGORY_COMMUNICATIONS_AND_NETWORKING_SIGNALS",

--- a/more_autograding_examples/matlab/config/config.json
+++ b/more_autograding_examples/matlab/config/config.json
@@ -11,10 +11,6 @@
       "submission_to_runner" : [ "*.m"],
       "work_to_details" : ["*.png"]
   },
-  "autograding" : {
-      "submission_to_runner" : [ "*.m"],
-      "work_to_details" : ["*.png"]
-  },
   "allow_system_calls" : [
         "ALLOW_SYSTEM_CALL_CATEGORY_COMMUNICATIONS_AND_NETWORKING_INTERPROCESS_COMMUNICATION",
         "ALLOW_SYSTEM_CALL_CATEGORY_COMMUNICATIONS_AND_NETWORKING_SIGNALS",

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1422,7 +1422,7 @@ class AdminGradeableController extends AbstractController {
                 $invalid_config_message = $gradeable->validateAutogradingConfig($_POST['autograding_config_path']);
 
                 if ($invalid_config_message !== null) {
-                    array_push($response_props, 'Warning:'.$invalid_config_message);
+                    array_push($response_props, 'Warning:' . $invalid_config_message);
                 }
             }
             // Finally, send the requester back the information

--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1422,7 +1422,7 @@ class AdminGradeableController extends AbstractController {
                 $invalid_config_message = $gradeable->validateAutogradingConfig($_POST['autograding_config_path']);
 
                 if ($invalid_config_message !== null) {
-                    $response_props['warnings']['autograding_config'] = $invalid_config_message;
+                    array_push($response_props, 'Warning:'.$invalid_config_message);
                 }
             }
             // Finally, send the requester back the information

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -149,7 +149,6 @@ class AutogradingConfigController extends AbstractController {
 
         $msg = 'Gradeable config uploaded';
         $this->core->addSuccessMessage($msg);
-
         return new MultiResponse(
             JsonResponse::getSuccessResponse([
                 'config_path' => $target_dir

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -10,10 +10,6 @@ use app\libraries\response\MultiResponse;
 use app\libraries\response\WebResponse;
 use app\libraries\response\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
-use Seld\JsonLint\JsonParser;
-use Seld\JsonLint\DuplicateKeyException;
-use Seld\JsonLint\ParsingException;
-
 
 /**
  * Class AutogradingConfigController

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -120,10 +120,12 @@ class AutogradingConfigController extends AbstractController {
                 );
             }
         }
+
         $invalid_config_message = $gradeable->validateAutogradingConfig($target_dir);
         if ($invalid_config_message !== null) {
             $this->core->addNoticeMessage($invalid_config_message);
         }
+
         $msg = 'Gradeable config uploaded';
         $this->core->addSuccessMessage($msg);
         return new MultiResponse(

--- a/site/app/controllers/admin/AutogradingConfigController.php
+++ b/site/app/controllers/admin/AutogradingConfigController.php
@@ -120,7 +120,10 @@ class AutogradingConfigController extends AbstractController {
                 );
             }
         }
-        $gradeable->validateAutogradingConfig();
+        $invalid_config_message = $gradeable->validateAutogradingConfig($target_dir);
+        if ($invalid_config_message !== null) {
+            $this->core->addNoticeMessage($invalid_config_message);
+        }
         $msg = 'Gradeable config uploaded';
         $this->core->addSuccessMessage($msg);
         return new MultiResponse(

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2611,15 +2611,18 @@ class Gradeable extends AbstractModel {
                 $json_parser = new JsonParser();
                 $path = $file_iter->current()->getPathname();
                 $json = file_get_contents($path);
+                $original_lines = substr_count($json, "\n");
 
                 try {
                     $content = preg_replace([
                         '#//.*$#m',      // remove // comments at end of the line
                         '#/\*.*?\*/#s'   // remove /* ... */ block comments
                     ], '', $json);
+                    $new_lines = substr_count($content, "\n");
+                    $line_diff = $original_lines - $new_lines;
                     $json_parser->parse($content, JsonParser::DETECT_KEY_CONFLICTS);
                 } catch (DuplicateKeyException $e) {
-                    return '\''.$e->getDetails()['key'].'\' is a duplicate key in '.$path.' at line '.$e->getDetails()['line'];
+                    return '\''.$e->getDetails()['key'].'\' is a duplicate key in '.$path.' at line '.($e->getDetails()['line'] - $line_diff);
                 } catch (ParsingException $e) {
                     return 'Invalid JSON in '.$path.': '.$e->getMessage();
                 }

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2621,11 +2621,14 @@ class Gradeable extends AbstractModel {
                     $new_lines = substr_count($content, "\n");
                     $line_diff = $original_lines - $new_lines;
                     $json_parser->parse($content, JsonParser::DETECT_KEY_CONFLICTS);
-                } catch (DuplicateKeyException $e) {
-                    return '\''.$e->getDetails()['key'].'\' is a duplicate key in '.$path.' at line '.($e->getDetails()['line'] - $line_diff);
-                } catch (ParsingException $e) {
-                    $message = $e->getDetails()['line'] ? preg_replace('/on line \d+/', 'on line ' . ($e->getDetails()['line'] - $line_diff), $e->getMessage()) : $e->getMessage();
-                    return 'Invalid JSON in '.$path.': '.$message;
+                }
+                catch (DuplicateKeyException $e) {
+                    return '\'' . $e->getDetails()['key'] . '\' is a duplicate key in ' . $path . ' at line ' . ($e->getDetails()['line'] - $line_diff);
+                }
+                catch (ParsingException $e) {
+                    $message = isset($e->getDetails()['line']) ?
+                        preg_replace('/on line \d+/', 'on line ' . ($e->getDetails()['line'] - $line_diff), $e->getMessage()) : $e->getMessage();
+                    return 'Invalid JSON in ' . $path . ': ' . $message;
                 }
             }
             $file_iter->next();

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2592,7 +2592,8 @@ class Gradeable extends AbstractModel {
     }
 
     /**
-     * Validates the autograding config for the gradeable, adding notices for any issues found.
+     * Validates the autograding config for the gradeable, warning instructors of
+     * any issues found, such as duplicate keys or invalid JSON syntax.
      *
      * @return void
      */
@@ -2604,7 +2605,7 @@ class Gradeable extends AbstractModel {
 
         while ($file_iter->valid()) {
             // Validate any config.json files within the autograding config directory
-        if ($file_iter->current()->getFilename() == 'config.json') {
+            if ($file_iter->current()->getFilename() == 'config.json') {
                 $json_parser = new JsonParser();
                 $path = $file_iter->current()->getPathName();
                 $json = file_get_contents($path);

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2596,7 +2596,6 @@ class Gradeable extends AbstractModel {
      * any issues found, such as duplicate keys or invalid JSON syntax.
      *
      * @param string|null $target_dir The directory to validate, defaults to the gradeable's autograding config path.
-     * @throws \Exception If the config is invalid.
      * @return string|null The error message if the config is invalid, null otherwise.
      */
     public function validateAutogradingConfig(?string $target_dir): ?string {

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2612,10 +2612,7 @@ class Gradeable extends AbstractModel {
                 $json_parser = new JsonParser();
                 $json = file_get_contents($path);
                 // Remove line and block-based comments from the JSON and calculate the line difference
-                $content = preg_replace([
-                    '#//.*$#m',      // remove // comments at end of the line
-                    '#/\*.*?\*/#s'   // remove /* ... */ block comments
-                ], '', $json);
+                $content = Utils::stripComments($json);
                 $original_lines = substr_count($json, "\n");
                 $new_lines = substr_count($content, "\n");
                 $line_diff = $original_lines - $new_lines;

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2624,7 +2624,8 @@ class Gradeable extends AbstractModel {
                 } catch (DuplicateKeyException $e) {
                     return '\''.$e->getDetails()['key'].'\' is a duplicate key in '.$path.' at line '.($e->getDetails()['line'] - $line_diff);
                 } catch (ParsingException $e) {
-                    return 'Invalid JSON in '.$path.': '.$e->getMessage();
+                    $message = $e->getDetails()['line'] ? preg_replace('/on line \d+/', 'on line ' . ($e->getDetails()['line'] - $line_diff), $e->getMessage()) : $e->getMessage();
+                    return 'Invalid JSON in '.$path.': '.$message;
                 }
             }
             $file_iter->next();

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2611,6 +2611,7 @@ class Gradeable extends AbstractModel {
                 $path = $file_iter->current()->getPathname();
                 $json_parser = new JsonParser();
                 $json = file_get_contents($path);
+
                 // Remove line and block-based comments from the JSON and calculate the line difference
                 $content = Utils::stripComments($json);
                 $original_lines = substr_count($json, "\n");

--- a/site/composer.json
+++ b/site/composer.json
@@ -32,6 +32,7 @@
     "onelogin/php-saml": "4.3.0",
     "php-ds/php-ds": "1.5.0",
     "ramsey/uuid": "4.8.1",
+    "seld/jsonlint": "^1.11",
     "symfony/cache": "6.4.7",
     "symfony/config": "6.4.4",
     "symfony/http-foundation": "6.4.14",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "718848efdbb8aee89986d91e737f23be",
+    "content-hash": "ea771209a18e443c216534f0ca83e081",
     "packages": [
         {
             "name": "brick/math",
@@ -3700,6 +3700,70 @@
                 "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.3"
             },
             "time": "2024-11-20T21:13:56+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-07-11T14:55:45+00:00"
         },
         {
             "name": "symfony/cache",
@@ -8778,13 +8842,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -403,7 +403,6 @@ function ajaxCheckBuildStatus() {
         type: 'GET',
         url: buildCourseUrl(['gradeable', gradeable_id, 'build_status']),
         success: function (response) {
-            console.log(response);
             $('#rebuild-log-button').css('display', 'block');
             if (response['data'] === 'queued') {
                 $('#rebuild-status').html(gradeable_id.concat(' is in the rebuild queue...'));
@@ -579,12 +578,15 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
                     url: buildCourseUrl(['gradeable', gradeable_id, 'update']),
                     data: p_values,
                     success: function (response) {
-                        if (response?.data?.warnings?.autograding_config !== undefined) {
-                            displayWarningMessage(response.data.warnings.autograding_config);
-                        }
+                        console.log(response);
                         if (Array.isArray(response['data'])) {
                             if (response['data'].includes('rebuild_queued')) {
                                 ajaxCheckBuildStatus(gradeable_id, 'unknown');
+                            }
+                            for (const item of response['data']) {
+                                if (typeof item === "string" && item.includes("Warning")) {
+                                    displayWarningMessage(item.split("Warning:")[1].trim());
+                                }
                             }
                         }
                         setGradeableUpdateComplete();
@@ -632,12 +634,14 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
             url: buildCourseUrl(['gradeable', gradeable_id, 'update']),
             data: p_values,
             success: function (response) {
-                if (response?.data?.warnings?.autograding_config !== undefined) {
-                    displayWarningMessage(response.data.warnings.autograding_config);
-                }
                 if (Array.isArray(response['data'])) {
                     if (response['data'].includes('rebuild_queued')) {
                         ajaxCheckBuildStatus(gradeable_id, 'unknown');
+                    }
+                    for (const item of response['data']) {
+                        if (typeof item === "string" && item.includes("Warning")) {
+                            displayWarningMessage(item.split("Warning:")[1].trim());
+                        }
                     }
                 }
                 setGradeableUpdateComplete();

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -116,12 +116,12 @@ function updateGradeableErrorCallback(message, response_data) {
 }
 
 function parseUpdateGradeableResponseArray(response, gradeable_id) {
-    // Trigger periodic checks for latest build status
+    // Trigger periodic checks for latest rebuild status
     if (response.includes('rebuild_queued')) {
         ajaxCheckBuildStatus(gradeable_id, 'unknown');
     }
 
-    // Display potential warnings
+    // Display potential server-side warnings
     for (const item of response) {
         if (typeof item === 'string' && item.includes('Warning')) {
             displayWarningMessage(item.split('Warning:')[1].trim());

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -115,6 +115,20 @@ function updateGradeableErrorCallback(message, response_data) {
     updateErrorMessage();
 }
 
+function parseUpdateGradeableResponseArray(response, gradeable_id) {
+    // Trigger periodic checks for latest build status
+    if (response.includes('rebuild_queued')) {
+        ajaxCheckBuildStatus(gradeable_id, 'unknown');
+    }
+
+    // Display potential warnings
+    for (const item of response) {
+        if (typeof item === 'string' && item.includes('Warning')) {
+            displayWarningMessage(item.split('Warning:')[1].trim());
+        }
+    }
+}
+
 function updateDueDate() {
     const cont = $('#due_date_container');
     const cont1 = $('#late_days_options_container');
@@ -579,14 +593,7 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
                     data: p_values,
                     success: function (response) {
                         if (Array.isArray(response['data'])) {
-                            if (response['data'].includes('rebuild_queued')) {
-                                ajaxCheckBuildStatus(gradeable_id, 'unknown');
-                            }
-                            for (const item of response['data']) {
-                                if (typeof item === "string" && item.includes("Warning")) {
-                                    displayWarningMessage(item.split("Warning:")[1].trim());
-                                }
-                            }
+                            parseUpdateGradeableResponseArray(response['data'], gradeable_id);
                         }
                         setGradeableUpdateComplete();
                         if (response.status === 'success') {
@@ -634,14 +641,7 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
             data: p_values,
             success: function (response) {
                 if (Array.isArray(response['data'])) {
-                    if (response['data'].includes('rebuild_queued')) {
-                        ajaxCheckBuildStatus(gradeable_id, 'unknown');
-                    }
-                    for (const item of response['data']) {
-                        if (typeof item === "string" && item.includes("Warning")) {
-                            displayWarningMessage(item.split("Warning:")[1].trim());
-                        }
-                    }
+                    parseUpdateGradeableResponseArray(response['data'], gradeable_id);
                 }
                 setGradeableUpdateComplete();
                 if (response.status === 'success') {

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1,7 +1,7 @@
 /* global csrfToken, buildCourseUrl, displayErrorMessage, gradeable_max_autograder_points,
           is_electronic, onHasReleaseDate, reloadInstructorEditRubric, getItempoolOptions,
           isItempoolAvailable, getGradeableId, closeAllComponents, onHasDueDate, setPdfPageAssignment,
-          PDF_PAGE_INSTRUCTOR, PDF_PAGE_STUDENT, PDF_PAGE_NONE */
+          PDF_PAGE_INSTRUCTOR, PDF_PAGE_STUDENT, PDF_PAGE_NONE, displayWarningMessage */
 /* exported showBuildLog, ajaxRebuildGradeableButton, onPrecisionChange, onItemPoolOptionChange, updatePdfPageSettings */
 
 let updateInProgressCount = 0;
@@ -403,6 +403,7 @@ function ajaxCheckBuildStatus() {
         type: 'GET',
         url: buildCourseUrl(['gradeable', gradeable_id, 'build_status']),
         success: function (response) {
+            console.log(response);
             $('#rebuild-log-button').css('display', 'block');
             if (response['data'] === 'queued') {
                 $('#rebuild-status').html(gradeable_id.concat(' is in the rebuild queue...'));
@@ -578,6 +579,9 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
                     url: buildCourseUrl(['gradeable', gradeable_id, 'update']),
                     data: p_values,
                     success: function (response) {
+                        if (response?.data?.warnings?.autograding_config !== undefined) {
+                            displayWarningMessage(response.data.warnings.autograding_config);
+                        }
                         if (Array.isArray(response['data'])) {
                             if (response['data'].includes('rebuild_queued')) {
                                 ajaxCheckBuildStatus(gradeable_id, 'unknown');
@@ -628,6 +632,9 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
             url: buildCourseUrl(['gradeable', gradeable_id, 'update']),
             data: p_values,
             success: function (response) {
+                if (response?.data?.warnings?.autograding_config !== undefined) {
+                    displayWarningMessage(response.data.warnings.autograding_config);
+                }
                 if (Array.isArray(response['data'])) {
                     if (response['data'].includes('rebuild_queued')) {
                         ajaxCheckBuildStatus(gradeable_id, 'unknown');

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -578,7 +578,6 @@ function ajaxUpdateGradeableProperty(gradeable_id, p_values, successCallback, er
                     url: buildCourseUrl(['gradeable', gradeable_id, 'update']),
                     data: p_values,
                     success: function (response) {
-                        console.log(response);
                         if (Array.isArray(response['data'])) {
                             if (response['data'].includes('rebuild_queued')) {
                                 ajaxCheckBuildStatus(gradeable_id, 'unknown');


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Instructors can provide a `config.json` for their autograding configuration properties for a given assignment. The rebuild status of a JSON file with invalid syntax or duplicate keys may fail silently with warnings or explicitly state a build failure, where both cases lack clarity in the source of the error within the file. Fixes #11631.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

When autograding configuration files are uploaded or chosen, a simple warning is displayed with the respective error.

![image](https://github.com/user-attachments/assets/fcba2ddd-bdb8-4435-8766-7fb05f423716)

![image](https://github.com/user-attachments/assets/bce230c2-aa52-4746-8ed0-465c0f4c7d4e)

![image](https://github.com/user-attachments/assets/2907a8e4-b5bf-470b-9c6d-f1f4fac163b9)


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Create a gradeable that allows student file uploads
2. Manipulate a valid `config.json`, such as `more_autograding_examples/matlab/config/config.json`, to account for invalid syntax or duplicate keys (global or nested)
3. Notice warnings shown at the upload or update config.json stage

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

`UtilsTester.php` lacks a test scenario for `stripComments`, which is leveraged by this pull request. Therefore, I'll create an issue for this, as the Regex expression may lack robustness for all cases.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
N/A
