### PR TITLE
[Bugfix:Developer] Fix cypress service worker flake

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-  "source.fixAll.eslint": "always",
-  },
-  "editor.formatOnSave": false,
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+  "source.fixAll.eslint": "always",
+  },
+  "editor.formatOnSave": false,
+}

--- a/site/public/sw.js
+++ b/site/public/sw.js
@@ -11,7 +11,7 @@ self.addEventListener('install', (installEvent) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+    event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener('fetch', (fetchEvent) => {

--- a/site/public/sw.js
+++ b/site/public/sw.js
@@ -6,8 +6,12 @@ self.addEventListener('install', (installEvent) => {
     installEvent.waitUntil(
         caches.open(staticDevPort).then((cache) => {
             cache.addAll(assets);
-        }),
+        }).then(self.skipWaiting()),
     );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener('fetch', (fetchEvent) => {
@@ -16,8 +20,4 @@ self.addEventListener('fetch', (fetchEvent) => {
             return res || fetch(fetchEvent.request);
         }),
     );
-});
-
-self.addEventListener('activate', (event) => {
-    event.waitUntil(self.clients.claim());
 });

--- a/site/public/sw.js
+++ b/site/public/sw.js
@@ -17,3 +17,7 @@ self.addEventListener('fetch', (fetchEvent) => {
         }),
     );
 });
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Interminitenly both locally for some developers and on ci Cypress would give the error [`Cannot read properties of undefined (reading 'claim')`](https://github.com/Submitty/Submitty/actions/runs/15688170023/job/44196516776?pr=11675#step:8:281). This seems to be a known bug online that can occur when a service worker is registered but does not listen to the activate event.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The service worker now waits for the activate event as well as its existing behavior.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
