### PR TITLE
[Refactor:Developer] Refactor untrusted setup from install

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -421,31 +421,7 @@ cp  "${SUBMITTY_REPOSITORY}/.setup/SUBMITTY_TEST.sh"        "${SUBMITTY_INSTALL_
 chown root:root "${SUBMITTY_INSTALL_DIR}/.setup/SUBMITTY_TEST.sh"
 chmod 700       "${SUBMITTY_INSTALL_DIR}/.setup/SUBMITTY_TEST.sh"
 
-########################################################################################################################
-########################################################################################################################
-# PREPARE THE UNTRUSTED_EXEUCTE EXECUTABLE WITH SUID
-
-# copy the file
-rsync -rtz  "${SUBMITTY_REPOSITORY}/.setup/untrusted_execute.c"   "${SUBMITTY_INSTALL_DIR}/.setup/"
-# replace necessary variables
-replace_fillin_variables "${SUBMITTY_INSTALL_DIR}/.setup/untrusted_execute.c"
-
-# SUID (Set owner User ID up on execution), allows the $DAEMON_USER
-# to run this executable as sudo/root, which is necessary for the
-# "switch user" to untrusted as part of the sandbox.
-
-pushd "${SUBMITTY_INSTALL_DIR}/.setup/" > /dev/null
-# set ownership/permissions on the source code
-chown root:root untrusted_execute.c
-chmod 500 untrusted_execute.c
-# compile the code
-g++ -static untrusted_execute.c -o "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
-# change permissions & set suid: (must be root)
-chown root           "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
-chgrp "$DAEMON_USER" "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
-chmod 4550           "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
-popd > /dev/null
-
+bash "${SUBMITTY_REPOSITORY}/.setup/install_submitty/build_untrusted_execute.sh" "config=${SUBMITTY_CONFIG_DIR:?}"
 
 ################################################################################################################
 ################################################################################################################

--- a/.setup/install_submitty/build_untrusted_execute.sh
+++ b/.setup/install_submitty/build_untrusted_execute.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -ev
+
+for cli_arg in "$@"
+do
+    if [[ $cli_arg =~ ^config=.* ]]; then
+        SUBMITTY_CONFIG_DIR="$(readlink -f "$(echo "$cli_arg" | cut -f2 -d=)")"
+    fi
+done
+
+if [ -z "${SUBMITTY_CONFIG_DIR}" ]; then
+    echo "ERROR: This script requires a config dir argument"
+    echo "Usage: ${BASH_SOURCE[0]} config=<config dir>"
+    exit 1
+fi
+
+SUBMITTY_REPOSITORY=$(jq -r '.submitty_repository' "${SUBMITTY_CONFIG_DIR:?}/submitty.json")
+# shellcheck disable=SC1091
+source "${SUBMITTY_REPOSITORY:?}/.setup/install_submitty/get_globals.sh" "config=${SUBMITTY_CONFIG_DIR:?}"
+########################################################################################################################
+########################################################################################################################
+# PREPARE THE UNTRUSTED_EXEUCTE EXECUTABLE WITH SUID
+
+# copy the file
+rsync -rtz  "${SUBMITTY_REPOSITORY}/.setup/untrusted_execute.c"   "${SUBMITTY_INSTALL_DIR}/.setup/"
+# replace necessary variables
+replace_fillin_variables "${SUBMITTY_INSTALL_DIR}/.setup/untrusted_execute.c"
+
+# SUID (Set owner User ID up on execution), allows the $DAEMON_USER
+# to run this executable as sudo/root, which is necessary for the
+# "switch user" to untrusted as part of the sandbox.
+
+pushd "${SUBMITTY_INSTALL_DIR}/.setup/" > /dev/null
+# set ownership/permissions on the source code
+chown root:root untrusted_execute.c
+chmod 500 untrusted_execute.c
+# compile the code
+g++ -static untrusted_execute.c -o "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
+# change permissions & set suid: (must be root)
+chown root           "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
+chgrp "$DAEMON_USER" "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
+chmod 4550           "${SUBMITTY_INSTALL_DIR}/sbin/untrusted_execute"
+popd > /dev/null


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Modularizing submitty_install is important because it will make it easier to manage which installation steps are run.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The `untrusted_execute` setup is split into a new file.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
