### PR TITLE
[Bugfix:TAGrading] Error on missing autograding config for status

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -513,6 +513,16 @@ class ElectronicGraderController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
 
+        if (!$gradeable->hasAutogradingConfig()) {
+            $this->core->getOutput()->renderOutput(
+                'Error',
+                'unbuiltGradeable',
+                $gradeable,
+                "grades"
+            );
+            return;
+        }
+
         // Make sure this gradeable is an electronic file gradeable
         if ($gradeable->getType() !== GradeableType::ELECTRONIC_FILE) {
             $this->core->addErrorMessage('This gradeable is not an electronic file gradeable');


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When you visit /grading/status and the gradeable config has an error, you will get a frog robot

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
This PR specifically checks for a missing autograding configuration before rendering the page, ensuring that there will be no frog robot.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Break a gradeable config. Visit the page. Error. Visit the page with the PR. It will direct you to a different page waiting for the autograding configuration.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
