### PR TITLE
[Bugfix:Notifications] Fix Invalid Email Status Pagination

### DIFF
--- a/site/app/controllers/EmailStatusController.php
+++ b/site/app/controllers/EmailStatusController.php
@@ -44,7 +44,7 @@ class EmailStatusController extends AbstractController {
     public function getEmailStatusesByPage(): WebResponse {
         $semester = $this->core->getConfig()->getTerm();
         $course = $this->core->getConfig()->getCourse();
-        $page = isset($_GET['page']) ? $_GET['page'] : 1;
+        $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
 
         /** @var EmailRepository $repository */
         $repository = $this->core->getSubmittyEntityManager()->getRepository(EmailEntity::class);
@@ -67,7 +67,7 @@ class EmailStatusController extends AbstractController {
     public function getSuperuserEmailStatusPage(): WebResponse {
         /** @var EmailRepository $repository */
         $repository = $this->core->getSubmittyEntityManager()->getRepository(EmailEntity::class);
-        $num_page = $repository->getPageNum();
+        $num_page = $repository->getPageNum(null, null);
 
         return new WebResponse(
             EmailStatusView::class,
@@ -84,10 +84,10 @@ class EmailStatusController extends AbstractController {
      */
     #[Route("/superuser/email_status_page", methods: ["GET"])]
     public function getSuperuserEmailStatusesByPage(): WebResponse {
-        $page = $_GET['page'] ?? 1;
+        $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
         /** @var EmailRepository $repository */
         $repository = $this->core->getSubmittyEntityManager()->getRepository(EmailEntity::class);
-        $result = $repository->getEmailsByPage($page);
+        $result = $repository->getEmailsByPage($page, null, null);
         $this->core->getOutput()->useHeader(false);
         $this->core->getOutput()->useFooter(false);
         return new WebResponse(

--- a/site/app/controllers/EmailStatusController.php
+++ b/site/app/controllers/EmailStatusController.php
@@ -44,7 +44,7 @@ class EmailStatusController extends AbstractController {
     public function getEmailStatusesByPage(): WebResponse {
         $semester = $this->core->getConfig()->getTerm();
         $course = $this->core->getConfig()->getCourse();
-        $page = isset($_POST['page']) ? $_POST['page'] : 1;
+        $page = isset($_GET['page']) ? $_GET['page'] : 1;
 
         /** @var EmailRepository $repository */
         $repository = $this->core->getSubmittyEntityManager()->getRepository(EmailEntity::class);

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -77,8 +77,8 @@ class EmailRepository extends EntityRepository {
     }
 
     /**
-     * Helper method to fetch the subjects for a specific page for pagination, containing their subject, created date,
-     * and count of emails.
+     * Helper method to fetch the emails for a specific page for pagination, containing their subject, created date,
+     * and count.
      *
      * @param int $page
      * @param string|null $semester

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -72,8 +72,23 @@ class EmailRepository extends EntityRepository {
      * @return int
      */
     public function getPageNum(?string $semester, ?string $course): int {
-        // Add 1 as no placeholder element is added for the first page
-        return count($this->getPageSubjects(PHP_INT_MAX, $semester, $course)) + 1;
+        $emails = $this->fetchEmails($semester, $course);
+        $count = 0;
+        $subject_count = 0;
+        $page_count = 1;
+
+        foreach ($emails as $email) {
+            $count += $email['cnt'];
+            $subject_count += 1;
+
+            if ($count >= self::PAGE_SIZE || $subject_count === self::MAX_SUBJECTS_PER_PAGE) {
+                $page_count += 1;
+                $count = 0;
+                $subject_count = 0;
+            }
+        }
+
+        return $page_count;
     }
 
     /**
@@ -108,10 +123,6 @@ class EmailRepository extends EntityRepository {
 
                 if ($curr_page > $page) {
                     break;
-                }
-                elseif ($page === PHP_INT_MAX) {
-                    // Each placeholder element represents a page to simplify page calculation
-                    array_push($subjects, null);
                 }
             }
         }

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -88,6 +88,11 @@ class EmailRepository extends EntityRepository {
             }
         }
 
+        // If the last increment was for a clean end, roll it back
+        if ($count === 0 && $subject_count === 0 && $page_count > 1) {
+            $page_count -= 1;
+        }
+
         return $page_count;
     }
 

--- a/site/app/repositories/email/EmailRepository.php
+++ b/site/app/repositories/email/EmailRepository.php
@@ -8,7 +8,15 @@ class EmailRepository extends EntityRepository {
     const PAGE_SIZE = 5000;
     const MAX_SUBJECTS_PER_PAGE = 10;
 
-    public function getEmailsByPage(int $page, $semester = null, $course = null): array {
+    /**
+     * Fetches a specific page of email entities, grouped by subject and created date, ordered from newest to oldest.
+     *
+     * @param int $page
+     * @param string|null $semester
+     * @param string|null $course
+     * @return array<int, iterable<int, mixed>>
+     */
+    public function getEmailsByPage(int $page, ?string $semester, ?string $course): array {
         $subjects = $this->getPageSubjects($page, $semester, $course);
         $result = [];
 
@@ -16,7 +24,7 @@ class EmailRepository extends EntityRepository {
             $qb = $this->getEntityManager()->createQueryBuilder();
             $qb ->select('e')
                 ->from('app\entities\email\EmailEntity', 'e');
-            if ($semester && $course) {
+            if ($semester !== null && $course !== null) {
                 $qb->where('e.term = :term')
                     ->andWhere('e.course = :course')
                     ->setParameter('term', $semester)
@@ -33,42 +41,57 @@ class EmailRepository extends EntityRepository {
         return $result;
     }
 
-    public function getPageNum($semester = null, $course = null): int {
-        if ($semester != null || $course != null) {
-            $dql = 'SELECT e.subject, e.created, COUNT(e) AS cnt FROM app\entities\email\EmailEntity e WHERE e.term = \'' . $semester . '\' AND e.course = \'' . $course . '\' GROUP BY e.subject, e.created ORDER BY e.created DESC';
+    /**
+     * Helper method to fetch all ordered emails for pagination, which contain their subject,
+     * created date, and count.
+     *
+     * @param string|null $semester
+     * @param string|null $course
+     * @return iterable<array<string, mixed>>
+     */
+    private function fetchEmails(?string $semester, ?string $course): iterable {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb ->select('e.subject, e.created, COUNT(e) AS cnt')
+            ->from('app\entities\email\EmailEntity', 'e');
+        if ($semester !== null && $course !== null) {
+            $qb->where('e.term = :term')
+                ->andWhere('e.course = :course')
+                ->setParameter('term', $semester)
+                ->setParameter('course', $course);
         }
-        else {
-            $dql = 'SELECT e.subject, e.created, COUNT(e) AS cnt FROM app\entities\email\EmailEntity e GROUP BY e.subject, e.created ORDER BY e.created DESC';
-        }
-        $q = $this->getEntityManager()->createQuery($dql);
-        $page = 1;
-        $count = 0;
-        $subject = 0;
-        foreach ($q->toIterable() as $email) {
-            $count += $email['cnt'];
-            $subject += 1;
-            if ($count >= self::PAGE_SIZE || $subject > self::MAX_SUBJECTS_PER_PAGE) {
-                $page += 1;
-                $count = 0;
-                $subject = 1;
-            }
-        }
-        return $page;
+        $qb->groupBy('e.subject, e.created')
+            ->orderBy('e.created', 'DESC');
+        return $qb->getQuery()->toIterable();
     }
 
-    private function getPageSubjects($page, $semester = null, $course = null): array {
-        if ($semester != null || $course != null) {
-            $dql = 'SELECT e.subject, e.created, COUNT(e) AS cnt FROM app\entities\email\EmailEntity e WHERE e.term = \'' . $semester . '\' AND e.course = \'' . $course . '\' GROUP BY e.subject, e.created ORDER BY e.created DESC';
-        }
-        else {
-            $dql = 'SELECT e.subject, e.created, COUNT(e) AS cnt FROM app\entities\email\EmailEntity e GROUP BY e.subject, e.created ORDER BY e.created DESC';
-        }
-        $q = $this->getEntityManager()->createQuery($dql);
+    /**
+     * Gets the total number of email pages for pagination.
+     *
+     * @param string|null $semester
+     * @param string|null $course
+     * @return int
+     */
+    public function getPageNum(?string $semester, ?string $course): int {
+        // Add 1 as no placeholder element is added for the first page
+        return count($this->getPageSubjects(PHP_INT_MAX, $semester, $course)) + 1;
+    }
+
+    /**
+     * Helper method to fetch the subjects for a specific page for pagination, containing their subject, created date,
+     * and count of emails.
+     *
+     * @param int $page
+     * @param string|null $semester
+     * @param string|null $course
+     * @return array<int, array<string, mixed>>
+     */
+    private function getPageSubjects(int $page, ?string $semester, ?string $course): array {
+        $emails = $this->fetchEmails($semester, $course);
         $curr_page = 1;
         $count = 0;
         $subject_count = 0;
         $subjects = [];
-        foreach ($q->toIterable() as $email) {
+        foreach ($emails as $email) {
             $count += $email['cnt'];
             $subject_count += 1;
             if ($curr_page === $page) {
@@ -86,8 +109,13 @@ class EmailRepository extends EntityRepository {
                 if ($curr_page > $page) {
                     break;
                 }
+                elseif ($page === PHP_INT_MAX) {
+                    // Each placeholder element represents a page to simplify page calculation
+                    array_push($subjects, null);
+                }
             }
         }
+
         return $subjects;
     }
 }

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -10887,56 +10887,6 @@ parameters:
 			path: app/repositories/SessionRepository.php
 
 		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 4
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) has parameter \\$course with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) has parameter \\$semester with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageNum\\(\\) has parameter \\$course with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageNum\\(\\) has parameter \\$semester with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$course with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$page with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) has parameter \\$semester with no type specified\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
-			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getPageSubjects\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/repositories/email/EmailRepository.php
-
-		-
 			message: "#^Method app\\\\repositories\\\\poll\\\\OptionRepository\\:\\:findByPollWithResponseCounts\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/repositories/poll/OptionRepository.php

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -10892,11 +10892,6 @@ parameters:
 			path: app/repositories/email/EmailRepository.php
 
 		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 2
-			path: app/repositories/email/EmailRepository.php
-
-		-
 			message: "#^Method app\\\\repositories\\\\email\\\\EmailRepository\\:\\:getEmailsByPage\\(\\) has parameter \\$course with no type specified\\.$#"
 			count: 1
 			path: app/repositories/email/EmailRepository.php

--- a/site/public/js/email-status.js
+++ b/site/public/js/email-status.js
@@ -1,6 +1,7 @@
 /* exported loadPage */
 const page_window = 5;
 function loadPage(page, load_page_url) {
+    $('.page-btn').removeClass('selected');
     $(`#${page}`).addClass('selected');
     $(`#${page}`).attr('disabled', 'disabled');
     $('.page-btn').each(function () {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

The email status page only displays the first page, regardless of the currently selected page. I believe this was never caught or documented, as most instructors or administrators would usually visit this page to verify recent, but not old, email details. Fixes #11799.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

The email status page now displays the correct page. The error stemmed from the invalid controller logic, where the page was determined by the POST request object, which was empty or undefined, as the pagination request is a GET request. Additionally, the repository code was refactored for clarity measures.

Old (all pages are the same)

![image](https://github.com/user-attachments/assets/5fbb8b30-b182-4e9e-83ff-21932d0bac0c)


New (expected last page)

![image](https://github.com/user-attachments/assets/187b3086-b75f-4b20-85ac-9f30758d340a)

### What steps should a reviewer take to reproduce or test the bug or new feature?

You can test the expected pages (10 emails or 5000 recipients per page) through the following commands, which are based on emails, not recipient limits. The following is also not tied to a specific course, which would require the `WHERE course='x' AND term='y'` clause to work, thus log in as the `superuser` to match the emails.

```bash
$ sudo su postgres
$ psql
$ \c submitty
$ SELECT
  ROW_NUMBER() OVER (ORDER BY e.created DESC) AS index,
  e.subject,
  e.created,
  COUNT(*) AS cnt
FROM emails e
GROUP BY e.subject, e.created
ORDER BY e.created DESC;
```


### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

There are no existing email status page tests, but I'll make an issue to ensure they're implemented as E2E tests to account for pagination, errors, and detail verification.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

N/A
