### PR TITLE
[Testing:Forum] E2E Cypress Tests for Forum WebSockets

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1472,6 +1472,7 @@ class ForumController extends AbstractController {
     }
 
     #[Route("/courses/{_semester}/{_course}/posts/likes", methods: ["POST"])]
+    #[Route("/api/courses/{_semester}/{_course}/posts/likes", methods: ["POST"])]
     public function toggleLike(): JsonResponse {
         $requiredKeys = ['post_id', 'current_user'];
         foreach ($requiredKeys as $key) {

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -4,9 +4,11 @@ const title1 = 'Cypress Title 1 Cypress';
 const title2 = 'Cypress Title 2 Cypress';
 const title3 = 'Cypress Title 3 Cypress';
 const title4 = 'Python Tutorials';
+const title5 = 'WebSocket Title Test';
 const content1 = 'Cypress Content 1 Cypress';
 const content2 = 'Cypress Content 2 Cypress';
 const content3 = 'Cypress Content 3 Cypress';
+const content4 = 'Cypress Content 4 Cypress';
 const reply1 = 'Cypress Reply 1 Cypress';
 const reply2 = 'Cypress Reply 2 Cypress';
 const reply3 = 'Cypress Reply 3 Cypress';
@@ -132,49 +134,48 @@ describe('Forum Thread Lock Date Functionality', () => {
 
         // Create a new thread via a POST request
         const body = {
-            'title': 'WebSocket Title Test',
+            'title': title5,
             'markdown_status': 0,
             'lock_thread_date': '',
-            'thread_post_content': 'WebSocket Content Test',
+            'thread_post_content': content4,
             'cat[]': '2', //  TODO: to prevent flaky tests, fetch all categories to not map to magic numbers ["Question" == 2]
             'expirationDate': new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(), // 1 week from now
             'thread_status': -1,
         };
 
-        removeThread('WebSocket Title Test');
+        removeThread(title5);
 
         verifyWebSocketFunctionality(buildUrl(['sample', 'forum', 'threads', 'new'], true), 'POST', 'multipart/form-data', body, (response) => {
             expect(response.status).to.eq(200);
 
             // Verify the thread is created
-            cy.get('[data-thread_title*="WebSocket Title Test"]') // Thread container
+            cy.get(`[data-thread_title*="${title5}"]`) // Thread container
                 .should('exist')
                 .within(() => {
                     cy.get('[data-testid="thread-list-item"]') // Verify the thread title
-                        .should('contain', 'WebSocket Title Test');
+                        .should('contain', title5);
                     cy.get('.thread-content') // Verify the thread content
-                        .should('contain', 'WebSocket Content Test');
+                        .should('contain', content4);
                     cy.get('.label_forum') // Verify the thread category
                         .should('contain', 'Question');
                 });
 
-            let id = NaN;
-            cy.get('[data-thread_title*="WebSocket Title Test"]')
+            cy.get(`[data-thread_title*="${title5}"]`)
                 .should('exist')
                 .invoke('attr', 'data-thread_id')
                 .then((val) => {
-                    id = Number(val); // Parse the inserted thread ID
+                    const id = Number(val); // Parse the inserted thread ID
                     expect(id).to.be.a('number');
                     expect(id).to.be.greaterThan(0);
 
-                    cy.get('[data-thread_title*="WebSocket Title Test"]')
+                    cy.get(`[data-thread_title*="${title5}"]`) // Verify we can visit the new thread
                         .should('exist')
                         .click();
                     cy.url().should('include', buildUrl(['sample', 'forum', 'threads', id], true));
                 });
 
-            removeThread('WebSocket Title Test');
-            cy.get('[data-testid="thread-list-item"]').contains('WebSocket Title Test').should('not.exist');
+            removeThread(title5);
+            cy.get('[data-testid="thread-list-item"]').contains(title5).should('not.exist');
         });
     });
 

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -221,11 +221,10 @@ describe('Should test WebSocket functionality', () => {
         cy.login('instructor');
         cy.visit(['sample', 'forum']);
         cy.get('#nav-sidebar-collapse-sidebar').click();
+        removeThread(title5);
     });
 
     it('Should verify WebSocket functionality for creating and deleting a new thread', () => {
-        removeThread(title5);
-
         const createBody = {
             'title': title5,
             'markdown_status': 0,
@@ -287,8 +286,6 @@ describe('Should test WebSocket functionality', () => {
     });
 
     it('Should verify WebSocket functionality for incoming and deleting posts with the correct reply level', () => {
-        removeThread(title5);
-
         const createBody = {
             'title': title5,
             'markdown_status': 0,
@@ -332,7 +329,6 @@ describe('Should test WebSocket functionality', () => {
                         return newPostId;
                     });
                 }).then((newPostId) => {
-                    console.log('newPostId', newPostId);
                     // Reply to self
                     const createBody = {
                         thread_id: threadId,
@@ -340,8 +336,6 @@ describe('Should test WebSocket functionality', () => {
                         thread_post_content: reply5,
                         markdown_status: 0,
                     };
-
-                    console.log(createBody);
 
                     verifyWebSocketFunctionality(['sample', 'forum', 'posts', 'new'], 'POST', 'multipart/form-data', createBody, (response) => {
                         cy.get('.post_box').contains(reply5).should('exist').closest('.post_box').as('finalPost');
@@ -368,7 +362,6 @@ describe('Should test WebSocket functionality', () => {
                         // Delete the initial reply to verify both posts are deleted
                         const deleteBody = { thread_id: threadId, post_id: newPostId };
                         verifyWebSocketFunctionality(['sample', 'forum', 'posts', 'delete'], 'POST', 'multipart/form-data', deleteBody, (response) => {
-                            console.log(response);
                             cy.get(`#${newPostId}`).should('not.exist');
                             cy.get(`#${finalPostId}`).should('not.exist');
                         });

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -18,7 +18,7 @@ const reply4 = 'Cypress Reply 4 Cypress';
 const reply5 = 'Cypress Reply 5 Cypress';
 const merged1 = 'Merged Thread Title: '.concat(title3, '\n\n', content3);
 const merged2 = 'Merged Thread Title: '.concat(title2, '\n\n', content2);
-const merged3 = 'Merged Thread Title: '.concat(title6, '\n\n', content1);
+const merged3 = 'Merged Thread Title: '.concat(title6, '\n\n', content5);
 const attachment1 = 'sea_animals.png';
 
 const createThread = (title, content, category) => {
@@ -329,7 +329,9 @@ const expectPostHierarchy = (post, expected) => {
         expect(Number(post.attr('id'))).to.equal(postId);
         expect(Number(post.attr('data-parent_id'))).to.equal(parentPostId);
         expect(Number(post.attr('data-reply_level'))).to.equal(level);
-        expect(post.get('post_content')).to.equal(content);
+        cy.get('.post_content').invoke('text').then((text) => {
+            expect(text.trim()).to.equal(content);
+        });
     });
 
     // Verify the next page is the thread page
@@ -436,14 +438,13 @@ describe('Should test WebSocket functionality', () => {
 
                 cy.visit(mergingNextPage).then(() => {
                     submitMergeThreadRequest(threadId, mergingThreadId).then(([mergeResponse, mergedPost]) => {
-                        console.log(mergeResponse);
                         expect(mergeResponse.redirect).to.equal(baseNextPage);
                         expectPostHierarchy(mergedPost, {
                             threadId: mergingThreadId,
                             postId: mergingPostId,
                             parentPostId: parentPostId,
                             level: 2,
-                            content: content5,
+                            content: merged3,
                             nextPage: mergingNextPage + '?option=tree',
                         });
                     });

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -131,24 +131,55 @@ describe('Forum Thread Lock Date Functionality', () => {
         cy.visit(['sample', 'forum']);
 
         // Create a new thread via a POST request
-        const formData = new FormData();
-        formData.append('title', 'WebSocket Title Test');
-        formData.append('markdown_status', 0);
-        formData.append('lock_thread_date', '');
-        formData.append('thread_post_content', 'WebSocket Content Test');
-        formData.append('cat[]', '2'); //  TODO: to prevent flaky tests, fetch all categories to not map to magic numbers ["Question" == 2]
-        formData.append('expirationDate', new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString()); // 1 week from now
-        formData.append('thread_status', -1);
+        const body = {
+            'title': 'WebSocket Title Test',
+            'markdown_status': 0,
+            'lock_thread_date': '',
+            'thread_post_content': 'WebSocket Content Test',
+            'cat[]': '2', //  TODO: to prevent flaky tests, fetch all categories to not map to magic numbers ["Question" == 2]
+            'expirationDate': new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(), // 1 week from now
+            'thread_status': -1,
+        };
 
-        verifyWebSocketFunctionality('POST', buildUrl(['sample', 'forum', 'threads', 'new'], true), formData, (response) => {
+        removeThread('WebSocket Title Test');
+
+        verifyWebSocketFunctionality(buildUrl(['sample', 'forum', 'threads', 'new'], true), 'POST', 'multipart/form-data', body, (response) => {
             expect(response.status).to.eq(200);
-            cy.get('[data-testid="thread-list-item"]').contains('WebSocket Title Test').should('exist');
+
+            // Verify the thread is created
+            cy.get('[data-thread_title*="WebSocket Title Test"]') // Thread container
+                .should('exist')
+                .within(() => {
+                    cy.get('[data-testid="thread-list-item"]') // Verify the thread title
+                        .should('contain', 'WebSocket Title Test');
+                    cy.get('.thread-content') // Verify the thread content
+                        .should('contain', 'WebSocket Content Test');
+                    cy.get('.label_forum') // Verify the thread category
+                        .should('contain', 'Question');
+                });
+
+            let id = NaN;
+            cy.get('[data-thread_title*="WebSocket Title Test"]')
+                .should('exist')
+                .invoke('attr', 'data-thread_id')
+                .then((val) => {
+                    id = Number(val); // Parse the inserted thread ID
+                    expect(id).to.be.a('number');
+                    expect(id).to.be.greaterThan(0);
+
+                    cy.get('[data-thread_title*="WebSocket Title Test"]')
+                        .should('exist')
+                        .click();
+                    cy.url().should('include', buildUrl(['sample', 'forum', 'threads', id], true));
+                });
+
             removeThread('WebSocket Title Test');
             cy.get('[data-testid="thread-list-item"]').contains('WebSocket Title Test').should('not.exist');
         });
     });
 
     it('Should prevent students from replying when lock date is in the past and allow replying when lock date is cleared', () => {
+        return;
         createThread(title1, content1, 'Comment');
         setLockDateToPast(title1);
         cy.login('student');
@@ -170,6 +201,7 @@ describe('Forum Thread Lock Date Functionality', () => {
 
 describe('Should test creating, replying, merging, removing, and upducks in forum', () => {
     beforeEach(() => {
+        return;
         cy.login('instructor');
         cy.visit(['sample', 'forum']);
         cy.get('#nav-sidebar-collapse-sidebar').click();
@@ -179,6 +211,7 @@ describe('Should test creating, replying, merging, removing, and upducks in foru
     });
 
     it('Remove threads removes all threads with the same title', () => {
+        return;
         createThread(title1, content1, 'Comment');
         createThread(title1, content1, 'Comment');
         removeThread(title1);
@@ -186,12 +219,14 @@ describe('Should test creating, replying, merging, removing, and upducks in foru
     });
 
     it('Reply button is disabled when applicable and thread reply can contain an attachment', () => {
+        return;
         createThread(title1, title1, 'Comment');
         replyDisabled(title1, attachment1);
         removeThread(title1);
     });
 
     it('Form content is not cleared while submitting with empty description', () => {
+        return;
         cy.get('[data-testid="Create Thread"]').click();
         cy.get('[data-testid="title"]').type(title1);
         cy.get('[data-testid="categories-pick-list"]').contains('Comment').click();
@@ -206,6 +241,7 @@ describe('Should test creating, replying, merging, removing, and upducks in foru
     });
 
     it('Create, reply to, merge, and delete threads', () => {
+        return;
         // Add and Delete Image Attachment
         uploadAttachmentAndDelete(title4, attachment1);
         createThread(title1, content1, 'Comment');

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -345,7 +345,7 @@ function submitToggleLikeRequest({ threadId, postId, currentUser, apiKey }) {
         body: {
             thread_id: threadId,
             post_id: postId,
-            current_user: currentUser
+            current_user: currentUser,
         },
     }).then((response) => {
         return JSON.parse(Cypress.Blob.arrayBufferToBinaryString(response.body) || '{}');

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -129,9 +129,6 @@ describe('Forum Thread Lock Date Functionality', () => {
     });
 
     it('Should verify WebSocket functionality', () => {
-        // Visit the forum thread page
-        cy.visit(['sample', 'forum']);
-
         // Create a new thread via a POST request
         const body = {
             'title': title5,
@@ -142,8 +139,6 @@ describe('Forum Thread Lock Date Functionality', () => {
             'expirationDate': new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString(), // 1 week from now
             'thread_status': -1,
         };
-
-        removeThread(title5);
 
         verifyWebSocketFunctionality(buildUrl(['sample', 'forum', 'threads', 'new'], true), 'POST', 'multipart/form-data', body, (response) => {
             expect(response.status).to.eq(200);

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -1,3 +1,5 @@
+import { buildUrl, verifyWebSocketFunctionality } from '../../support/utils';
+
 const title1 = 'Cypress Title 1 Cypress';
 const title2 = 'Cypress Title 2 Cypress';
 const title3 = 'Cypress Title 3 Cypress';
@@ -122,6 +124,28 @@ describe('Forum Thread Lock Date Functionality', () => {
         cy.login('instructor');
         cy.visit(['sample', 'forum']);
         cy.get('#nav-sidebar-collapse-sidebar').click();
+    });
+
+    it('Should verify WebSocket functionality', () => {
+        // Visit the forum thread page
+        cy.visit(['sample', 'forum']);
+
+        // Create a new thread via a POST request
+        const formData = new FormData();
+        formData.append('title', 'WebSocket Title Test');
+        formData.append('markdown_status', 0);
+        formData.append('lock_thread_date', '');
+        formData.append('thread_post_content', 'WebSocket Content Test');
+        formData.append('cat[]', '2'); //  TODO: to prevent flaky tests, fetch all categories to not map to magic numbers ["Question" == 2]
+        formData.append('expirationDate', new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString()); // 1 week from now
+        formData.append('thread_status', -1);
+
+        verifyWebSocketFunctionality('POST', buildUrl(['sample', 'forum', 'threads', 'new'], true), formData, (response) => {
+            expect(response.status).to.eq(200);
+            cy.get('[data-testid="thread-list-item"]').contains('WebSocket Title Test').should('exist');
+            removeThread('WebSocket Title Test');
+            cy.get('[data-testid="thread-list-item"]').contains('WebSocket Title Test').should('not.exist');
+        });
     });
 
     it('Should prevent students from replying when lock date is in the past and allow replying when lock date is cleared', () => {

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -338,20 +338,17 @@ function submitToggleLikeRequest({ threadId, postId, currentUser, apiKey }) {
         'Authorization': apiKey,
     };
 
-    return cy.window().then((window) => {
-        return cy.request({
-            method: 'POST',
-            url,
-            headers,
-            body: {
-                thread_id: threadId,
-                post_id: postId,
-                current_user: currentUser,
-                csrf_token: window.csrfToken,
-            },
-        }).then((response) => {
-            return JSON.parse(Cypress.Blob.arrayBufferToBinaryString(response.body) || '{}');
-        });
+    return cy.request({
+        method: 'POST',
+        url,
+        headers,
+        body: {
+            thread_id: threadId,
+            post_id: postId,
+            current_user: currentUser
+        },
+    }).then((response) => {
+        return JSON.parse(Cypress.Blob.arrayBufferToBinaryString(response.body) || '{}');
     });
 }
 

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -62,33 +62,50 @@ export function buildUrl(parts = [], include_base = false) {
 }
 
 /**
+ * Format the body of the request based on the content type and the CSRF token
+ *
+ * @param {Object} body - The body of the request, which can be a FormData or JSON object
+ * @param {String} contentType - The content type of the request, which can be 'multipart/form-data' or 'application/json'
+ * @param {String} csrfToken - The CSRF token to be added to the request
+ * @returns {Object} - The formatted body of the request
+ */
+function formatBody(body, contentType, csrfToken) {
+    if (contentType === 'multipart/form-data') {
+        const formData = new FormData();
+
+        for (const [key, value] of Object.entries(body)) {
+            formData.append(key, value);
+        }
+        formData.append('csrf_token', csrfToken);
+        return formData;
+    }
+    else {
+        return { ...body, csrf_token: csrfToken };
+    }
+}
+
+/**
  * Verify the WebSocket functionality of a given request.
  *
- * @param {String} user - The user to verify the WebSocket functionality for
- * @param {String} method - The HTTP method to use for the request
  * @param {String} url - The URL to send the request to
+ * @param {String} method - The HTTP method to use for the request
+ * @param {String} contentType - The content type of the request, which can be 'multipart/form-data' or 'application/json'
  * @param {Object} body - The body of the request, which can be a FormData object or a JSON object
  * @param {Function} verifyResponse - The method to call once the response can be verified, which should verify the response and updates to the DOM
  */
 export function verifyWebSocketFunctionality(
-    method = 'GET',
     url = '',
+    method = 'GET',
+    contentType = 'application/json',
     body = {},
     verifyResponse = () => {},
 ) {
     cy.window().then(async (window) => {
-        if (body instanceof FormData) {
-            body.append('csrf_token', window.csrfToken);
-        }
-        else {
-            body.csrf_token = window.csrfToken;
-        }
-
         cy.request({
-            headers: { 'Content-Type': body instanceof FormData ? 'multipart/form-data' : 'application/json' },
+            headers: { 'Content-Type': contentType },
             method: method,
             url: url,
-            body: body,
+            body: formatBody(body, contentType, window.csrfToken),
         }).then((response) => {
             verifyResponse(response);
         });

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -100,16 +100,18 @@ export function verifyWebSocketFunctionality(
     body = {},
     verifyResponse = () => {},
 ) {
-    cy.window().then(async (window) => {
+    return cy.window().then(async (window) => {
         cy.request({
             headers: { 'Content-Type': contentType },
             method: method,
             url: buildUrl(urlArray, true), // Always include the base URL for websocket requests
             body: formatBody(body, contentType, window.csrfToken),
         }).then((res) => {
+            console.log(res);
+            console.log(Cypress.Blob.arrayBufferToBinaryString(res.body));
             // Cypress response body is returned as an array buffer, so we need to parse it into a valid JSON representation
             const response = JSON.parse(Cypress.Blob.arrayBufferToBinaryString(res.body) || '{}');
-
+            console.log(response);
             if (Object.keys(response).length > 0) {
                 // Handle responses returning data, such as create requests
                 expect(response.status).to.equal('success');

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -112,11 +112,11 @@ export function verifyWebSocketFunctionality(
 
             if (res.redirects && Array.isArray(res.redirects)) {
                 // Handle redirects
+                const index = res.redirects[0].indexOf('http');
+                const redirect = res.redirects[0].slice(index).trim();
                 response = {
                     status: 'success',
-                    data: {
-                        redirect: `http${res.redirects[0].split('http')[1].trim()}`,
-                    },
+                    data: { redirect },
                 };
             }
             else {

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -108,7 +108,21 @@ export function verifyWebSocketFunctionality(
             body: formatBody(body, contentType, window.csrfToken),
         }).then((res) => {
             // Cypress response body is returned as an array buffer, so we need to parse it into a valid JSON representation
-            const response = JSON.parse(Cypress.Blob.arrayBufferToBinaryString(res.body) || '{}');
+            let response;
+
+            if (res.redirects && Array.isArray(res.redirects)) {
+                // Handle redirects
+                response = {
+                    status: 'success',
+                    data: {
+                        redirect: `http${res.redirects[0].split('http')[1].trim()}`,
+                    },
+                };
+            }
+            else {
+                response = JSON.parse(Cypress.Blob.arrayBufferToBinaryString(res.body) || '{}');
+            }
+
             if (Object.keys(response).length > 0) {
                 // Handle responses returning data, such as create requests
                 expect(response.status).to.equal('success');

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -60,3 +60,37 @@ export function buildUrl(parts = [], include_base = false) {
 
     return `${url}courses/${getCurrentSemester()}/${parts.join('/')}`;
 }
+
+/**
+ * Verify the WebSocket functionality of a given request.
+ *
+ * @param {String} user - The user to verify the WebSocket functionality for
+ * @param {String} method - The HTTP method to use for the request
+ * @param {String} url - The URL to send the request to
+ * @param {Object} body - The body of the request, which can be a FormData object or a JSON object
+ * @param {Function} verifyResponse - The method to call once the response can be verified, which should verify the response and updates to the DOM
+ */
+export function verifyWebSocketFunctionality(
+    method = 'GET',
+    url = '',
+    body = {},
+    verifyResponse = () => {},
+) {
+    cy.window().then(async (window) => {
+        if (body instanceof FormData) {
+            body.append('csrf_token', window.csrfToken);
+        }
+        else {
+            body.csrf_token = window.csrfToken;
+        }
+
+        cy.request({
+            headers: { 'Content-Type': body instanceof FormData ? 'multipart/form-data' : 'application/json' },
+            method: method,
+            url: url,
+            body: body,
+        }).then((response) => {
+            verifyResponse(response);
+        });
+    });
+}

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -70,7 +70,7 @@ export function buildUrl(parts = [], include_base = false) {
  * @returns {Object} - The formatted body of the request
  */
 function formatBody(body, contentType, csrfToken) {
-    if (contentType !== 'application/json') {
+    if (contentType === 'multipart/form-data') {
         const formData = new FormData();
 
         for (const [key, value] of Object.entries(body)) {

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -84,7 +84,7 @@ function formatRequestBody(body, contentType, csrfToken) {
         return formData;
     }
     else {
-        return { ...body, csrf_token: csrfToken };
+        return { ...body, csrf_token: csrfToken || undefined };
     }
 }
 
@@ -97,6 +97,7 @@ function formatRequestBody(body, contentType, csrfToken) {
  * @param {Object} body - The body of the request, which can be a FormData object or a JSON object
  * @param {Function} successCallback - The method to call for response and UI verification
  * @param {String} apiKey - The API key to use for the request Authorization header, if present
+
  */
 export function verifyWebSocketFunctionality(
     urlArray = [],
@@ -106,6 +107,7 @@ export function verifyWebSocketFunctionality(
     successCallback = () => {},
     apiKey = '',
 ) {
+    const url = buildUrl(urlArray, true);
     return cy.window().then(async (window) => {
         cy.request({
             headers: {
@@ -113,7 +115,7 @@ export function verifyWebSocketFunctionality(
                 'Authorization': apiKey || undefined,
             },
             method: method,
-            url: buildUrl(urlArray, true),
+            url: apiKey ? url.replace('courses/', 'api/courses/') : url,
             body: formatRequestBody(body, contentType, apiKey ? undefined : window.csrfToken),
         }).then((res) => {
             let response;

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -94,7 +94,7 @@ function formatRequestBody(body, contentType, csrfToken) {
  * @param {String[]} urlArray - The URL parts to string together using the buildUrl function including the base URL
  * @param {String} method - The HTTP method to use for the request
  * @param {String} contentType - The content type of the request, which can be 'multipart/form-data' or 'application/json'
- * @param {Object} body - The body of the request, which can be a FormData object or a JSON object
+ * @param {Object} body - The body of the request, which should be a JSON object
  * @param {Function} successCallback - The method to call for response and UI verification
  * @param {String} apiKey - The API key to use for the request Authorization header, if present
 

--- a/site/cypress/support/utils.js
+++ b/site/cypress/support/utils.js
@@ -107,11 +107,8 @@ export function verifyWebSocketFunctionality(
             url: buildUrl(urlArray, true), // Always include the base URL for websocket requests
             body: formatBody(body, contentType, window.csrfToken),
         }).then((res) => {
-            console.log(res);
-            console.log(Cypress.Blob.arrayBufferToBinaryString(res.body));
             // Cypress response body is returned as an array buffer, so we need to parse it into a valid JSON representation
             const response = JSON.parse(Cypress.Blob.arrayBufferToBinaryString(res.body) || '{}');
-            console.log(response);
             if (Object.keys(response).length > 0) {
                 // Handle responses returning data, such as create requests
                 expect(response.status).to.equal('success');

--- a/site/ts/ta-grading-panels.ts
+++ b/site/ts/ta-grading-panels.ts
@@ -10,16 +10,16 @@ declare global {
 }
 
 // Panel elements info to be used for layout designs
-type PanelElement =
-    | 'autograding_results'
-    | 'grading_rubric'
-    | 'submission_browser'
-    | 'solution_ta_notes'
-    | 'student_info'
-    | 'grade_inquiry_info'
-    | 'discussion_browser'
-    | 'peer_info'
-    | 'notebook-view';
+type PanelElement
+    = | 'autograding_results'
+        | 'grading_rubric'
+        | 'submission_browser'
+        | 'solution_ta_notes'
+        | 'student_info'
+        | 'grade_inquiry_info'
+        | 'discussion_browser'
+        | 'peer_info'
+        | 'notebook-view';
 
 let panelElements: Array<{ str: PanelElement; icon: string }> = [
     { str: 'autograding_results', icon: '.grading_toolbar .fa-list' },

--- a/site/vue/src/ts/sql-toolbox.ts
+++ b/site/vue/src/ts/sql-toolbox.ts
@@ -1,7 +1,7 @@
 import { buildCourseUrl, getCsrfToken } from '../../../ts/utils/server';
 
-export type ServerResponse<T> =
-    | {
+export type ServerResponse<T>
+    = | {
         status: 'success';
         data: T;
     }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

WebSocket functionality can be quite complex, and we currently have no existing infrastructure to validate our message producers and consumers. The `forum.js` WebSocket message handler alone contains thirteen different types of messages it can receive, where many existing tests don't cover their functionality, as a successful response may lead to a full page reload or redirection.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

Discussion forum end-to-end tests have been augmented to include an additional section to test the WebSocket functionality as an instructor. API requests will be made either through the user API key or the local CSRF token for testing purposes. This also serves as a great foundation for future WebSocket E2E tests.

### What steps should a reviewer take to reproduce or test the bug or new feature?

To quickly run the additional Cypress tests, comment out the prior discussion forum testing blocks, `describe`, and run the tests locally via `npx cypress open` from the `/site` directory.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

A new `describe` block has been added to the existing `forum.spec.js` to implement these end-to-end tests.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

N/A
