### PR TITLE
[Refactor:RainbowGrades] Improve RainbowGrades handling

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -367,7 +367,7 @@ class GlobalController extends AbstractController {
         // --------------------------------------------------------------------------
 
         $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
-        if ($display_rainbow_grades_summary) {
+        if ($display_rainbow_grades_summary || $this->core->getUser()->getGroup() === User::GROUP_INSTRUCTOR) {
             $sidebar_buttons[] = new NavButton($this->core, [
                 "href" => $this->core->buildCourseUrl(['grades']),
                 "title" => "Rainbow Grades",

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -1295,42 +1295,4 @@ class UsersController extends AbstractController {
         $this->core->addSuccessMessage("Uploaded {$_FILES['upload']['name']}: ({$added} added, {$updated} updated)");
         $this->core->redirect($return_url);
     }
-
-    /**
-     * @AccessControl(role="INSTRUCTOR")
-     **/
-    #[Route("/courses/{_semester}/{_course}/users/view_grades", methods: ["POST"])]
-    public function viewStudentGrades() {
-        if (!isset($_POST["student_id"])) {
-            $this->core->addErrorMessage("No student ID provided");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['users']))
-            );
-        }
-        $student_id = $_POST["student_id"];
-        $user = $this->core->getQueries()->getUserById($student_id);
-        if ($user === null) {
-            $this->core->addErrorMessage("Invalid Student ID \"" . $_POST["student_id"] . "\"");
-            return MultiResponse::RedirectOnlyResponse(
-                new RedirectResponse($this->core->buildCourseUrl(['users']))
-            );
-        }
-
-        $grade_path = $this->core->getConfig()->getCoursePath() . "/reports/summary_html/"
-            . $student_id . "_summary.html";
-
-        $grade_file = null;
-        if (file_exists($grade_path)) {
-            $grade_file = file_get_contents($grade_path);
-        }
-
-        return MultiResponse::webOnlyResponse(
-            new WebResponse(
-                ['submission', 'RainbowGrades'],
-                'showStudentToInstructor',
-                $user,
-                $grade_file
-            )
-        );
-    }
 }

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -28,6 +28,7 @@ class RainbowGradesController extends AbstractController {
 
     /**
      * @AccessControl(role="INSTRUCTOR")
+     * This route is used to view the grades of a specific student.
      **/
     #[Route("/courses/{_semester}/{_course}/users/view_grades", methods: ["POST"])]
     public function viewStudentGrades() {

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -11,7 +11,7 @@ use app\models\User;
 class RainbowGradesController extends AbstractController {
     #[Route("/courses/{_semester}/{_course}/grades")]
     public function gradesReport() {
-        if(!$this->core->getConfig()->displayRainbowGradesSummary() && $this->core->getUser()->getGroup() !== User::GROUP_INSTRUCTOR) {
+        if (!$this->core->getConfig()->displayRainbowGradesSummary() && $this->core->getUser()->getGroup() !== User::GROUP_INSTRUCTOR) {
             $this->core->addErrorMessage("Rainbow Grades are not enabled for this course");
             return new RedirectResponse($this->core->buildCourseUrl([]));
         }

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -5,12 +5,13 @@ namespace app\controllers\student;
 use app\controllers\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use app\libraries\response\RedirectResponse;
+use app\libraries\response\WebResponse;
 use app\libraries\routers\AccessControl;
 use app\models\User;
 
 class RainbowGradesController extends AbstractController {
     #[Route("/courses/{_semester}/{_course}/grades")]
-    public function gradesReport() {
+    public function gradesReport(): RedirectResponse|WebResponse {
         if (!$this->core->getConfig()->displayRainbowGradesSummary() && $this->core->getUser()->getGroup() !== User::GROUP_INSTRUCTOR) {
             $this->core->addErrorMessage("Rainbow Grades are not enabled for this course");
             return new RedirectResponse($this->core->buildCourseUrl([]));
@@ -23,7 +24,11 @@ class RainbowGradesController extends AbstractController {
             $grade_file = file_get_contents($grade_path);
         }
 
-        $this->core->getOutput()->renderOutput(['submission', 'RainbowGrades'], 'showGrades', $grade_file);
+        return new WebResponse(
+            ['submission', 'RainbowGrades'],
+            'showGrades',
+            $grade_file
+        );
     }
 
     /**
@@ -31,7 +36,7 @@ class RainbowGradesController extends AbstractController {
      * This route is used to view the grades of a specific student.
      **/
     #[Route("/courses/{_semester}/{_course}/users/view_grades", methods: ["POST"])]
-    public function viewStudentGrades() {
+    public function viewStudentGrades(): RedirectResponse|WebResponse {
         if (!isset($_POST["student_id"])) {
             $this->core->addErrorMessage("No student ID provided");
             return new RedirectResponse($this->core->buildCourseUrl(['users']));
@@ -51,6 +56,11 @@ class RainbowGradesController extends AbstractController {
             $grade_file = file_get_contents($grade_path);
         }
 
-        $this->core->getOutput()->renderOutput(['submission', 'RainbowGrades'], 'showGrades', $grade_file);
+        return new WebResponse(
+            ['submission', 'RainbowGrades'],
+            'showStudentToInstructor',
+            $user,
+            $grade_file
+        );
     }
 }

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -13,7 +13,7 @@ class RainbowGradesController extends AbstractController {
     #[Route("/courses/{_semester}/{_course}/grades")]
     public function gradesReport(): RedirectResponse|WebResponse {
         if (!$this->core->getConfig()->displayRainbowGradesSummary() && $this->core->getUser()->getGroup() !== User::GROUP_INSTRUCTOR) {
-            $this->core->addErrorMessage("Rainbow Grades are not enabled for this course");
+            $this->core->addErrorMessage("Rainbow Grades are not enabled for this course.");
             return new RedirectResponse($this->core->buildCourseUrl([]));
         }
         $grade_path = $this->core->getConfig()->getCoursePath() . "/reports/summary_html/"

--- a/site/app/controllers/student/RainbowGradesController.php
+++ b/site/app/controllers/student/RainbowGradesController.php
@@ -4,12 +4,46 @@ namespace app\controllers\student;
 
 use app\controllers\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
+use app\libraries\response\RedirectResponse;
+use app\libraries\routers\AccessControl;
+use app\models\User;
 
 class RainbowGradesController extends AbstractController {
     #[Route("/courses/{_semester}/{_course}/grades")]
-    public function run() {
+    public function gradesReport() {
+        if(!$this->core->getConfig()->displayRainbowGradesSummary() && $this->core->getUser()->getGroup() !== User::GROUP_INSTRUCTOR) {
+            $this->core->addErrorMessage("Rainbow Grades are not enabled for this course");
+            return new RedirectResponse($this->core->buildCourseUrl([]));
+        }
         $grade_path = $this->core->getConfig()->getCoursePath() . "/reports/summary_html/"
             . $this->core->getUser()->getId() . "_summary.html";
+
+        $grade_file = null;
+        if (file_exists($grade_path)) {
+            $grade_file = file_get_contents($grade_path);
+        }
+
+        $this->core->getOutput()->renderOutput(['submission', 'RainbowGrades'], 'showGrades', $grade_file);
+    }
+
+    /**
+     * @AccessControl(role="INSTRUCTOR")
+     **/
+    #[Route("/courses/{_semester}/{_course}/users/view_grades", methods: ["POST"])]
+    public function viewStudentGrades() {
+        if (!isset($_POST["student_id"])) {
+            $this->core->addErrorMessage("No student ID provided");
+            return new RedirectResponse($this->core->buildCourseUrl(['users']));
+        }
+        $student_id = $_POST["student_id"];
+        $user = $this->core->getQueries()->getUserById($student_id);
+        if ($user === null) {
+            $this->core->addErrorMessage("Invalid Student ID \"" . $_POST["student_id"] . "\"");
+            return new RedirectResponse($this->core->buildCourseUrl(['users']));
+        }
+
+        $grade_path = $this->core->getConfig()->getCoursePath() . "/reports/summary_html/"
+            . $user->getId() . "_summary.html";
 
         $grade_file = null;
         if (file_exists($grade_path)) {

--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -1,3 +1,10 @@
+{% if not rainbow_grade_active %}
+    <div class="content warning-banner" data-testid="rainbow-grades-not-active-banner">
+        <p>Rainbow Grades are not available to the student.</p>
+        <p>You can choose to toggle it on in <a href="{{ config_url }}">course settings.</a></p>
+    </div>
+{% endif %}
+
 <div class="content">
     <header>
         <h1 class="label">

--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -1,4 +1,4 @@
-{% if not rainbow_grade_active %}
+{% if rainbow_grade_active is defined and not rainbow_grade_active %}
     <div class="content warning-banner" data-testid="rainbow-grades-not-active-banner">
         <p>Rainbow Grades are not available to the student.</p>
         <p>You can choose to toggle it on in <a href="{{ config_url }}">course settings.</a></p>

--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -1,7 +1,7 @@
 {% if rainbow_grade_active is defined and not rainbow_grade_active %}
     <div class="content warning-banner" data-testid="rainbow-grades-not-active-banner">
-        <p>Rainbow Grades are not available to the student.</p>
-        <p>You can choose to toggle it on in <a href="{{ config_url }}">course settings.</a></p>
+        <p>Rainbow Grades are not available to students.</p>
+        <p>You can choose to toggle it on within the <a href="{{ config_url }}">course settings.</a></p>
     </div>
 {% endif %}
 

--- a/site/app/views/admin/ReportView.php
+++ b/site/app/views/admin/ReportView.php
@@ -23,8 +23,6 @@ class ReportView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb('Gradebook');
         $this->core->getOutput()->addInternalCss('rainbow-grades.css');
 
-        $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
-
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
             "show_summary" => $grade_file !== null,
             "grade_file" => $grade_file,

--- a/site/app/views/submission/RainbowGradesView.php
+++ b/site/app/views/submission/RainbowGradesView.php
@@ -3,27 +3,38 @@
 namespace app\views\submission;
 
 use app\views\AbstractView;
+use app\models\User;
 
 class RainbowGradesView extends AbstractView {
-    public function showGrades($grade_file) {
-        $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
+    /**
+     * Renders the Rainbow Grades page.
+     *
+     * @param string|null $grade_file The contents of the grade file, or null if not available.
+     * @return string Rendered HTML for the Rainbow Grades page.
+     */
+    public function showGrades($grade_file): string {
         $this->core->getOutput()->addBreadcrumb('Rainbow Grades');
         $this->core->getOutput()->addInternalCss('rainbow-grades.css');
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
-            "show_summary" => $display_rainbow_grades_summary && $grade_file !== null,
+            "show_summary" => $grade_file !== null,
             "grade_file" => $grade_file
         ]);
     }
 
-    public function showStudentToInstructor($user, $grade_file) {
-        $display_rainbow_grades_summary = $this->core->getConfig()->displayRainbowGradesSummary();
+    /**
+     * Renders the Rainbow Grades page for a specific student.
+     *
+     * @param User $user The user whose grades are being displayed.
+     * @param string|null $grade_file The contents of the grade file for the student, or null if not available.
+     */
+    public function showStudentToInstructor($user, $grade_file): string {
         $manage_url = $this->core->buildCourseUrl(['users']);
         $this->core->getOutput()->addBreadcrumb('Manage Students', $manage_url);
         $this->core->getOutput()->addBreadcrumb($user->getDisplayFullName());
         $this->core->getOutput()->addInternalCss('rainbow-grades.css');
 
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
-            "show_summary" => $display_rainbow_grades_summary && $grade_file !== null,
+            "show_summary" => $grade_file !== null,
             "grade_file" => $grade_file,
             "extra_label" => "For " . $user->getDisplayFullName()
         ]);

--- a/site/app/views/submission/RainbowGradesView.php
+++ b/site/app/views/submission/RainbowGradesView.php
@@ -8,14 +8,18 @@ use app\models\User;
 class RainbowGradesView extends AbstractView {
     /**
      * Renders the Rainbow Grades page.
-     *
      * @param string|null $grade_file The contents of the grade file, or null if not available.
      */
     public function showGrades($grade_file): string {
         $this->core->getOutput()->addBreadcrumb('Rainbow Grades');
         $this->core->getOutput()->addInternalCss('rainbow-grades.css');
+
+        $rainbow_grade_active = $this->core->getConfig()->displayRainbowGradesSummary();
+        $config_url = $this->core->buildCourseUrl(['config#display-rainbow-grades-summary']);
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
             "show_summary" => $grade_file !== null,
+            "rainbow_grade_active" => $rainbow_grade_active,
+            "config_url" => $config_url,
             "grade_file" => $grade_file
         ]);
     }
@@ -32,9 +36,14 @@ class RainbowGradesView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb($user->getDisplayFullName());
         $this->core->getOutput()->addInternalCss('rainbow-grades.css');
 
+        $rainbow_grade_active = $this->core->getConfig()->displayRainbowGradesSummary();
+        $config_url = $this->core->buildCourseUrl(['config#display-rainbow-grades-summary']);
+
         return $this->core->getOutput()->renderTwigTemplate("submission/RainbowGrades.twig", [
             "show_summary" => $grade_file !== null,
             "grade_file" => $grade_file,
+            "rainbow_grade_active" => $rainbow_grade_active,
+            "config_url" => $config_url,
             "extra_label" => "For " . $user->getDisplayFullName()
         ]);
     }

--- a/site/app/views/submission/RainbowGradesView.php
+++ b/site/app/views/submission/RainbowGradesView.php
@@ -10,7 +10,6 @@ class RainbowGradesView extends AbstractView {
      * Renders the Rainbow Grades page.
      *
      * @param string|null $grade_file The contents of the grade file, or null if not available.
-     * @return string Rendered HTML for the Rainbow Grades page.
      */
     public function showGrades($grade_file): string {
         $this->core->getOutput()->addBreadcrumb('Rainbow Grades');

--- a/site/cypress/e2e/Cypress-Gradeable/rainbow_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/rainbow_grading.spec.js
@@ -210,7 +210,15 @@ describe('Test Rainbow Grading', () => {
         cy.get('[data-testid="display-rainbow-grades-summary"]').uncheck();
         cy.get('[data-testid="display-rainbow-grades-summary"]').should('not.be.checked');
         cy.visit(['testing', 'grades']);
-        cy.get('[data-testid="rainbow-grades"]').should('contain', 'No grades are available...');
+        // rainbow grades should be visible to the instructor
+        cy.get('[data-testid="rainbow-grades"]').should('not.contain.text', 'No grades are available...');
+        cy.get('[data-testid="rainbow-grades-not-active-banner"]').should('be.visible');
+
+        // rainbow grades should not be visible to the student
+        cy.logout();
+        cy.login('student');
+        cy.visit(['testing', 'grades']);
+        cy.get('[data-testid="popup-message"]').should('contain.text', 'Rainbow Grades are not enabled for this course.');
     });
 });
 describe('Test Automatic Nightly Processing for Rainbow Grades', () => {

--- a/site/cypress/e2e/Cypress-Gradeable/rainbow_grading.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/rainbow_grading.spec.js
@@ -204,12 +204,15 @@ describe('Test Rainbow Grading', () => {
                 checkRainbowGradesOption();
             }
         });
+
+        // turn off rainbow grades and view pages
         cy.logout();
         cy.login('instructor2');
         cy.visit(['testing', 'config']);
         cy.get('[data-testid="display-rainbow-grades-summary"]').uncheck();
         cy.get('[data-testid="display-rainbow-grades-summary"]').should('not.be.checked');
         cy.visit(['testing', 'grades']);
+
         // rainbow grades should be visible to the instructor
         cy.get('[data-testid="rainbow-grades"]').should('not.contain.text', 'No grades are available...');
         cy.get('[data-testid="rainbow-grades-not-active-banner"]').should('be.visible');

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -1530,22 +1530,6 @@ parameters:
 			path: app/controllers/admin/StudentActivityDashboardController.php
 
 		-
-			message: """
-				#^Call to deprecated method RedirectOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
-				should not be used, just return RedirectResponse directly$#
-			"""
-			count: 2
-			path: app/controllers/admin/UsersController.php
-
-		-
-			message: """
-				#^Call to deprecated method webOnlyResponse\\(\\) of class app\\\\libraries\\\\response\\\\MultiResponse\\:
-				should not be used, just return WebResponse directly$#
-			"""
-			count: 1
-			path: app/controllers/admin/UsersController.php
-
-		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/controllers/admin/UsersController.php
@@ -1627,11 +1611,6 @@ parameters:
 
 		-
 			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:uploadUserList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/controllers/admin/UsersController.php
-
-		-
-			message: "#^Method app\\\\controllers\\\\admin\\\\UsersController\\:\\:viewStudentGrades\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/controllers/admin/UsersController.php
 
@@ -2858,7 +2837,12 @@ parameters:
 			path: app/controllers/student/LeaderboardController.php
 
 		-
-			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:run\\(\\) has no return type specified\\.$#"
+			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:gradesReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/controllers/student/RainbowGradesController.php
+
+		-
+			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:viewStudentGrades\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/controllers/student/RainbowGradesController.php
 

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -2837,16 +2837,6 @@ parameters:
 			path: app/controllers/student/LeaderboardController.php
 
 		-
-			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:gradesReport\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/controllers/student/RainbowGradesController.php
-
-		-
-			message: "#^Method app\\\\controllers\\\\student\\\\RainbowGradesController\\:\\:viewStudentGrades\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/controllers/student/RainbowGradesController.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/controllers/student/SubmissionController.php
@@ -12339,31 +12329,6 @@ parameters:
 			message: "#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#"
 			count: 2
 			path: app/views/submission/HomeworkView.php
-
-		-
-			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showGrades\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/views/submission/RainbowGradesView.php
-
-		-
-			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showGrades\\(\\) has parameter \\$grade_file with no type specified\\.$#"
-			count: 1
-			path: app/views/submission/RainbowGradesView.php
-
-		-
-			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/views/submission/RainbowGradesView.php
-
-		-
-			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has parameter \\$grade_file with no type specified\\.$#"
-			count: 1
-			path: app/views/submission/RainbowGradesView.php
-
-		-
-			message: "#^Method app\\\\views\\\\submission\\\\RainbowGradesView\\:\\:showStudentToInstructor\\(\\) has parameter \\$user with no type specified\\.$#"
-			count: 1
-			path: app/views/submission/RainbowGradesView.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -418,13 +418,6 @@ body::-webkit-scrollbar-track {
     color: var(--standard-vibrant-red);
 }
 
-.warning-banner {
-    display: none;
-    margin: 0 0 1em;
-    background-color: var(--standard-vibrant-yellow);
-    color: var(--default-black);
-}
-
 .date-warning {
     display: none;
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2227,3 +2227,8 @@ End of slider switch
 .notebook-cell {
     padding: 0 0.5em;
 }
+
+.warning-banner {
+    background-color: var(--standard-vibrant-yellow);
+    color: var(--default-black);
+}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
1. Refactors viewing students grades to the rainbowgrades controller, instead of the user controller. This mimics late days being in the latecontroller instead of the user controller
2. Added additional types to everything involved, refactoring from `$this->getOutput()->renderOutput()` to `WebResponse`.
3. moved access control from view to controller, in addition to making sure that instructors can see rainbowgrades when it is disabled

This removes all of the phpstan warnings about rainbowGrades
### What is the New Behavior?

<!-- Include before & after screenshots/videos if the user interface has changed. -->
1. viewing student grades from instructor is now in rainbowgrades controller
2. Improve rainbowgrades handling

### What steps should a reviewer take to reproduce or test the bug or new feature?
When viewing rainbow grades for a user, the behavior should not change.
When rainbowgrades summary is disabled but instructors set up rainbowgrades, instructors should be able to see user rainbowgrades.
Overall the page should not see that many changes.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
Issue will be made

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
