### PR TITLE
[Bugfix:InstructorUI] Fixed Config Selector Refresh

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -88,7 +88,7 @@
     <div class="settings">
         <div>
             <div class="drop-down" id="config-drop-down">
-                <select name="autograding_config_path" id="autograding_config_selector" onchange="configSelectorChange()">
+                <select name="autograding_config_path" id="autograding_config_selector">
                     <option>{{ gradeable.getAutogradingConfigPath() }}</option>
                     {% for path in all_config_paths %}
                         <option value={{path.1}}>{{path.0}}</option>

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -294,6 +294,10 @@ $(document).ready(() => {
                 }
                 updateErrorMessage();
                 checkWarningBanners();
+                if (this.id === 'autograding_config_selector') {
+                    location.reload();
+                    return;
+                }
             }, updateGradeableErrorCallback);
     });
 

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -294,9 +294,8 @@ $(document).ready(() => {
                 }
                 updateErrorMessage();
                 checkWarningBanners();
-                if (this.id === 'autograding_config_selector') {
+                if (this.id === 'autograding_config_selector' && response_data[0] === 'rebuild_queued') {
                     location.reload();
-                    return;
                 }
             }, updateGradeableErrorCallback);
     });

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1014,10 +1014,6 @@ function loadGradeableEditor(g_id, file_path) {
     });
 }
 
-function configSelectorChange() {
-    location.reload();
-}
-
 function isUsingDefaultConfig() {
     const selector = document.getElementById('autograding_config_selector');
     const selectedPath = selector.value;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In #10325 a helper function was added that reloaded the page immediately when an instructor picked a different autograding configuration, so the gradeable-config editor would show the new files.

However, the AJAX request that actually saves the new `autograding_config_path` is fired from a separate delegated `change` listener. In some browsers (notably Firefox) the instant reload could occur before that request left the page, so the rebuild job wasn’t queued and the editor still showed the old config.

### What is the New Behavior?
The reload call has been moved inside the existing delegated `change` listener, after the AJAX update returns successfully. Now every browser waits until the payload is sent (and acknowledged) before reloading, guaranteeing the gradeable configuration is updated correctly.

### What steps should a reviewer take to reproduce or test the bug or new feature?
In Firefox and Chrome, change autograding configurations. Ensure the config editor is updated, and the gradeable is being properly rebuilt.

### Other information
This is not a breaking change.