### PR TITLE
[Refactor:Developer] Improve error when magic method missing

### DIFF
--- a/site/tests/phpstan/ModelClassExtension.php
+++ b/site/tests/phpstan/ModelClassExtension.php
@@ -18,6 +18,10 @@ class ModelClassExtension implements MethodsClassReflectionExtension {
         $method_name = preg_replace_callback('/([A-Z])/', function ($match) {
             return '_' . strtolower($match[0]);
         }, $method_name);
+        $phpDoc = $reflection->getResolvedPhpDoc();
+        if ($phpDoc === null || !array_key_exists($method_name, $phpDoc->getMethodTags())) {
+            return false;
+        }
         return $reflection->hasProperty($method_name);
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When a magic method comment is missing but we attempt to call the method the current phpstan error will look like the following:
```
 -- ----------------------------------------------------------------------------------------------
     Error
 -- ----------------------------------------------------------------------------------------------
     Internal error: Internal error: Call to a member function getParameters() on null while
     analysing file
     /home/alex/Documents/Programming/Submitty/SubmittyClean/site/app/libraries/socket/Client.php
     Run PHPStan with -v option and post the stack trace to:
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml
     Internal error: Internal error: Call to a member function getParameters() on null while
     analysing file
     /home/alex/Documents/Programming/Submitty/SubmittyClean/site/app/views/GlobalView.php
     Run PHPStan with -v option and post the stack trace to:
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml
     Child process error (exit code 1):
 -- ----------------------------------------------------------------------------------------------
```

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The error will be much more readable and look like:
```
 ------ --------------------------------------------------------------------
  Line   app/libraries/socket/Client.php
 ------ --------------------------------------------------------------------
  17     Call to an undefined method app\models\Config::getWebsocketPort().
 ------ --------------------------------------------------------------------

 ------ --------------------------------------------------------------------
  Line   app/views/GlobalView.php
 ------ --------------------------------------------------------------------
  88     Call to an undefined method app\models\Config::getWebsocketPort().
 ------ --------------------------------------------------------------------
```

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Remove any magic method comment (https://github.com/Submitty/Submitty/blob/14777244a187217f4c6666746cd9406937e90835/site/app/models/Config.php#L23 was used for testing)

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
The old code was assuming that the comment would exist, causing a crash due do attempting to call methods on a null value.
