### PR TITLE
[Bugfix:System] Fix install_site Script for Vagrant VMs

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -449,6 +449,11 @@ popd > /dev/null
 
 ################################################################################################################
 ################################################################################################################
+
+# Obtains the current git hash and tag and stores them in the appropriate jsons.
+python3 "${SUBMITTY_INSTALL_DIR}/.setup/bin/track_git_version.py"
+chmod o+r "${SUBMITTY_INSTALL_DIR}/config/version.json"
+
 # COPY THE 1.0 Grading Website if not in worker mode
 if [ "${IS_WORKER}" == 0 ]; then
     bash "${SUBMITTY_REPOSITORY}/.setup/install_submitty/install_site.sh" browscap "config=${SUBMITTY_CONFIG_DIR:?}"
@@ -561,10 +566,6 @@ fi
 
 ################################################################################################################
 ################################################################################################################
-
-# Obtains the current git hash and tag and stores them in the appropriate jsons.
-python3 "${SUBMITTY_INSTALL_DIR}/.setup/bin/track_git_version.py"
-chmod o+r "${SUBMITTY_INSTALL_DIR}/config/version.json"
 
 installed_commit=$(jq '.installed_commit' /usr/local/submitty/config/version.json)
 most_recent_git_tag=$(jq '.most_recent_git_tag' /usr/local/submitty/config/version.json)

--- a/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_BIN.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-bash "${THIS_DIR}/install_submitty/install_bin.sh"
+SUBMITTY_CONFIG_DIR="/usr/local/submitty/config"
+bash "${THIS_DIR}/install_submitty/install_bin.sh" browscap "config=${SUBMITTY_CONFIG_DIR:?}"

--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-bash "${THIS_DIR}/install_submitty/install_site.sh"
+SUBMITTY_CONFIG_DIR="/usr/local/submitty/config"
+bash "${THIS_DIR}/install_submitty/install_site.sh" browscap "config=${SUBMITTY_CONFIG_DIR:?}"

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -68,8 +68,8 @@ if [ -z "${SUBMITTY_CONFIG_DIR}" ]; then
 fi
 
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${SUBMITTY_CONFIG_DIR:?}/submitty.json)
-source ${SUBMITTY_REPOSITORY:?}/.setup/get_globals.sh "config=${SUBMITTY_CONFIG_DIR:?}"
-source ${SUBMITTY_REPOSITORY:?}/bin/versions.sh
+source ${SUBMITTY_REPOSITORY:?}/.setup/install_submitty/get_globals.sh "config=${SUBMITTY_CONFIG_DIR:?}"
+source ${SUBMITTY_REPOSITORY:?}/.setup/bin/versions.sh
 
 mkdir -p ${SUBMITTY_INSTALL_DIR}/site/public
 

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -63,10 +63,9 @@ done
 
 if [ -z "${SUBMITTY_CONFIG_DIR}" ]; then
     echo "ERROR: This script requires a config dir argument"
-    SUBMITTY_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../../../../config
     echo "Usage: ${BASH_SOURCE[0]} config=<config dir> [browscap]"
+    exit 1
 fi
-
 
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${SUBMITTY_CONFIG_DIR:?}/submitty.json)
 source ${SUBMITTY_REPOSITORY:?}/.setup/get_globals.sh "config=${SUBMITTY_CONFIG_DIR:?}"

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -63,9 +63,10 @@ done
 
 if [ -z "${SUBMITTY_CONFIG_DIR}" ]; then
     echo "ERROR: This script requires a config dir argument"
+    SUBMITTY_CONFIG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../../../../config
     echo "Usage: ${BASH_SOURCE[0]} config=<config dir> [browscap]"
-    exit 1
 fi
+
 
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${SUBMITTY_CONFIG_DIR:?}/submitty.json)
 source ${SUBMITTY_REPOSITORY:?}/.setup/get_globals.sh "config=${SUBMITTY_CONFIG_DIR:?}"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
After the merging of #10645 the install_site script broke due to a config file requirement that is supplied by install_submitty_helper but not by install_site_helper. 

### What is the New Behavior?
The submitty_install_site script should run without issue on VMs

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
There isn't testing for submitty_install_site it seems, this is an area which should probably be looked into.

### Other information
