### PR TITLE
[Bugfix:System] Fix Ansible No Role Prefix

### DIFF
--- a/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
@@ -25,4 +25,4 @@
   register: submitty_course_add_user_add_user_result
   become: true
   become_user: root
-  changed_when: "'User added' in add_user_result.stdout"
+  changed_when: "'User added' in submitty_course_add_user_add_user_result.stdout"

--- a/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
@@ -22,7 +22,7 @@
       "{{ submitty_course_add_user_registration_section }}"
       --user_group "{{ submitty_course_add_user_user_group }}"
     chdir: /usr/local/submitty/sbin/
-  register: submitty_course_add_user_add_user_result
+  register: submitty_course_add_user_result
   become: true
   become_user: root
-  changed_when: "'User added' in submitty_course_add_user_add_user_result.stdout"
+  changed_when: "'User added' in submitty_course_add_user_result.stdout"

--- a/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_add_user/tasks/main.yml
@@ -22,7 +22,7 @@
       "{{ submitty_course_add_user_registration_section }}"
       --user_group "{{ submitty_course_add_user_user_group }}"
     chdir: /usr/local/submitty/sbin/
-  register: add_user_result
+  register: submitty_course_add_user_add_user_result
   become: true
   become_user: root
   changed_when: "'User added' in add_user_result.stdout"

--- a/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
@@ -115,8 +115,8 @@
     chdir: /usr/local/submitty/sbin/
   become: true
   become_user: root
-  register: submitty_course_creation_
-  changed_when: submitty_course_creation_.rc != 0
+  register: submitty_course_creation_status
+  changed_when: submitty_course_creation_status.rc != 0
 
 - name: Restart PHP=FPM service.
   ansible.builtin.systemd:

--- a/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
@@ -115,8 +115,8 @@
     chdir: /usr/local/submitty/sbin/
   become: true
   become_user: root
-  register: submitty_course_creation_submitty_course_creation
-  changed_when: submitty_course_creation.rc != 0
+  register: submitty_course_creation_
+  changed_when: submitty_course_creation_.rc != 0
 
 - name: Restart PHP=FPM service.
   ansible.builtin.systemd:

--- a/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_course_creation/tasks/main.yml
@@ -115,7 +115,7 @@
     chdir: /usr/local/submitty/sbin/
   become: true
   become_user: root
-  register: submitty_course_creation
+  register: submitty_course_creation_submitty_course_creation
   changed_when: submitty_course_creation.rc != 0
 
 - name: Restart PHP=FPM service.

--- a/.setup/ansible/roles/submitty_install/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_install/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.apt:
     name: php
     state: present
-  register: apt_action
+  register: submitty_install_apt_action
   retries: 100
   until: apt_action is success or
     ('Failed to lock apt for exclusive operation' not in apt_action.msg and

--- a/.setup/ansible/roles/submitty_install/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_install/tasks/main.yml
@@ -10,9 +10,9 @@
     state: present
   register: submitty_install_apt_action
   retries: 100
-  until: apt_action is success or
-    ('Failed to lock apt for exclusive operation' not in apt_action.msg and
-    '/var/lib/dpkg/lock' not in apt_action.msg)
+  until: submitty_install_apt_action is success or
+    ('Failed to lock apt for exclusive operation' not in submitty_install_apt_action.msg and
+    '/var/lib/dpkg/lock' not in submitty_install_apt_action.msg)
 
 - name: Create submitty git directory if none exists
   ansible.builtin.file:

--- a/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
@@ -8,5 +8,5 @@
   become: true
   become_user: root
   notify: Reload fpm
-  register: create_term_creation_output
+  register: submitty_term_creation_create_term_creation_output
   changed_when: create_term_creation_output.rc != 0

--- a/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
@@ -8,5 +8,5 @@
   become: true
   become_user: root
   notify: Reload fpm
-  register: submitty_term_creation_create_term_creation_output
-  changed_when: submitty_term_creation_create_term_creation_output.rc != 0
+  register: submitty_term_creation_output
+  changed_when: submitty_term_creation_output.rc != 0

--- a/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
+++ b/.setup/ansible/roles/submitty_term_creation/tasks/main.yml
@@ -9,4 +9,4 @@
   become_user: root
   notify: Reload fpm
   register: submitty_term_creation_create_term_creation_output
-  changed_when: create_term_creation_output.rc != 0
+  changed_when: submitty_term_creation_create_term_creation_output.rc != 0


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
This change is necessary because it fixes Ansible linting errors as a result of Ansible Lint reinforcing role prefixes for "global" variables: https://github.com/ansible/ansible-lint/commit/249cd4cc07444f5900ec23e3c16103798edb07af.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Registers now have their respective role prefixes and Ansible Lint tests should pass now.

### What steps should a reviewer take to reproduce or test the bug or new feature?
You can test the bug by viewing CI tests in previous merged PRs.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
