### PR TITLE
[Bugfix:TAGrading] Always show new columns in TAGrading

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -81,30 +81,8 @@
         'component': 'toggleColumns',
         'style': 'display: inline;',
         'args': {
-            'columns': [
-                "index",
-                "section",
-                "user_id",
-                "user_given",
-                "user_family",
-                "autograding",
-                "graded_questions",
-                "total",
-                "grading",
-                "active_version"
-            ],
-            'labels': [
-                "# / Count / Index",
-                "Section",
-                "User ID",
-                "User Given",
-                "User Family",
-                "Autograding",
-                "Graded Questions",
-                "Total",
-                "Grading",
-                "Active Version"
-            ],
+            'columns': all_columns|map(column => column.function),
+            'labels': all_columns|map(column => column.title),
             'forced': [
                 'grading'
             ],

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -891,11 +891,11 @@ HTML;
                 $team_gradeable_view_history[$team_id]['hover_string'] = $hover_over_string;
             }
         }
-        if (count($grading_details_columns) > 0) {
-            $columns = array_filter($columns, function ($column) use ($grading_details_columns) {
-                return array_key_exists($column['function'], $grading_details_columns) && $grading_details_columns[$column['function']];
-            });
-        }
+
+        $shown_columns = array_filter($columns, function ($column) use ($grading_details_columns) {
+            return !array_key_exists($column['function'], $grading_details_columns) || $grading_details_columns[$column['function']];
+        });
+
         $details_base_url = $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'details']);
         $details_base_path = '\/gradeable\/' . $gradeable->getId() . '/grading/details';
         $this->core->getOutput()->addInternalCss('details.css');
@@ -923,7 +923,8 @@ HTML;
             "show_import_teams_button" => $show_import_teams_button,
             "show_export_teams_button" => $show_export_teams_button,
             "past_grade_start_date" => $past_grade_start_date,
-            "columns" => $columns,
+            "columns" => $shown_columns,
+            "all_columns" => $columns,
             "export_teams_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'teams', 'export']),
             "randomize_team_rotating_sections_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'teams', 'randomize_rotating']),
             "grade_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'grade']),

--- a/site/vue/src/components/toggleColumns.vue
+++ b/site/vue/src/components/toggleColumns.vue
@@ -38,7 +38,7 @@ function loadColumns() {
 }
 function saveColumns() {
     if (format === 'json') {
-        const cookieData: Record<string, boolean> = {};
+        const cookieData: Record<string, boolean> = JSON.parse(decodeURIComponent(Cookies.get(cookie) ?? encodeURIComponent('{}'))) as Record<string, boolean>;
         columns.forEach((col, i) => {
             cookieData[col] = selected.value[i];
         });


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When switching between different TAGrading views, there is a regression in #11487 that means non-default columns will be hidden by default. Sometimes it does not even show toggles to enable the new columns.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The list of columns is dynamic and automatically enabled for any columns that have not yet been seen by the user.
Fix #11754 

### What steps should a reviewer take to reproduce or test the bug or new feature?
On main:
1. Open the grading details page
2. Turn off first and last name
3. switch to anon mode

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
