### PR TITLE
[Refactor:InstructorUI] Improve Docker Sorting & Column Order

### DIFF
--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -94,7 +94,7 @@
                 {{ self.sortable_header('Image Name', 'name') }}
                 <th>Tag</th>
                 <th>Alias</th>
-                <th>Digest/Id</th>
+                <th>Id</th>
                 {{ self.sortable_header('Size', 'size') }}
                 {{ self.sortable_header('Created', 'created') }}
                 <th>Capabilities Containing This Image</th>

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -92,13 +92,13 @@
         <thead>
             <tr>
                 {{ self.sortable_header('Image Name', 'name') }}
-                <th>Owner</th>
+                <th>Tag</th>
+                <th>Alias</th>
                 <th>Id</th>
                 {{ self.sortable_header('Size', 'size') }}
-                <th>Tag</th>
                 {{ self.sortable_header('Created', 'created') }}
-                <th>Alias</th>
                 <th>Capabilities Containing This Image</th>
+                <th>Owner</th>
                 <th>Remove</th>
             </tr>
         </thead>
@@ -111,11 +111,7 @@
 
             <tr class="image-row" >
                 <td>{{ name }}</td>
-                <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>
-                <td>{{ image.id | trim("sha256:")}}</td>
-                <td>{{ image.size_mb }}</td>
                 <td>{{ tag }}</td>
-                <td>{{ image.created_timestamp }}</td>
                 <td>
                     {% if image.aliases|length > 0 %}
                         <ul class="tag-list">
@@ -125,11 +121,15 @@
                         </ul>
                     {% endif %}
                 </td>
+                <td>{{ image.id | trim("sha256:")}}</td>
+                <td>{{ image.size_mb }}</td>
+                <td>{{ image.created_timestamp }}</td>
                 <td>
                     {% for capability in image.capabilities %}
                         <span class="badge badge-{{ capability_to_color_mapping[capability] % 8 + 1 }}">{{capability}}</span>
                     {% endfor %}
                 </td>
+                <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>
                 <td>
                     {% if is_super_user or (docker_image_owners[image.primary_name] is defined and user_id == docker_image_owners[image.primary_name]) %}
                         <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" onclick=confirmationDialog("{{admin_url}}/remove_image",id)>Remove</button>

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -94,7 +94,7 @@
                 {{ self.sortable_header('Image Name', 'name') }}
                 <th>Tag</th>
                 <th>Alias</th>
-                <th>Id</th>
+                <th>Digest/Id</th>
                 {{ self.sortable_header('Size', 'size') }}
                 {{ self.sortable_header('Created', 'created') }}
                 <th>Capabilities Containing This Image</th>

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -185,7 +185,7 @@ function applySort(sortKey, direction) {
     const table = document.getElementById('docker-table');
     const tbody = table.querySelector('tbody');
     const rows = Array.from(tbody.querySelectorAll('tr'));
-    const colMap = { name: 0, size: 3, created: 5 };
+    const colMap = { name: 0, size: 4, created: 5 };
     const colIndex = colMap[sortKey];
 
     rows.sort((rowA, rowB) => {
@@ -193,11 +193,22 @@ function applySort(sortKey, direction) {
         const bText = rowB.children[colIndex].textContent.trim();
         let cmp = 0;
         if (sortKey === 'name') {
-            const [nameA, tagA = ''] = aText.split(':');
-            const [nameB, tagB = ''] = bText.split(':');
+            const nameA = rowA.children[0].textContent.trim();
+            const nameB = rowB.children[0].textContent.trim();
             cmp = nameA.localeCompare(nameB);
             if (cmp === 0) {
-                cmp = tagA.localeCompare(tagB);
+                const tagA = rowA.children[1].textContent.trim();
+                const tagB = rowB.children[1].textContent.trim();
+                const numA = parseFloat(tagA);
+                const numB = parseFloat(tagB);
+                const isNumA = !isNaN(numA);
+                const isNumB = !isNaN(numB);
+                if (isNumA && isNumB) {
+                    cmp = numA - numB;
+                }
+                else {
+                    cmp = tagA.localeCompare(tagB);
+                }
             }
         }
         else if (sortKey === 'size') {

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -203,12 +203,14 @@ function applySort(sortKey, direction) {
                 const numB = parseFloat(tagB);
                 const isNumA = !isNaN(numA);
                 const isNumB = !isNaN(numB);
+                // Tag is descending regardless of Image Name
                 if (isNumA && isNumB) {
-                    cmp = numA - numB;
+                    cmp = numB - numA;
                 }
                 else {
-                    cmp = tagA.localeCompare(tagB);
+                    cmp = tagB.localeCompare(tagA);
                 }
+                return cmp;
             }
         }
         else if (sortKey === 'size') {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Sorting columns by `Image Name` in the DockerUI does not have any tiebreakers when the names are the same. Additionally, the ordering of the columns is not intuitive. This affect the user experience, especially when there are many images present on the page.

### What is the New Behavior?
Sorting columns by `Image Name` now uses the `Tag` column for tiebreakers. The `Tag` column is always sorted in descending order, so that the latest version is at the top.

Column Ordering Refactor:
**Before:**  Image Name | Owner | Id | Size | Tag | Created | Alias | Capabilities | Remove
**After:** Image Name | Tag | Alias | Id | Size | Capabilities | Owner | Remove

### To Test:
Add duplicate images with different tag names to the Docker UI, ensure sorting uses tags as the tiebreaker.

### Other information
This is not a breaking change

_Both images here use the same sort method (Image Name ascending). Observe the differences in how tiebreakers are resolved._
## Before
![Old dockerui bad sorting and standard id](https://github.com/user-attachments/assets/3983ad36-5421-4834-a835-fdf21b6ee078)

## After
![New Autograding docker images with tag tb plus digest](https://github.com/user-attachments/assets/db81945c-acc2-4120-8a02-f58823cd04bc)