### PR TITLE
[Refactor:TAGrading] Move All Autoran code out of TS

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1244,7 +1244,9 @@ HTML;
         $this->core->getOutput()->addInternalModuleJs('ta-grading-rubric.js');
         $this->core->getOutput()->addInternalModuleJs('panel-selector-modal.js');
         $this->core->getOutput()->addInternalModuleJs('ta-grading-keymap.js');
+        $this->core->getOutput()->addInternalModuleJs('ta-grading-keymap-init.js');
         $this->core->getOutput()->addInternalModuleJs('ta-grading.js');
+        $this->core->getOutput()->addInternalModuleJs('ta-grading-init.js');
         $this->core->getOutput()->addInternalModuleJs('ta-grading-navigation.js');
         $this->core->getOutput()->addInternalModuleJs('ta-grading-panels.js');
 

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -74,6 +74,7 @@ class SimpleGraderView extends AbstractView {
 
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('twigjs', 'twig.min.js'));
         $this->core->getOutput()->addInternalModuleJs('ta-grading-keymap.js');
+        $this->core->getOutput()->addInternalModuleJs('ta-grading-keymap-init.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $this->core->getOutput()->addInternalJs('simple-grading.js');
         $this->core->getOutput()->addInternalCss('simple-grading.css');

--- a/site/ts/ta-grading-init.ts
+++ b/site/ts/ta-grading-init.ts
@@ -1,0 +1,297 @@
+import { changeStudentArrowTooltips } from './ta-grading';
+import { loadTAGradingSettingData, registerKeyHandler, settingsData } from './ta-grading-keymap';
+import { gotoNextStudent, gotoPrevStudent } from './ta-grading-navigation';
+import {
+    closeComponent,
+    CUSTOM_MARK_ID,
+    getComponentIdByOrder,
+    getFirstOpenComponentId,
+    getMarkIdFromOrder,
+    getNextComponentId,
+    getPrevComponentId,
+    NO_COMPONENT_ID,
+    onToggleEditMode,
+    scrollToComponent,
+    scrollToOverallComment,
+    toggleCommonMark,
+    toggleComponent as oldToggleComponent,
+} from './ta-grading-rubric';
+
+const settingsCallbacks = {
+    'general-setting-arrow-function': changeStudentArrowTooltips,
+    'general-setting-navigate-assigned-students-only': function (
+        value: string,
+    ) {
+        // eslint-disable-next-line eqeqeq
+        if (value == 'true') {
+            window.Cookies.set('view', 'assigned', { path: '/' });
+        }
+        else {
+            window.Cookies.set('view', 'all', { path: '/' });
+        }
+    },
+};
+
+function checkOpenComponentMark(index: number) {
+    const component_id = getFirstOpenComponentId();
+    if (component_id !== NO_COMPONENT_ID) {
+        const mark_id = getMarkIdFromOrder(component_id, index);
+        // TODO: Custom mark id is zero as well, should use something unique
+        if (mark_id === CUSTOM_MARK_ID || mark_id === 0) {
+            return;
+        }
+        void toggleCommonMark(component_id, mark_id).catch((err: { message: string }) => {
+            console.error(err);
+            alert(`Error toggling mark! ${err.message}`);
+        });
+    }
+}
+
+async function toggleComponent(component_id: number, saveChanges: boolean, edit_mode: boolean): Promise<void> {
+    void edit_mode; // to avoid unused variable warning
+    await oldToggleComponent(component_id, saveChanges);
+    changeStudentArrowTooltips(
+        localStorage.getItem('general-setting-arrow-function') || 'default',
+    );
+}
+
+// Navigate to the prev / next student buttons
+registerKeyHandler({ name: 'Previous Student', code: 'ArrowLeft' }, () => {
+    gotoPrevStudent();
+});
+registerKeyHandler({ name: 'Next Student', code: 'ArrowRight' }, () => {
+    gotoNextStudent();
+});
+
+// Key handler / shorthand for toggling in between panels
+registerKeyHandler({ name: 'Toggle Autograding Panel', code: 'KeyA' }, () => {
+    $('#autograding_results_btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler({ name: 'Toggle Rubric Panel', code: 'KeyG' }, () => {
+    $('#grading_rubric_btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler({ name: 'Toggle Submissions Panel', code: 'KeyO' }, () => {
+    $('#submission_browser_btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler(
+    { name: 'Toggle Student Information Panel', code: 'KeyS' },
+    () => {
+        $('#student_info_btn button').trigger('click');
+        window.updateCookies();
+    },
+);
+registerKeyHandler({ name: 'Toggle Grade Inquiry Panel', code: 'KeyX' }, () => {
+    $('#grade_inquiry_info_btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler({ name: 'Toggle Discussion Panel', code: 'KeyD' }, () => {
+    $('#discussion_browser_btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler({ name: 'Toggle Peer Panel', code: 'KeyP' }, () => {
+    $('#peer_info_btn button').trigger('click');
+    window.updateCookies();
+});
+
+registerKeyHandler({ name: 'Toggle Notebook Panel', code: 'KeyN' }, () => {
+    $('#notebook-view-btn button').trigger('click');
+    window.updateCookies();
+});
+registerKeyHandler(
+    { name: 'Toggle Solution/TA-Notes Panel', code: 'KeyT' },
+    () => {
+        $('#solution_ta_notes_btn button').trigger('click');
+        window.updateCookies();
+    },
+);
+
+registerKeyHandler({ name: 'Open Next Component', code: 'ArrowDown' }, (e: { preventDefault: () => void }) => {
+    const openComponentId = getFirstOpenComponentId();
+    const numComponents = $('#component-list').find(
+        '.component-container',
+    ).length;
+
+    // Note: we use the 'toggle' functions instead of the 'open' functions
+    //  Since the 'open' functions don't close any components
+    if (openComponentId === NO_COMPONENT_ID) {
+        // No component is open, so open the first one
+        const componentId = getComponentIdByOrder(0);
+        void toggleComponent(componentId, true, false).then(() => {
+            scrollToComponent(componentId);
+        });
+    }
+    else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
+        // Last component is open, close it and then open and scroll to first component
+        void closeComponent(openComponentId, true).then(() => {
+            const componentId = getComponentIdByOrder(0);
+            void toggleComponent(componentId, true, false).then(() => {
+                scrollToComponent(componentId);
+            });
+        });
+    }
+    else {
+        // Any other case, open the next one
+        const nextComponentId = getNextComponentId(openComponentId);
+        void toggleComponent(nextComponentId, true, false).then(() => {
+            scrollToComponent(nextComponentId);
+        });
+    }
+    e.preventDefault();
+});
+
+registerKeyHandler(
+    { name: 'Open Previous Component', code: 'ArrowUp' },
+    (e: { preventDefault: () => void }) => {
+        const openComponentId = getFirstOpenComponentId();
+        const numComponents = $('#component-list').find(
+            '.component-container',
+        ).length;
+
+        // Note: we use the 'toggle' functions instead of the 'open' functions
+        //  Since the 'open' functions don't close any components
+        if (openComponentId === NO_COMPONENT_ID) {
+            // No Component is open, so open the overall comment
+            // Targets the box outside of the container, can use tab to focus comment
+            // TODO: Add "Overall Comment" focusing, control
+            scrollToOverallComment();
+        }
+        else if (openComponentId === getComponentIdByOrder(0)) {
+            // First component is open, close it and then open and scroll to the last one
+            void closeComponent(openComponentId, true).then(() => {
+                const componentId = getComponentIdByOrder(numComponents - 1);
+                void toggleComponent(componentId, true, false).then(() => {
+                    scrollToComponent(componentId);
+                });
+            });
+        }
+        else {
+            // Any other case, open the previous one
+            const prevComponentId = getPrevComponentId(openComponentId);
+            void toggleComponent(prevComponentId, true, false).then(() => {
+                scrollToComponent(prevComponentId);
+            });
+        }
+        e.preventDefault();
+    },
+);
+
+// -----------------------------------------------------------------------------
+// Misc rubric options
+registerKeyHandler({ name: 'Toggle Rubric Edit Mode', code: 'KeyE' }, () => {
+    const editBox = $('#edit-mode-enabled');
+    editBox.prop('checked', !editBox.prop('checked'));
+    void onToggleEditMode();
+    window.updateCookies();
+});
+
+// -----------------------------------------------------------------------------
+// Selecting marks
+
+registerKeyHandler(
+    { name: 'Select Full/No Credit Mark', code: 'Digit0' },
+    () => {
+        checkOpenComponentMark(0);
+    },
+);
+registerKeyHandler({ name: 'Select Mark 1', code: 'Digit1' }, () => {
+    checkOpenComponentMark(1);
+});
+registerKeyHandler({ name: 'Select Mark 2', code: 'Digit2' }, () => {
+    checkOpenComponentMark(2);
+});
+registerKeyHandler({ name: 'Select Mark 3', code: 'Digit3' }, () => {
+    checkOpenComponentMark(3);
+});
+registerKeyHandler({ name: 'Select Mark 4', code: 'Digit4' }, () => {
+    checkOpenComponentMark(4);
+});
+registerKeyHandler({ name: 'Select Mark 5', code: 'Digit5' }, () => {
+    checkOpenComponentMark(5);
+});
+registerKeyHandler({ name: 'Select Mark 6', code: 'Digit6' }, () => {
+    checkOpenComponentMark(6);
+});
+registerKeyHandler({ name: 'Select Mark 7', code: 'Digit7' }, () => {
+    checkOpenComponentMark(7);
+});
+registerKeyHandler({ name: 'Select Mark 8', code: 'Digit8' }, () => {
+    checkOpenComponentMark(8);
+});
+registerKeyHandler({ name: 'Select Mark 9', code: 'Digit9' }, () => {
+    checkOpenComponentMark(9);
+});
+
+window.Twig.twig({
+    id: 'Attachments',
+    href: '/templates/grading/Attachments.twig',
+    async: true,
+});
+
+$(() => {
+    loadTAGradingSettingData();
+
+    for (let i = 0; i < settingsData.length; i++) {
+        for (let x = 0; x < settingsData[i].values.length; x++) {
+            const storageCode = settingsData[i].values[x].storageCode;
+            const item = localStorage.getItem(storageCode);
+            if (
+                item
+                && Object.prototype.hasOwnProperty.call(
+                    settingsCallbacks,
+                    storageCode,
+                )
+            ) {
+                if (storageCode in settingsCallbacks) {
+                    settingsCallbacks[storageCode as keyof typeof settingsCallbacks](item);
+                }
+            }
+        }
+    }
+
+    $('#settings-popup').on(
+        'change',
+        '.ta-grading-setting-option',
+        function () {
+            const storageCode = $(this).attr('data-storage-code');
+            if (storageCode) {
+                localStorage.setItem(storageCode, (this as HTMLSelectElement).value);
+                if (
+                    settingsCallbacks
+                    && Object.prototype.hasOwnProperty.call(
+                        settingsCallbacks,
+                        storageCode,
+                    )
+                ) {
+                    settingsCallbacks[storageCode as keyof typeof settingsCallbacks]((this as HTMLSelectElement).value);
+                    if ((this as HTMLSelectElement).value !== 'active-inquiry') {
+                        // if user change setting to non-grade inquiry option, change the inquiry_status to off and set inquiry_status to off in grading index page
+                        window.Cookies.set('inquiry_status', 'off');
+                    }
+                    else {
+                        window.Cookies.set('inquiry_status', 'on');
+                    }
+                }
+            }
+        },
+    );
+
+    // Progress bar value
+    const value = $('.progressbar').val() ?? 0;
+    $('.progress-value').html(`<b>${String(value)}%</b>`);
+
+    if (
+        localStorage.getItem('notebook-setting-file-submission-expand')
+        === 'true'
+    ) {
+        const notebookPanel = $('#notebook-view');
+        if (notebookPanel.length !== 0) {
+            const notebookItems = notebookPanel.find('.openAllFilesubmissions');
+            for (let i = 0; i < notebookItems.length; i++) {
+                $(notebookItems[i]).trigger('click');
+            }
+        }
+    }
+});

--- a/site/ts/ta-grading-keymap-init.ts
+++ b/site/ts/ta-grading-keymap-init.ts
@@ -1,0 +1,11 @@
+window.Twig.twig({
+    id: 'HotkeyList',
+    href: '/templates/grading/settings/HotkeyList.twig',
+    async: true,
+});
+
+window.Twig.twig({
+    id: 'GeneralSettingList',
+    href: '/templates/grading/settings/GeneralSettingList.twig',
+    async: true,
+});

--- a/site/ts/ta-grading-keymap.ts
+++ b/site/ts/ta-grading-keymap.ts
@@ -15,10 +15,8 @@ declare global {
     }
 }
 
-// eslint-disable-next-line no-var
-var keymap: KeymapEntry<unknown>[] = [];
-// eslint-disable-next-line no-var
-var remapping = {
+const keymap: KeymapEntry<unknown>[] = [];
+const remapping = {
     active: false,
     index: 0,
 };
@@ -166,12 +164,6 @@ window.showSettings = function () {
     captureTabInModal('settings-popup');
 };
 
-window.Twig.twig({
-    id: 'HotkeyList',
-    href: '/templates/grading/settings/HotkeyList.twig',
-    async: true,
-});
-
 window.restoreAllHotkeys = function () {
     keymap.forEach((hotkey, index) => {
         updateKeymapAndStorage(index, hotkey.originalCode!);
@@ -198,12 +190,6 @@ function generateHotkeysList() {
         })),
     }));
 }
-
-window.Twig.twig({
-    id: 'GeneralSettingList',
-    href: '/templates/grading/settings/GeneralSettingList.twig',
-    async: true,
-});
 
 /**
  * Generate list of settings on the ui

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -1,22 +1,9 @@
-import { loadTAGradingSettingData, registerKeyHandler, settingsData } from './ta-grading-keymap';
-import { gotoNextStudent, gotoPrevStudent } from './ta-grading-navigation';
 import {
-    closeComponent,
-    CUSTOM_MARK_ID,
     getAnonId,
-    getComponentIdByOrder,
     getFirstOpenComponentId,
     getGradeableId,
-    getMarkIdFromOrder,
-    getNextComponentId,
-    getPrevComponentId,
     isSilentEditModeEnabled,
     NO_COMPONENT_ID,
-    toggleComponent as oldToggleComponent,
-    onToggleEditMode,
-    scrollToComponent,
-    scrollToOverallComment,
-    toggleCommonMark,
 } from './ta-grading-rubric';
 
 declare global {
@@ -45,88 +32,7 @@ declare global {
 // Used to reset users cookies
 const cookie_version = 1;
 
-const settingsCallbacks = {
-    'general-setting-arrow-function': changeStudentArrowTooltips,
-    'general-setting-navigate-assigned-students-only': function (
-        value: string,
-    ) {
-        // eslint-disable-next-line eqeqeq
-        if (value == 'true') {
-            window.Cookies.set('view', 'assigned', { path: '/' });
-        }
-        else {
-            window.Cookies.set('view', 'all', { path: '/' });
-        }
-    },
-};
-
-$(() => {
-    loadTAGradingSettingData();
-
-    for (let i = 0; i < settingsData.length; i++) {
-        for (let x = 0; x < settingsData[i].values.length; x++) {
-            const storageCode = settingsData[i].values[x].storageCode;
-            const item = localStorage.getItem(storageCode);
-            if (
-                item
-                && Object.prototype.hasOwnProperty.call(
-                    settingsCallbacks,
-                    storageCode,
-                )
-            ) {
-                if (storageCode in settingsCallbacks) {
-                    settingsCallbacks[storageCode as keyof typeof settingsCallbacks](item);
-                }
-            }
-        }
-    }
-
-    $('#settings-popup').on(
-        'change',
-        '.ta-grading-setting-option',
-        function () {
-            const storageCode = $(this).attr('data-storage-code');
-            if (storageCode) {
-                localStorage.setItem(storageCode, (this as HTMLSelectElement).value);
-                if (
-                    settingsCallbacks
-                    && Object.prototype.hasOwnProperty.call(
-                        settingsCallbacks,
-                        storageCode,
-                    )
-                ) {
-                    settingsCallbacks[storageCode as keyof typeof settingsCallbacks]((this as HTMLSelectElement).value);
-                    if ((this as HTMLSelectElement).value !== 'active-inquiry') {
-                        // if user change setting to non-grade inquiry option, change the inquiry_status to off and set inquiry_status to off in grading index page
-                        window.Cookies.set('inquiry_status', 'off');
-                    }
-                    else {
-                        window.Cookies.set('inquiry_status', 'on');
-                    }
-                }
-            }
-        },
-    );
-
-    // Progress bar value
-    const value = $('.progressbar').val() ?? 0;
-    $('.progress-value').html(`<b>${String(value)}%</b>`);
-
-    if (
-        localStorage.getItem('notebook-setting-file-submission-expand')
-        === 'true'
-    ) {
-        const notebookPanel = $('#notebook-view');
-        if (notebookPanel.length !== 0) {
-            const notebookItems = notebookPanel.find('.openAllFilesubmissions');
-            for (let i = 0; i < notebookItems.length; i++) {
-                $(notebookItems[i]).trigger('click');
-            }
-        }
-    }
-});
-
-function changeStudentArrowTooltips(data: string) {
+export function changeStudentArrowTooltips(data: string) {
     const inquiry_status = window.Cookies.get('inquiry_status');
     if (inquiry_status === 'on') {
         data = 'active-inquiry';
@@ -317,14 +223,6 @@ function changeStudentArrowTooltips(data: string) {
     }
 }
 
-async function toggleComponent(component_id: number, saveChanges: boolean, edit_mode: boolean): Promise<void> {
-    void edit_mode; // to avoid unused variable warning
-    await oldToggleComponent(component_id, saveChanges);
-    changeStudentArrowTooltips(
-        localStorage.getItem('general-setting-arrow-function') || 'default',
-    );
-}
-
 window.updateCookies = function () {
     window.Cookies.set('silent_edit_enabled', String(isSilentEditModeEnabled()), {
         path: '/',
@@ -354,193 +252,6 @@ window.updateCookies = function () {
     window.Cookies.set('files', JSON.stringify(files), { path: '/' });
     window.Cookies.set('cookie_version', String(cookie_version), { path: '/' });
 };
-
-// Navigate to the prev / next student buttons
-registerKeyHandler({ name: 'Previous Student', code: 'ArrowLeft' }, () => {
-    gotoPrevStudent();
-});
-registerKeyHandler({ name: 'Next Student', code: 'ArrowRight' }, () => {
-    gotoNextStudent();
-});
-
-// Key handler / shorthand for toggling in between panels
-registerKeyHandler({ name: 'Toggle Autograding Panel', code: 'KeyA' }, () => {
-    $('#autograding_results_btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler({ name: 'Toggle Rubric Panel', code: 'KeyG' }, () => {
-    $('#grading_rubric_btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler({ name: 'Toggle Submissions Panel', code: 'KeyO' }, () => {
-    $('#submission_browser_btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler(
-    { name: 'Toggle Student Information Panel', code: 'KeyS' },
-    () => {
-        $('#student_info_btn button').trigger('click');
-        window.updateCookies();
-    },
-);
-registerKeyHandler({ name: 'Toggle Grade Inquiry Panel', code: 'KeyX' }, () => {
-    $('#grade_inquiry_info_btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler({ name: 'Toggle Discussion Panel', code: 'KeyD' }, () => {
-    $('#discussion_browser_btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler({ name: 'Toggle Peer Panel', code: 'KeyP' }, () => {
-    $('#peer_info_btn button').trigger('click');
-    window.updateCookies();
-});
-
-registerKeyHandler({ name: 'Toggle Notebook Panel', code: 'KeyN' }, () => {
-    $('#notebook-view-btn button').trigger('click');
-    window.updateCookies();
-});
-registerKeyHandler(
-    { name: 'Toggle Solution/TA-Notes Panel', code: 'KeyT' },
-    () => {
-        $('#solution_ta_notes_btn button').trigger('click');
-        window.updateCookies();
-    },
-);
-// -----------------------------------------------------------------------------
-// Show/hide components
-
-registerKeyHandler({ name: 'Open Next Component', code: 'ArrowDown' }, (e: { preventDefault: () => void }) => {
-    const openComponentId = getFirstOpenComponentId();
-    const numComponents = $('#component-list').find(
-        '.component-container',
-    ).length;
-
-    // Note: we use the 'toggle' functions instead of the 'open' functions
-    //  Since the 'open' functions don't close any components
-    if (openComponentId === NO_COMPONENT_ID) {
-        // No component is open, so open the first one
-        const componentId = getComponentIdByOrder(0);
-        void toggleComponent(componentId, true, false).then(() => {
-            scrollToComponent(componentId);
-        });
-    }
-    else if (openComponentId === getComponentIdByOrder(numComponents - 1)) {
-        // Last component is open, close it and then open and scroll to first component
-        void closeComponent(openComponentId, true).then(() => {
-            const componentId = getComponentIdByOrder(0);
-            void toggleComponent(componentId, true, false).then(() => {
-                scrollToComponent(componentId);
-            });
-        });
-    }
-    else {
-        // Any other case, open the next one
-        const nextComponentId = getNextComponentId(openComponentId);
-        void toggleComponent(nextComponentId, true, false).then(() => {
-            scrollToComponent(nextComponentId);
-        });
-    }
-    e.preventDefault();
-});
-
-registerKeyHandler(
-    { name: 'Open Previous Component', code: 'ArrowUp' },
-    (e: { preventDefault: () => void }) => {
-        const openComponentId = getFirstOpenComponentId();
-        const numComponents = $('#component-list').find(
-            '.component-container',
-        ).length;
-
-        // Note: we use the 'toggle' functions instead of the 'open' functions
-        //  Since the 'open' functions don't close any components
-        if (openComponentId === NO_COMPONENT_ID) {
-            // No Component is open, so open the overall comment
-            // Targets the box outside of the container, can use tab to focus comment
-            // TODO: Add "Overall Comment" focusing, control
-            scrollToOverallComment();
-        }
-        else if (openComponentId === getComponentIdByOrder(0)) {
-            // First component is open, close it and then open and scroll to the last one
-            void closeComponent(openComponentId, true).then(() => {
-                const componentId = getComponentIdByOrder(numComponents - 1);
-                void toggleComponent(componentId, true, false).then(() => {
-                    scrollToComponent(componentId);
-                });
-            });
-        }
-        else {
-            // Any other case, open the previous one
-            const prevComponentId = getPrevComponentId(openComponentId);
-            void toggleComponent(prevComponentId, true, false).then(() => {
-                scrollToComponent(prevComponentId);
-            });
-        }
-        e.preventDefault();
-    },
-);
-
-// -----------------------------------------------------------------------------
-// Misc rubric options
-registerKeyHandler({ name: 'Toggle Rubric Edit Mode', code: 'KeyE' }, () => {
-    const editBox = $('#edit-mode-enabled');
-    editBox.prop('checked', !editBox.prop('checked'));
-    void onToggleEditMode();
-    window.updateCookies();
-});
-
-// -----------------------------------------------------------------------------
-// Selecting marks
-
-registerKeyHandler(
-    { name: 'Select Full/No Credit Mark', code: 'Digit0' },
-    () => {
-        checkOpenComponentMark(0);
-    },
-);
-registerKeyHandler({ name: 'Select Mark 1', code: 'Digit1' }, () => {
-    checkOpenComponentMark(1);
-});
-registerKeyHandler({ name: 'Select Mark 2', code: 'Digit2' }, () => {
-    checkOpenComponentMark(2);
-});
-registerKeyHandler({ name: 'Select Mark 3', code: 'Digit3' }, () => {
-    checkOpenComponentMark(3);
-});
-registerKeyHandler({ name: 'Select Mark 4', code: 'Digit4' }, () => {
-    checkOpenComponentMark(4);
-});
-registerKeyHandler({ name: 'Select Mark 5', code: 'Digit5' }, () => {
-    checkOpenComponentMark(5);
-});
-registerKeyHandler({ name: 'Select Mark 6', code: 'Digit6' }, () => {
-    checkOpenComponentMark(6);
-});
-registerKeyHandler({ name: 'Select Mark 7', code: 'Digit7' }, () => {
-    checkOpenComponentMark(7);
-});
-registerKeyHandler({ name: 'Select Mark 8', code: 'Digit8' }, () => {
-    checkOpenComponentMark(8);
-});
-registerKeyHandler({ name: 'Select Mark 9', code: 'Digit9' }, () => {
-    checkOpenComponentMark(9);
-});
-
-function checkOpenComponentMark(index: number) {
-    const component_id = getFirstOpenComponentId();
-    if (component_id !== NO_COMPONENT_ID) {
-        const mark_id = getMarkIdFromOrder(component_id, index);
-        // TODO: Custom mark id is zero as well, should use something unique
-        if (mark_id === CUSTOM_MARK_ID || mark_id === 0) {
-            return;
-        }
-        void toggleCommonMark(component_id, mark_id).catch((err: { message: string }) => {
-            console.error(err);
-            alert(`Error toggling mark! ${err.message}`);
-        });
-    }
-}
-
 // expand all files in Submissions and Results section
 window.openAll = function (click_class: string, class_modifier: string) {
     const toClose = $(
@@ -1030,12 +741,6 @@ window.collapseFile = function (rawPanel: string = 'submission') {
         },
     );
 };
-
-window.Twig.twig({
-    id: 'Attachments',
-    href: '/templates/grading/Attachments.twig',
-    async: true,
-});
 
 let uploadedAttachmentIndex = 1;
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When you import from a typescript file, you are unknowingly "running" the typescript file and that can cause errors. When we port this to vue, we would **never** want this to happen, especially as vue files **will** include some functions from typescript (see sqlToolboxPage.vue). This will cause problems when vue files start to run.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
There should be no noticable behavior difference on the user end.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Please test that nothing breaks

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
I updated two var's to two const.
