### PR TITLE
[Bugfix:InstructorUI] Fix missing docker image userid

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9491,7 +9491,7 @@ ORDER BY
     public function getDockerImageOwner(string $image): string|false {
         $this->submitty_db->query("SELECT image_name, user_id FROM docker_images WHERE image_name = ?", [$image]);
         $row = $this->submitty_db->row();
-        if ($row) {
+        if ($row === []) {
             return false;
         }
         return $row['user_id'] ?? '';

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -166,8 +166,7 @@ $(document).ready(() => {
     };
 
     ajaxCheckBuildStatus();
-    // eslint-disable-next-line @stylistic/max-statements-per-line
-    setTimeout(() => { checkWarningBanners(); }, 0);
+    checkWarningBanners();
     $('input:not(#random-peer-graders-list,#number_to_peer_grade),select,textarea').change(function () {
         if ($(this).hasClass('date-radio') && is_electronic) {
             updateDueDate();
@@ -352,13 +351,6 @@ $(document).ready(() => {
 
 function checkWarningBanners() {
     $('#gradeable-dates-warnings-banner').hide();
-
-    // early return if grade inquiry dates are not visible or disabled
-    if (!($('#date_grade_inquiry_start').is(':visible') && $('#date_grade_inquiry_due').is(':visible')
-        && !$('#date_grade_inquiry_start').is(':disabled') && !$('#date_grade_inquiry_due').is(':disabled'))) {
-        return;
-    }
-
     if ($('#yes_grade_inquiry_allowed').is(':checked')) {
         const grade_inquiry_start_date = $('#date_grade_inquiry_start').val();
         const grade_inquiry_due_date = $('#date_grade_inquiry_due').val();


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Image rights gets lost whenever an instructor uploads the same image with a different capability. This is because whenever we check for the current owner, an empty string is returned as the select statement selects one string and returns the next, and there is no next string because there can only be a single owner.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
We have a temporary value for the current row, and return that value as part of the function

### What steps should a reviewer take to reproduce or test the bug or new feature?
Add a new docker image under instructor, ex `submitty/prolog:8`, with a capability of default.
Add the same docker image under instructor `submitty/prolog:8` with a capability of cpp.
Image owner should not change with this PR fix.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
This PR allows users to "hijack" the default images and remove them since these images are not initially inserted into the master database. An existing migration introduced in PR #8845 (https://github.com/Submitty/Submitty/blob/main/migration/migrator/migrations/master/20240219141515_docker_image.py) should insert these images into the database.
