### PR TITLE
[Bugfix:InstructorUI] Hide Withdrawn Students for Graders

### DIFF
--- a/site/public/js/details.js
+++ b/site/public/js/details.js
@@ -146,6 +146,7 @@ function filterWithdrawnUpdate() {
 window.addEventListener('DOMContentLoaded', () => {
     const inquiryFilterStatus = Cookies.get('inquiry_status');
     const withdrawnFilterElements = $('[data-student="electronic-grade-withdrawn"]');
+    withdrawnFilterElements.hide();
     // Instructors and TAs have access to all toggles
     if (full_access_grader_permission) {
         // Only Assigned Sections


### PR DESCRIPTION
Hides withdrawn students by default instead of showing them by default

### Why is this Change Important & Necessary?
Graders are not supposed to be able to see withdrawn students (unless it is a team assignment). Currently, graders always see withdrawn students.

### What is the New Behavior?
By default, withdrawn students will not be displayed on page load. This change does not affect Instructors or TAs as they have full grading access.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Manage Students -> change several students to withdrawn
2. [AS INSTRUCTOR] verify that you can toggle withdrawn students
3. [AS MENTOR] verify that you cannot see withdrawn students, or toggle them

### Other information
This is not a breaking change.
