### PR TITLE
[Bugfix:InstructorUI] Fix Edit Gradeable Page Errors

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -1778,7 +1778,7 @@ class AdminGradeableController extends AbstractController {
                 $logs = $this->getBuildLogs($gradeable_id);
 
                 $needle = 'The submitty configuration validator detected the above error in your config.';
-                $haystack = $logs->json['data'][0];
+                $haystack = $logs->json['data'][0] ?? '';
 
                 if (str_contains($haystack, 'MAKE ERROR')) {
                     $status = false;

--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -58,10 +58,6 @@
             $("#custom_marks_warning").show();
         }
         loadTemplates().then(function() {
-            if ($('#silent-edit-id').length === 0) {
-                return;
-            }
-
             reloadInstructorEditRubric($('#g_id').val(), $('#gradeable_rubric').attr('data-notebook'), JSON.parse($('#gradeable_rubric').attr('data-itempool-options'))).then( function() {
                 const componentContainer = document.querySelector('.component-container');
                 if (componentContainer) {

--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -58,17 +58,29 @@
             $("#custom_marks_warning").show();
         }
         loadTemplates().then(function() {
+            if (!window.reloadInstructorEditRubric) return;
+
             reloadInstructorEditRubric($('#g_id').val(), $('#gradeable_rubric').attr('data-notebook'), JSON.parse($('#gradeable_rubric').attr('data-itempool-options'))).then( function() {
-                $('body').on('DOMSubtreeModified', '.component-container', function() {
-                    let yesPeer = ($('.peer-component-container').length == 0) ? false : true;
-                    if (yesPeer) {
-                        $('#page_4_nav').show();
-                        $('#page_4_nav').removeClass("hidden-no-peers");
-                    } else {
-                        $('#page_4_nav').hide();
-                        $('#page_4_nav').addClass("hidden-no-peers");
-                    }
-                });
+                const componentContainer = document.querySelector('.component-container');
+                if (componentContainer) {
+                    const observer = new MutationObserver(() => {
+                        let yesPeer = ($('.peer-component-container').length == 0) ? false : true;
+                        if (yesPeer) {
+                            $('#page_4_nav').show();
+                            $('#page_4_nav').removeClass("hidden-no-peers");
+                        } else {
+                            $('#page_4_nav').hide();
+                            $('#page_4_nav').addClass("hidden-no-peers");
+                        }
+                    });
+
+                    observer.observe(componentContainer, {
+                        childList: true,
+                        subtree: true
+                    });
+                }
+            }).catch((error) => {
+                console.error('Failed to call reloadInstructorEditRubric', error);
             });
         });
         //toggle warning message if custom marks have already been used and the settings are changed

--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -58,7 +58,7 @@
             $("#custom_marks_warning").show();
         }
         loadTemplates().then(function() {
-            if (!window.reloadInstructorEditRubric) return;
+            if (!$('#silent-edit-id')) return;
 
             reloadInstructorEditRubric($('#g_id').val(), $('#gradeable_rubric').attr('data-notebook'), JSON.parse($('#gradeable_rubric').attr('data-itempool-options'))).then( function() {
                 const componentContainer = document.querySelector('.component-container');

--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -58,7 +58,9 @@
             $("#custom_marks_warning").show();
         }
         loadTemplates().then(function() {
-            if (!$('#silent-edit-id')) return;
+            if ($('#silent-edit-id').length === 0) {
+                return;
+            }
 
             reloadInstructorEditRubric($('#g_id').val(), $('#gradeable_rubric').attr('data-notebook'), JSON.parse($('#gradeable_rubric').attr('data-itempool-options'))).then( function() {
                 const componentContainer = document.querySelector('.component-container');

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -921,10 +921,16 @@ function setupSimpleGrading(action) {
     $('#student-search-input').on('keydown', () => {
         highlightOnSingleMatch(false);
     });
-    $('#student-search').on('DOMSubtreeModified', () => {
-        highlightOnSingleMatch(true);
-    });
-
+    const studentSearch = document.querySelector('#student-search');
+    if (studentSearch) {
+        const observer = new MutationObserver(() => {
+            highlightOnSingleMatch(true);
+        });
+        observer.observe(studentSearch, {
+            childList: true,
+            subtree: true,
+        });
+    }
     // clear the input field when it is focused
     $('#student-search-input').on('focus', function () {
         $(this).val('');

--- a/site/public/templates/grading/Gradeable.twig
+++ b/site/public/templates/grading/Gradeable.twig
@@ -44,8 +44,12 @@
                 });
         }
     }
-    // Will work for Chrome
-    window.onbeforeunload = unloadSave;
-    // Will work for other browsers
-    window.onunload = unloadSave;
+
+    if (navigator.userAgent.indexOf('Chrome') > -1) {
+        // Will work for Chrome
+        window.onbeforeunload = unloadSave;
+    } else {
+        // Will work for other browsers
+        window.onunload = unloadSave;
+    }
 </script>

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -760,7 +760,7 @@ function initializeTaLayout() {
             setPanelsVisibilities(taLayoutDet.currentOpenPanel);
         }
     }
-    if (taLayoutDet.isFullScreenMode && document.getElementById('grading-panel-header') !== null) {
+    if (taLayoutDet.isFullScreenMode && $('#silent-edit-id').length !== 0) {
         toggleFullScreenMode();
     }
     updateLayoutDimensions();

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -230,12 +230,11 @@ $(() => {
     });
 
     window.addEventListener('resize', () => {
-        const name_div = $('#grading-panel-student-name');
-        const panel_div = $('.panels-container');
-        if (name_div.length === 0 || panel_div.length === 0) {
-            // Ignore undefined panel elements on specific pages, such as the edit gradeable page
+        if ($('#silent-edit-id').length === 0) {
             return;
         }
+        const name_div = $('#grading-panel-student-name');
+        const panel_div = $('.panels-container');
         // have to calculate the height since the item is positioned absolutely
         const height = panel_div[0].getClientRects()[0].top - name_div.closest('.content-item')[0].getClientRects()[0].top;
         const padding_bottom = 12;

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -231,8 +231,13 @@ $(() => {
 
     window.addEventListener('resize', () => {
         const name_div = $('#grading-panel-student-name');
+        const panel_div = $('.panels-container');
+        if (name_div.length === 0 || panel_div.length === 0) {
+            // Ignore undefined panel elements on specific pages, such as the edit gradeable page
+            return;
+        }
         // have to calculate the height since the item is positioned absolutely
-        const height = $('.panels-container')[0].getClientRects()[0].top - name_div.closest('.content-item')[0].getClientRects()[0].top;
+        const height = panel_div[0].getClientRects()[0].top - name_div.closest('.content-item')[0].getClientRects()[0].top;
         const padding_bottom = 12;
         name_div.css('height', height - padding_bottom);
         name_div.show();

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -761,7 +761,7 @@ function initializeTaLayout() {
             setPanelsVisibilities(taLayoutDet.currentOpenPanel);
         }
     }
-    if (taLayoutDet.isFullScreenMode) {
+    if (taLayoutDet.isFullScreenMode && document.getElementById('grading-panel-header') !== null) {
         toggleFullScreenMode();
     }
     updateLayoutDimensions();


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

The edit gradable page displays numerous console errors during the initial load and when the window is resized. While functionality remains mostly intact, some users, particularly on Chrome, have reported issues with broken sidebar rendering, which is caused by TA grading parameters being applied to this specific page as well.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

The following errors are the ones I was able to capture and address within this patch, which display occasionally on the main branch and shouldn't be shown anymore when the editable page is initially loaded or resized. Many type errors and deprecated warnings have been addressed, such as moving away from `DOMSubtreeModified` and `window.onunload`. Additionally, the full-screen mode should no longer be applied within this page.

```
[Error]
[Deprecation] Listener added for a 'DOMSubtreeModified' mutation event. Support for this event type has been removed, and this event will no longer be fired. See https://chromestatus.com/feature/5083947249172480 for more information.
add @ jquery.min.js?v=1750335357:2
(anonymous) @ jquery.min.js?v=1750335357:2
each @ jquery.min.js?v=1750335357:2
each @ jquery.min.js?v=1750335357:2
Le @ jquery.min.js?v=1750335357:2
on @ jquery.min.js?v=1750335357:2
(anonymous) @ update?nav_tab=0:2243
Promise.then
(anonymous) @ update?nav_tab=0:2242
Promise.then
(anonymous) @ update?nav_tab=0:2241
e @ jquery.min.js?v=1750335357:2
t @ jquery.min.js?v=1750335357:2
setTimeout
(anonymous) @ jquery.min.js?v=1750335357:2
c @ jquery.min.js?v=1750335357:2
fireWith @ jquery.min.js?v=1750335357:2
fire @ jquery.min.js?v=1750335357:2
c @ jquery.min.js?v=1750335357:2
fireWith @ jquery.min.js?v=1750335357:2
ready @ jquery.min.js?v=1750335357:2
P @ jquery.min.js?v=1750335357:2

[Error]
admin-gradeable-upda…js?v=1750336026:438 Failed to parse response from server: [object Object]
"<br />

[Server Response]
<b>Deprecated</b>:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in <b>/usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php</b> on line <b>1783</b><br />
<br />
<b>Deprecated</b>:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in <b>/usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php</b> on line <b>1786</b><br />
{
    "status": "success",
    "data": true
}"

[Error]
Uncaught (in promise) ReferenceError: reloadInstructorEditRubric is not defined
    at update?nav_tab=0:2242:13

[Deprecated Feature Issue]
Unload event listeners are deprecated and will be removed.

1 source
(unknown)
```
Before (full screen mode persistence)
![image](https://github.com/user-attachments/assets/a3c4e6c8-f034-4f94-8c1c-98916d4a7599)


After
![image](https://github.com/user-attachments/assets/315d06e6-17e1-4b5b-9aa3-eb13d14c6b1d)


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Visit the edit gradeable page on the main branch
2. Notice console errors and browser-specific issues when loading and resizing the page
3. Visit the same page on this branch
4. Notice no console errors (outside of flatpickr for Chrome)
5. For full-screen mode verification, toggle the mode within a grading panel page, then revisit the edit gradeable page to see no UI rendering issues

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
N/A

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

I keep getting the following error on Chrome, specifically within this page, but when I compare the DOM structure across different browsers, Chrome tends to have a completely different structure. Addressing this issue is outside the scope of this PR and should be addressed in a future one.

```
[Error]
TypeError: Cannot read properties of undefined (reading 'appendChild')
    at Object.onReady (index.ts:169:38)
    at De (flatpickr.min.js?v=1750335357:2:35446)
    at flatpickr.min.js?v=1750335357:2:49325
    at k (flatpickr.min.js?v=1750335357:2:49339)
    at T (flatpickr.min.js?v=1750335357:2:49626)
    at I (flatpickr.min.js?v=1750335357:2:50016)
    at HTMLDocument.<anonymous> (update?nav_tab=1:5531:9)
    at e (jquery.min.js?v=1750335357:2:27028)
    at t (jquery.min.js?v=1750335357:2:27330)
```
