### PR TITLE
[Bugfix:System] Duplicate task name in course creation

### DIFF
--- a/.setup/ansible/playbooks/submitty_course_creation.yml
+++ b/.setup/ansible/playbooks/submitty_course_creation.yml
@@ -16,7 +16,7 @@
         submitty_term_creation_start_date: 01/01/2024
         submitty_term_creation_end_date: 06/07/2024
 
-    - name: Add instructor
+    - name: Add instructor Quinn
       ansible.builtin.include_role:
         name: submitty_add_user
       vars:
@@ -27,7 +27,7 @@
         submitty_add_user_password: instructor
 
     # This user is the github actions runner, delete if using on production.
-    - name: Add instructor
+    - name: Add instructor runner
       ansible.builtin.include_role:
         name: submitty_add_user
       vars:


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently in the Ansible playbook for course creation, there are two tasks with names "Add instructor". This change is important because our CI test for Ansible Lint fails as a result of the task names not being unique.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The tasks now have unique names and CI Ansible Lint should pass.

### What steps should a reviewer take to reproduce or test the bug or new feature?
You can test the bug by viewing CI tests in previous merged PRs.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
