### PR TITLE
[Bugfix:CourseMaterails] Fix invalid filepath causes broken database

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -1389,6 +1389,10 @@ function handleEditCourseMaterials(csrf_token, hide_from_students, id, sectionsE
         if (window.isValidFileName(file_name)) {
             formData.append('file_path', file_path);
         }
+        else {
+            alert('Invalid filename');
+            return;
+        }
     }
 
     if (title !== null && window.isValidFileName(title)) {
@@ -1397,6 +1401,9 @@ function handleEditCourseMaterials(csrf_token, hide_from_students, id, sectionsE
             title = encodeURIComponent(`link-${title}`);
         }
         formData.append('title', title);
+    } else {
+        alert('Invalid filename');
+        return;
     }
 
     if (overwrite !== null) {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
A recent issue popped up in a class where having a duplicate folder name to its child filename caused the course materials page to become permanently broken, requiring manual intervention in the database. We have replicated this issue as being one that occurs upon course material edit, but this PR also introduces fixes for other potential ways this error could have happened.

### What is the New Behavior?
We now throw errors in more of the places where they should be thrown, which should prevent bad course materials from being uploaded and edited.

### What steps should a reviewer take to reproduce or test the bug or new feature?

Upload a course material, edit it to have a parent directory with the same name as the file, i.e. 'check.pdf/check.pdf', and then submit. Two alerts should pop up, but upon page reload you should get an error. To reverse this, you must delete the associated course material database entry and the associated file from /var/local/submitty/courses/f25/sample/uploads/course_materials/. Switch to this branch, submitty_install_site, and try to do the same thing. It should now throw the error alert but not cause an error on reload.

### Automated Testing & Documentation
This isn't tested, maybe it should be.

### Other information
N/A
