### PR TITLE
[Feature:TAGrading] Add active graders to grading details

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1094,7 +1094,18 @@ class ElectronicGraderController extends AbstractController {
             }
         }
 
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode, $overrides, $anon_ids, $inquiry_status, $grading_details_columns);
+        $activeGradersData = $this->core->getQueries()->getActiveGradersForGradeable($gradeable_id);
+        $activeGraders = [];
+        if ($gradeable->isTeamAssignment()) {
+            $key = "ag_team_id";
+        } else {
+            $key = "ag_user_id";
+        }
+        for ($i = 0; $i < count($activeGradersData); $i++) {
+            $activeGraders[$activeGradersData[$i][$key]][$activeGradersData[$i]['gc_title']][] = $activeGradersData[$i]; 
+        }
+
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'detailsPage', $gradeable, $graded_gradeables, $teamless_users, $graders, $empty_teams, $show_all_sections_button, $show_import_teams_button, $show_export_teams_button, $show_edit_teams, $past_grade_start_date, $view_all, $sort, $direction, $anon_mode, $overrides, $anon_ids, $inquiry_status, $grading_details_columns, $activeGraders);
 
         if ($show_edit_teams) {
             $all_reg_sections = $this->core->getQueries()->getRegistrationSections();
@@ -2387,7 +2398,7 @@ class ElectronicGraderController extends AbstractController {
      * @param GradingAction $action
      * @return JsonResponse
      */
-    public function changeComponentGraders(string $gradeable_id, string $anon_id, string $component_id, GradingAction $action) {
+    public function changeComponentGraders(string $gradeable_id, string $anon_id, ?string $component_id = null, ?GradingAction $action = null) {
         $grader = $this->core->getUser();
 
         // Get the gradeable

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9574,4 +9574,14 @@ ORDER BY
         );
         return $this->submitty_db->getRowCount() > 0;
     }
+
+    public function getActiveGradersForGradeable(string $gradeable_id): array {
+        $this->course_db->query(
+            "SELECT ag.*, gc.gc_title FROM active_graders AS ag
+             JOIN gradeable_component AS gc ON ag.gc_id = gc.gc_id
+             WHERE gc.g_id = ?",
+            [$gradeable_id]
+        );
+        return $this->course_db->rows();
+    }
 }

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -83,6 +83,7 @@
         'args': {
             'columns': all_columns|map(column => column.function),
             'labels': all_columns|map(column => column.title),
+            'hiddenColumns': ["active_graders"],
             'forced': [
                 'grading'
             ],
@@ -194,7 +195,7 @@
                 <tbody class="details-content panel-content-active"{% if section.title in collapsed_sections %} style="display: none"{% endif %}>
                     {% if section.rows is defined %}
                         {% for info in section.rows %}
-                            {{ _self.render_student(_context, section, info.graded_gradeable, loop.index, info, columns, team_gradeable_view_history, overrides, anon_ids, max_team_name_length) }}
+                            {{ _self.render_student(_context, section, info.graded_gradeable, loop.index, info, columns, team_gradeable_view_history, overrides, anon_ids, max_team_name_length, active_graders) }}
                         {% endfor %}
                     {% endif %}
                     {% if section.teamless_users is defined %}
@@ -249,7 +250,7 @@
     </table>
 </div>
 
-{% macro render_student(context, section, graded_gradeable, index, info, columns, team_gradeable_view_history, overrides, anon_ids, max_team_name_length) %}
+{% macro render_student(context, section, graded_gradeable, index, info, columns, team_gradeable_view_history, overrides, anon_ids, max_team_name_length, active_graders) %}
     <tr class="grade-table" data-testid="grade-table"
         {% if not graded_gradeable.getSubmitter().isTeam() and graded_gradeable.getSubmitter().getUser().accessGrading() %}
             style='background: #7bd0f7;'
@@ -302,6 +303,8 @@
                 {{ _self.render_column_user_family(context, section, graded_gradeable, index, info, column) }}
             {% elseif column.function == "viewed_grade" %}
                 {{ _self.render_column_viewed_grade(context, section, graded_gradeable, index, info, column, team_gradeable_view_history) }}
+            {% elseif column.function == "active_graders" %}
+                {{ _self.render_column_active_graders(context, section, graded_gradeable, index, info, column, active_graders) }}
             {% endif %}
         {% endfor %}
     </tr>
@@ -746,6 +749,19 @@
     {% else %}
         <td></td>
     {% endif %}
+{% endmacro %}
+
+{# Active Graders #}
+{% macro render_column_active_graders(context, section, graded_gradeable, index, info, column, active_graders) %}
+    <td>
+    {% set user_id = graded_gradeable.getSubmitter().getId() %}
+    {% set user_graders = active_graders[user_id] is defined ? active_graders[user_id] : {} %}
+    {% include 'Vue.twig' with {
+        'component': 'activeGraders',
+        'args': {
+            "userGraders": user_graders
+        }
+    } %}
 {% endmacro %}
 
 {# /Column functions #}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -505,7 +505,7 @@ HTML;
      * @param array<string,bool> $grading_details_columns
      * @return string
      */
-    public function detailsPage(Gradeable $gradeable, array $graded_gradeables, array $teamless_users, array $graders, array $empty_teams, bool $show_all_sections_button, bool $show_import_teams_button, bool $show_export_teams_button, bool $show_edit_teams, string $past_grade_start_date, bool $view_all, string $sort, string $direction, bool $anon_mode, array $overrides, array $anon_ids, bool $inquiry_status, array $grading_details_columns) {
+    public function detailsPage(Gradeable $gradeable, array $graded_gradeables, array $teamless_users, array $graders, array $empty_teams, bool $show_all_sections_button, bool $show_import_teams_button, bool $show_export_teams_button, bool $show_edit_teams, string $past_grade_start_date, bool $view_all, string $sort, string $direction, bool $anon_mode, array $overrides, array $anon_ids, bool $inquiry_status, array $grading_details_columns, array $active_graders) {
         $collapsed_sections = isset($_COOKIE['collapsed_sections']) ? json_decode(rawurldecode($_COOKIE['collapsed_sections'])) : [];
 
         $peer = false;
@@ -607,6 +607,7 @@ HTML;
             }
             else {
                 $columns[] = ["title" => "Grading", "function" => "grading"];
+                $columns[] = ["title" => "Active Graders", "function" => "active_graders"];
             }
             $columns[] = ["title" => "Total", "function" => "total"];
             $columns[] = ["title" => "Active Version", "function" => "active_version"];
@@ -893,6 +894,9 @@ HTML;
         }
 
         $shown_columns = array_filter($columns, function ($column) use ($grading_details_columns) {
+            if ($column['function'] === "active_graders") {
+                return array_key_exists('active_graders', $grading_details_columns) && $grading_details_columns['active_graders'];
+            }
             return !array_key_exists($column['function'], $grading_details_columns) || $grading_details_columns[$column['function']];
         });
 
@@ -948,6 +952,7 @@ HTML;
             "overrides" => $overrides,
             "anon_ids" => $anon_ids,
             "max_team_name_length" => Team::MAX_TEAM_NAME_LENGTH,
+            "active_graders" => $active_graders,
             "csrf_token" => $this->core->getCsrfToken(),
         ]);
     }

--- a/site/vue/env.d.ts
+++ b/site/vue/env.d.ts
@@ -5,3 +5,10 @@ declare module '*.vue' {
     const Component: DefineComponent;
     export default Component;
 }
+
+import * as luxon from 'luxon';
+declare global {
+    interface Window {
+        luxon: typeof luxon;
+    }
+}

--- a/site/vue/src/components/activeGraders.vue
+++ b/site/vue/src/components/activeGraders.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const { userGraders } = defineProps<{
+    userGraders: Record<string, { grader_id: string; timestamp: string }[]>;
+}>();
+function formatTimestamp(timestamp: string): string {
+    return window.luxon.DateTime.fromFormat(timestamp, 'yyyy-MM-dd HH:mm:ssZZ')
+        .toRelative({ base: window.luxon.DateTime.now() }) || timestamp;
+}
+</script>
+
+<template>
+  <div v-if="Object.keys(userGraders).length">
+    <ul>
+      <li
+        v-for="(graders, componentTitle) in userGraders"
+        :key="componentTitle"
+      >
+        <p>{{ componentTitle }}: {{ graders.map(g=> `${g.grader_id} - ${formatTimestamp(g.timestamp)}`).join(", ") }}</p>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/site/vue/src/components/toggleColumns.vue
+++ b/site/vue/src/components/toggleColumns.vue
@@ -4,10 +4,11 @@ import { onMounted, ref } from 'vue';
 import Popup from './popup.vue';
 export type ColumnFormats = 'bits' | 'json';
 
-const { columns, labels, cookie, forced = [], format = 'bits', buttonWrapped } = defineProps<{
+const { columns, labels, cookie, hiddenColumns = [], forced = [], format = 'bits', buttonWrapped } = defineProps<{
     columns: string[];
     labels: string[];
     cookie: string;
+    hiddenColumns?: string[];
     forced?: string[];
     format?: ColumnFormats;
     buttonWrapped?: boolean;
@@ -25,7 +26,7 @@ function loadColumns() {
             }
         }
         for (const col of columns) {
-            if (cookieData[col] === undefined) {
+            if (cookieData[col] === undefined && !hiddenColumns.includes(col)) {
                 selected.value[columns.indexOf(col)] = true;
             }
         }

--- a/site/vue/src/main.ts
+++ b/site/vue/src/main.ts
@@ -14,7 +14,7 @@ const exports = {
             }
         })();
 
-        app.mount(target);
+        return app.mount(target);
     },
 };
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently the active graders are only visible when grading an individual student.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
They are now available on the grading details page.
![image](https://github.com/user-attachments/assets/d5cebbf6-0fce-45b1-949f-e2687e847bc5)


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Start grading a user and open a component
2. In another tab view the grading details page

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
