### PR TITLE
[Bugfix:InstructorUI] rubric reorder component function

### DIFF
--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -1074,7 +1074,6 @@ function setRubricDOMElements(elements: string | Element | DocumentFragment | Do
     gradingBox.html(elements);
 
     if (isInstructorEditEnabled()) {
-        console.log('is instructor');
         setupSortableComponents();
     }
 }

--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -1074,6 +1074,7 @@ function setRubricDOMElements(elements: string | Element | DocumentFragment | Do
     gradingBox.html(elements);
 
     if (isInstructorEditEnabled()) {
+        console.log('is instructor');
         setupSortableComponents();
     }
 }
@@ -1202,7 +1203,7 @@ function setupSortableMarks(component_id: number) {
 function setupSortableComponents() {
     const componentList = $('#component-list');
     componentList.sortable({
-        update: void onComponentOrderChange,
+        update: () => void onComponentOrderChange(),
         handle: '.reorder-component-container',
     });
     componentList.on('keydown', keyPressHandler);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
The function to reorder component was not called correctly. This caused the function to not run at all, which instructors are unable to update/reorder component. Once they refresh, the ordering will be the same
Before:
https://github.com/user-attachments/assets/dd97df3d-97fa-42df-a2d5-ba91b52cca16

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Instructors will now be reorder components that saves to the database after changes
After:
https://github.com/user-attachments/assets/c337e3f6-80cf-44eb-b1a0-56477ea6d3cc

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
I believe we have trouble in cypress to drag stuff, so I don't know if the testing can be achieved.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
