### PR TITLE
[Feature:InstructorUI] Added CodeMirror to Edit Gradeable Config

### DIFF
--- a/site/app/controllers/admin/AdminGradeableController.php
+++ b/site/app/controllers/admin/AdminGradeableController.php
@@ -3,6 +3,7 @@
 namespace app\controllers\admin;
 
 use app\controllers\AbstractController;
+use app\libraries\CodeMirrorUtils;
 use app\exceptions\ValidationException;
 use app\libraries\DateUtils;
 use app\libraries\Utils;
@@ -547,6 +548,7 @@ class AdminGradeableController extends AbstractController {
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'flatpickr.min.css'));
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'shortcut-buttons-flatpickr.min.js'));
         $this->core->getOutput()->addVendorCss(FileUtils::joinPaths('flatpickr', 'plugins', 'shortcutButtons', 'themes', 'light.min.css'));
+        CodeMirrorUtils::loadDefaultDependencies($this->core);
         $this->core->getOutput()->addSelect2WidgetCSSAndJs();
         $this->core->getOutput()->addInternalJs('admin-gradeable-updates.js');
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -401,11 +401,22 @@ body::-webkit-scrollbar-track {
     margin-top: 0.5em;
 }
 
-#gradeable-config-edit {
+/* stylelint-disable-next-line selector-class-pattern */
+#gradeable-config-edit-bar .CodeMirror {
+    /* The below instances of !important are identical to those used in gradeable-notebook.css.
+    It appears to be the only way to override the CodeMirror styling */
+    /* stylelint-disable-next-line declaration-no-important */
+    background-color: var(--standard-input-background) !important;
+    /* stylelint-disable-next-line declaration-no-important */
+    border: 1px solid var(--standard-light-gray) !important;
+    /* stylelint-disable-next-line declaration-no-important */
+    border-radius: 4px !important;
+    /* stylelint-disable-next-line declaration-no-important */
+    vertical-align: middle !important;
     min-height: 500px;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    overflow: auto;
+    overflow: hidden;
+    margin-top: 0.75em;
+    margin-bottom: 0.75em;
     resize: vertical;
 }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When editing a gradeable config, using `TAB` to indent is not supported. This hinders the experience of instructors editing large config files, making it difficult to maintain consistent indentation.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The text area used to edit the gradeable config is now CodeMirror. This allows the use of  `TAB` to make indentations, while having a working undo/redo system.

I chose CodeMirror over a standard JavaScript solution because while I can insert a tab with something like a `keydown` event listener, the undo/redo functionality of the DOM gets messed up. CodeMirror offers built-in undo/redo tracking and keyboard handling, making it a more robust and accessible solution compared to patching native `<textarea>` behavior with `keydown` events.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Go to a gradeable with an uploaded config file -> open editor -> observe that `TAB` is now supported, and all other functionality is the same.

### Other information
<!-- Is this a breaking change?  
This is not a breaking change.
A few `!important` declarations were added to override CodeMirror's internal styles and align the config editor with existing Submitty design patterns. These follow the precedent set in `gradeable-notebook.css`.
