### PR TITLE
[Bugfix:InstructorUI]

### DIFF
--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -351,29 +351,33 @@ $(document).ready(() => {
 
 function checkWarningBanners() {
     $('#gradeable-dates-warnings-banner').hide();
-    if ($('#yes_grade_inquiry_allowed').is(':checked')) {
-        const grade_inquiry_start_date = $('#date_grade_inquiry_start').val();
-        const grade_inquiry_due_date = $('#date_grade_inquiry_due').val();
+    // show banners only if we can see the grade inquiry dates and theyre not disabled
+    if ($('#date_grade_inquiry_start').is(':visible') && $('#date_grade_inquiry_due').is(':visible')
+        && !$('#date_grade_inquiry_start').is(':disabled') && !$('#date_grade_inquiry_due').is(':disabled')) {
+        if ($('#yes_grade_inquiry_allowed').is(':checked')) {
+            const grade_inquiry_start_date = $('#date_grade_inquiry_start').val();
+            const grade_inquiry_due_date = $('#date_grade_inquiry_due').val();
 
-        // hide/show the element when the start date is before/after the due date respectfully
-        if (grade_inquiry_start_date > grade_inquiry_due_date) {
-            $('#grade-inquiry-dates-warning').show();
-            $('#gradeable-dates-warnings-banner').show();
+            // hide/show the element when the start date is before/after the due date respectfully
+            if (grade_inquiry_start_date > grade_inquiry_due_date) {
+                $('#grade-inquiry-dates-warning').show();
+                $('#gradeable-dates-warnings-banner').show();
+            }
+            else {
+                $('#grade-inquiry-dates-warning').hide();
+            }
         }
-        else {
-            $('#grade-inquiry-dates-warning').hide();
-        }
-    }
 
-    if ($('#has_release_date_yes').is(':checked')) {
-        const release_date = $('#date_released').val();
-        const grade_inquiry_due_date = $('#date_grade_inquiry_due').val();
-        if (release_date > grade_inquiry_due_date) {
-            $('#no-grade-inquiry-warning').show();
-            $('#gradeable-dates-warnings-banner').show();
-        }
-        else {
-            $('#release-dates-warning').hide();
+        if ($('#has_release_date_yes').is(':visible')) {
+            const release_date = $('#date_released').val();
+            const grade_inquiry_due_date = $('#date_grade_inquiry_due').val();
+            if (release_date > grade_inquiry_due_date) {
+                $('#no-grade-inquiry-warning').show();
+                $('#gradeable-dates-warnings-banner').show();
+            }
+            else {
+                $('#release-dates-warning').hide();
+            }
         }
     }
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
#11095 removes the grade inquriy constraint. However, the javascript on the frontend doesn't fully check if grade inquries are even active. This leads to simple gradeables (checkpoint, numeric) having a grade inquiry banner while not having any grade inquries at all.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Simple Gradeables will no longer have grade inquiries. Electronic gradeables that have grade inquries and invalid grade inquries will display a banner

### What steps should a reviewer take to reproduce or test the bug or new feature?
Check simple gradeable, should never have banner display despite whatever date is put on the screen.
Check electronic gradeable, should have banner display if start > end and if start < grade_release

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
