### PR TITLE
[Bugfix:TAGrading] Fix Verify Grader

### DIFF
--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -999,7 +999,7 @@ function isInstructorEditEnabled() {
  * @returns {boolean}
  */
 function canVerifyGraders() {
-    return $('#grader-info').attr('data-can_verify') === 'true';
+    return $('#grader-info').attr('data-can_verify') === '1';
 }
 window.canVerifyGraders = canVerifyGraders;
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
As of now, you cannot verify a single component for one grader. You have to click "verify all" in order to verify one person. IN order to test this, log in as grader and grade a component. When you go as the instructor, the verfiy button on the component is gone.


### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Fixed it so that the verify grader button is active

<img width="477" alt="image" src="https://github.com/user-attachments/assets/aabd25f2-1ac0-4af3-acbc-d13854952e4c" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
We should have tests, but with the TAGrading refactor going on, now would not be the right time. We also have subpar testing data.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
