### PR TITLE
[Bugfix:Submission] Fix Overridden Banner display

### DIFF
--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -7,11 +7,6 @@
         "class" : "content gradeable_message"
     } only %}
 {% endif %}
-
-{% if has_overridden_grades %}
-    <div class='content overridden-message'><p>Please see your instructor if you have for questions about your grade for this assignment</p></div>
-{% endif %}
-
 <div class="content" id="gradeable-submission-cont">
     <header id="gradeable-info">
         <h1 data-testid="new-submission-info">
@@ -62,6 +57,9 @@
 
     {% if show_no_late_submission_warning %}
         <i class="red-message">Warning, you are making a late submission for a gradeable without late submissions enabled!</i>
+    {% endif %}
+    {% if has_overridden_grades %}
+        <div class='content overridden-message'><p>Your grade has been overridden. Please contact your instructor if this is unexpected.</p></div>
     {% endif %}
     {# Admin submission type selector #}
     {% if core.getUser().accessFullGrading() and bulk_upload_access %}

--- a/site/app/views/submission/HomeworkView.php
+++ b/site/app/views/submission/HomeworkView.php
@@ -532,7 +532,7 @@ class HomeworkView extends AbstractView {
         $this->core->getOutput()->addInternalJs('markdown-code-highlight.js');
         CodeMirrorUtils::loadDefaultDependencies($this->core);
 
-        $has_overridden_grades = false;
+        $has_overridden_grades = $graded_gradeable !== null && $graded_gradeable->hasOverriddenGrades();
         if (!is_null($graded_gradeable)) {
             $graded_gradeable->hasOverriddenGrades();
         }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Fix #10331
On the student side, they will have no indication that their grade has been overridden, unless the instructor updates rainbowgrades. Now, there will be a banner on top of the submission page to indicate a grade override.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/993ec6f2-74c4-46c0-bdb2-c35e04038974" />
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/fc851d2e-4678-4821-b2aa-cc815279c3e5" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
Overriden a student
notice that they will have no indication that their grade is overridden.
Test new code.
See new banner

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
I can change the UI/UX if needed
Are there security concerns with this PR? -->
