### PR TITLE
[Refactor:Developer] Modularize install_site

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER_SITE.sh
@@ -2,4 +2,4 @@
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 SUBMITTY_CONFIG_DIR="/usr/local/submitty/config"
-bash "${THIS_DIR}/install_submitty/install_site.sh" browscap "config=${SUBMITTY_CONFIG_DIR:?}"
+bash "${THIS_DIR}/install_submitty/install_site.sh" "config=${SUBMITTY_CONFIG_DIR:?}" "$@"

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -59,6 +59,7 @@ CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../../../../config
 SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' ${CONF_DIR}/submitty.json)
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' ${CONF_DIR}/submitty.json)
 SUBMITTY_DATA_DIR=$(jq -r '.submitty_data_dir' ${SUBMITTY_INSTALL_DIR}/config/submitty.json)
+DEBUG_MODE=$(jq -r '.debugging_enabled' ${SUBMITTY_INSTALL_DIR}/config/database.json)
 PHP_USER=$(jq -r '.php_user' ${CONF_DIR}/submitty_users.json)
 PHP_GROUP=${PHP_USER}
 CGI_USER=$(jq -r '.cgi_user' ${CONF_DIR}/submitty_users.json)
@@ -76,6 +77,12 @@ do
         SUBMITTY_CONFIG_DIR="$(readlink -f "$(echo "$cli_arg" | cut -f2 -d=)")"
     elif [ "$cli_arg" == "browscap" ]; then
         BROWSCAP=true
+    elif [[ $cli_arg == "skip-vendor" ]]; then
+        SKIP_VENDOR=true
+    elif [[ $cli_arg == "skip-node" ]]; then
+        SKIP_NODE=true
+    elif [[ $cli_arg == "skip-npm-build" ]]; then
+        SKIP_NPM_BUILD=true
     fi
 done
 
@@ -238,7 +245,7 @@ for entry in "${result_array[@]}"; do
     fi
 done
 
-if echo "${result}" | grep -E -q "composer\.(json|lock)"; then
+if [ -z "${SKIP_VENDOR}" ]; then
     # install composer dependencies and generate classmap
     if [ ${VAGRANT} == 1 ]; then
         su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --dev --prefer-dist --optimize-autoloader"
@@ -246,20 +253,15 @@ if echo "${result}" | grep -E -q "composer\.(json|lock)"; then
         su - ${PHP_USER} -c "composer install -d \"${SUBMITTY_INSTALL_DIR}/site\" --no-dev --prefer-dist --optimize-autoloader"
     fi
     chown -R ${PHP_USER}:${PHP_USER} ${SUBMITTY_INSTALL_DIR}/site/vendor
-else
-    if [ ${VAGRANT} == 1 ]; then
-        su - ${PHP_USER} -c "composer dump-autoload -d \"${SUBMITTY_INSTALL_DIR}/site\" --optimize"
-    else
-        su - ${PHP_USER} -c "composer dump-autoload -d \"${SUBMITTY_INSTALL_DIR}/site\" --optimize --no-dev"
-    fi
-    chown -R ${PHP_USER}:${PHP_USER} ${SUBMITTY_INSTALL_DIR}/site/vendor/composer
+
+    find ${SUBMITTY_INSTALL_DIR}/site/vendor -type d -exec chmod 551 {} \;
+    find ${SUBMITTY_INSTALL_DIR}/site/vendor -type f -exec chmod 440 {} \;
 fi
 
-find ${SUBMITTY_INSTALL_DIR}/site/vendor -type d -exec chmod 551 {} \;
-find ${SUBMITTY_INSTALL_DIR}/site/vendor -type f -exec chmod 440 {} \;
-
 # create doctrine proxy classes
-php "${SUBMITTY_INSTALL_DIR}/sbin/doctrine.php" "orm:generate-proxies"
+if [ $DEBUG_MODE != true ]; then
+    php "${SUBMITTY_INSTALL_DIR}/sbin/doctrine.php" "orm:generate-proxies"
+fi
 
 # load lang files
 php "${SUBMITTY_INSTALL_DIR}/sbin/load_lang.php" "${SUBMITTY_REPOSITORY}/../Localization/lang" "${SUBMITTY_INSTALL_DIR}/site/cache/lang"
@@ -280,7 +282,7 @@ NODE_FOLDER=${SUBMITTY_INSTALL_DIR}/site/node_modules
 
 chmod 440 ${SUBMITTY_INSTALL_DIR}/site/composer.lock
 
-if echo "{$result}" | grep -E -q "package(-lock)?.json"; then
+if [[ -z "${SKIP_NODE}" ]]; then
     # Install JS dependencies and then copy them into place
     # We need to create the node_modules folder initially if it
     # doesn't exist, or else submitty_php won't be able to make it
@@ -410,23 +412,25 @@ chmod 550 ${SUBMITTY_INSTALL_DIR}/site/cgi-bin/git-http-backend
 mkdir -p "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chgrp "${PHP_USER}" "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
-echo "Running esbuild"
-chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
-chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
-chmod a+x ${NODE_FOLDER}/vite/bin/vite.js
-chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
-chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
-chmod +w "${SUBMITTY_INSTALL_DIR}/site/vue"
-su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm run build"
-chmod -w "${SUBMITTY_INSTALL_DIR}/site/vue"
-chmod a-x ${NODE_FOLDER}/esbuild/bin/esbuild
-chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
-chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
-chmod a-x ${NODE_FOLDER}/vite/bin/vite.js
-chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+if [[ -z "${SKIP_NPM_BUILD}" ]]; then
+    echo "Running esbuild"
+    chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
+    chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
+    chmod a+x ${NODE_FOLDER}/vite/bin/vite.js
+    chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+    chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+    chmod +w "${SUBMITTY_INSTALL_DIR}/site/vue"
+    su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm run build"
+    chmod -w "${SUBMITTY_INSTALL_DIR}/site/vue"
+    chmod a-x ${NODE_FOLDER}/esbuild/bin/esbuild
+    chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
+    chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
+    chmod a-x ${NODE_FOLDER}/vite/bin/vite.js
+    chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
-chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs
-set_mjs_permission ${SUBMITTY_INSTALL_DIR}/site/public/mjs
+    chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs
+    set_mjs_permission ${SUBMITTY_INSTALL_DIR}/site/public/mjs
+fi
 
 # cache needs to be writable
 find ${SUBMITTY_INSTALL_DIR}/site/cache -type d -exec chmod u+w {} \;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
`submitty_install_site` currently has two issues:
1. It can be flaky deciding if `composer install` and `npm install` are needed causing install to complete unsuccessfully
2. It is very slow when attempting to iterate locally

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
`submitty_install_site` will always run `composer install` and `npm install` by default but has 3 new arguments to skip potentially unneeded build phases. The fastest install can be run via `submitty_install_site skip-vendor skip-node skip-npm-build` and takes 1.1s on my development vm compared to 27.9s on main when not running either dependency install command.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Run `submitty_install_site`
2. Attempt different combinations of `skip-vendor`, `skip-node`, and `skip-npm-build`

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
