### PR TITLE
[Bugfix:TAGrading] Mark component as modified

### DIFF
--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -527,6 +527,7 @@ class Component extends AbstractModel {
 
     public function setTitle(string $title): void {
         $this->title = $title;
+        $this->modified = true;
     }
 
     public function getTaComment(): string {
@@ -535,6 +536,7 @@ class Component extends AbstractModel {
 
     public function setTaComment(string $ta_comment): void {
         $this->ta_comment = $ta_comment;
+        $this->modified = true;
     }
 
     public function getStudentComment(): string {
@@ -543,6 +545,7 @@ class Component extends AbstractModel {
 
     public function setStudentComment(string $student_comment): void {
         $this->student_comment = $student_comment;
+        $this->modified = true;
     }
 
     public function getLowerClamp(): float {
@@ -567,6 +570,7 @@ class Component extends AbstractModel {
 
     public function setText(bool $is_text): void {
         $this->text = $is_text;
+        $this->modified = true;
     }
 
     public function isPeerComponent(): bool {
@@ -575,6 +579,7 @@ class Component extends AbstractModel {
 
     public function setPeerComponent(bool $is_peer_component): void {
         $this->peer_component = $is_peer_component;
+        $this->modified = true;
     }
 
     public function getOrder(): int {
@@ -583,6 +588,7 @@ class Component extends AbstractModel {
 
     public function setOrder(int $order): void {
         $this->order = $order;
+        $this->modified = true;
     }
 
     public function getPage(): int {
@@ -591,6 +597,7 @@ class Component extends AbstractModel {
 
     public function setIsItempoolLinked(bool $is_linked): void {
         $this->is_itempool_linked = $is_linked;
+        $this->modified = true;
     }
 
     public function getIsItempoolLinked(): bool {
@@ -599,6 +606,7 @@ class Component extends AbstractModel {
 
     public function setItempool(string $itempool_name): void {
         $this->itempool = $itempool_name;
+        $this->modified = true;
     }
 
     public function getItempool(): string {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Due to setting `Component::modified` inside:
https://github.com/Submitty/Submitty/blob/bcdd81478559d0c66552e2d494e91878b5c8a79a/site/app/models/AbstractModel.php#L131-L207
As we are removing the magic methods we have to make sure that we also set `modified` in all of the setters.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
All of the setters that did not update `Component::modified` now do.

### What steps should a reviewer take to reproduce or test the bug or new feature?
There is no way to currently produce incorrect behavior, since all code paths that lead to `saveComponent` either call it without the possibility of the component being edited or they call an existing `Component` setter as well as the new ones so `Component::modified` is already set to true.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
