### PR TITLE
[Refactor:Developer] Refactor Autograding setup scripts

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -45,6 +45,7 @@ runs:
           sudo cp -R SUBMITTY_CPY/. ${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/Submitty
           sudo chmod -R a+rwx  ${SUBMITTY_INSTALL_DIR}
           sudo chmod -R a+rwx /tmp/
+          echo "This file is used to check if Submitty is being run in the Github Actions CI." > ${SUBMITTY_REPOSITORY}/.github_actions_ci_flag
       shell: bash
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -864,15 +864,6 @@ jobs:
             ${{ (matrix.containers == 'Autograding-Development' || matrix.containers == 'Autograding-Tutorial') && '--no_submissions' ||
                 '--test_only_grading' }}
 
-      - name: Copy Autograding Files
-        if: ${{ matrix.containers == 'Autograding-Development' }}
-        run: |
-          cp -R ${{env.SUBMITTY_REPOSITORY}}/more_autograding_examples ${{env.SUBMITTY_REPOSITORY}}/site/cypress/fixtures/copy_of_more_autograding_examples
-
-      - name: Copy sample files
-        run: |
-          cp -R ${{env.SUBMITTY_REPOSITORY}}/sample_files ${{env.SUBMITTY_REPOSITORY}}/site/cypress/fixtures/copy_of_sample_files
-
       # TODO: Remove this block after upgrading jsPDF
       - name: Cache Node Modules
         uses: actions/cache@v4

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -877,13 +877,11 @@ fi
 # Install cypress related files if not in worker mode
 if [ "${IS_WORKER}" == 0 ]; then
     echo -e "Install cypress related files"
-    # rsync if we are on vagrant
-    if [ "${VAGRANT}" == 1 ]; then
-        rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
-        rsync -rtz "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
-    # copy if we are on CI and not vagrant
-    elif [ "${IS_CI}" == 1 ]; then
-        cp -r "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
-        cp -r "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
+    
+    # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
+    copy_cmd=$([ "$IS_VAGRANT" == 1 ] && echo "rsync -rtz" || { [ "$IS_CI" == 1 ] && echo "cp -r"; })
+    if [ -n "$copy_cmd" ]; then
+        $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
+        $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
     fi
 fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -880,6 +880,10 @@ if [ "${IS_WORKER}" == 0 ]; then
     
     # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
     copy_cmd=$([ "$IS_VAGRANT" == 1 ] && echo "rsync -rtz" || { [ "$IS_CI" == 1 ] && echo "cp -r"; })
+    echo "IS_VAGRANT: $IS_VAGRANT"
+    echo "IS_CI: $IS_CI"
+    echo "copy_cmd='$copy_cmd'"
+    echo "Length: ${#copy_cmd}"
     if [ -n "$copy_cmd" ]; then
         $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
         $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -285,7 +285,7 @@ if [ "${IS_WORKER}" == 0 ]; then
     # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
     if [ "${IS_VAGRANT}" == 1 ]; then
         copy_cmd="rsync -rtz"
-    elif [ "${CI}" == 1 ]; then
+    elif [ "${IS_CI}" == 1 ]; then
         copy_cmd="cp -r"
     else
         copy_cmd=""

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -282,7 +282,6 @@ if [ "${IS_WORKER}" == 0 ]; then
     find "${SUBMITTY_INSTALL_DIR}/more_autograding_examples" -type f -exec chmod 444 {} \;
 
     # Install cypress related files that are elsewhere in the repository
-    # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
     if [ "${IS_VAGRANT}" == 1 ]; then
         copy_cmd="rsync -rtz"
     elif [ "${IS_CI}" == 1 ]; then

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -876,11 +876,17 @@ fi
 ################################################################################################################
 # Install cypress related files if not in worker mode
 if [ "${IS_WORKER}" == 0 ]; then
-    echo -e "Install cypress related files"
-    
     # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
-    copy_cmd=$([ "$IS_VAGRANT" = 1 ] && echo "rsync -rtz" || ([ "$IS_CI" = 1 ] && echo "cp -r" || echo ""))
+    if [ "${IS_VAGRANT}" == 1 ]; then
+        copy_cmd="rsync -rtz"
+    elif [ "${CI}" == 1 ]; then
+        copy_cmd="cp -r"
+    else
+        copy_cmd=""
+    fi
+
     if [ -n "$copy_cmd" ]; then
+        echo -e "Install cypress related files"
         $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
         $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
     fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -879,11 +879,7 @@ if [ "${IS_WORKER}" == 0 ]; then
     echo -e "Install cypress related files"
     
     # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
-    copy_cmd=$([ "$IS_VAGRANT" == 1 ] && echo "rsync -rtz" || { [ "$IS_CI" == 1 ] && echo "cp -r"; })
-    echo "IS_VAGRANT: $IS_VAGRANT"
-    echo "IS_CI: $IS_CI"
-    echo "copy_cmd='$copy_cmd'"
-    echo "Length: ${#copy_cmd}"
+    copy_cmd=$([ "$IS_VAGRANT" = 1 ] && echo "rsync -rtz" || ([ "$IS_CI" = 1 ] && echo "cp -r" || echo ""))
     if [ -n "$copy_cmd" ]; then
         $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
         $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -280,6 +280,22 @@ if [ "${IS_WORKER}" == 0 ]; then
     # but everyone can read all that files & directories, and cd into all the directories
     find "${SUBMITTY_INSTALL_DIR}/more_autograding_examples" -type d -exec chmod 555 {} \;
     find "${SUBMITTY_INSTALL_DIR}/more_autograding_examples" -type f -exec chmod 444 {} \;
+
+    # Install cypress related files that are elsewhere in the repository
+    # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
+    if [ "${IS_VAGRANT}" == 1 ]; then
+        copy_cmd="rsync -rtz"
+    elif [ "${CI}" == 1 ]; then
+        copy_cmd="cp -r"
+    else
+        copy_cmd=""
+    fi
+
+    if [ -n "$copy_cmd" ]; then
+        echo -e "Install cypress related files"
+        $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
+        $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
+    fi
 fi
 ########################################################################################################################
 ########################################################################################################################
@@ -870,24 +886,4 @@ else
     chmod 750 "${SUBMITTY_INSTALL_DIR}/sbin/update_worker_sysinfo.sh"
     "${SUBMITTY_INSTALL_DIR}/sbin/update_worker_sysinfo.sh" UpdateDockerImages
     "${SUBMITTY_INSTALL_DIR}/sbin/update_worker_sysinfo.sh" UpdateSystemInfo
-fi
-
-################################################################################################################
-################################################################################################################
-# Install cypress related files if not in worker mode
-if [ "${IS_WORKER}" == 0 ]; then
-    # rsync if we are on vagrant. cp if we are on CI and not vagrant. do nothing otherwise
-    if [ "${IS_VAGRANT}" == 1 ]; then
-        copy_cmd="rsync -rtz"
-    elif [ "${CI}" == 1 ]; then
-        copy_cmd="cp -r"
-    else
-        copy_cmd=""
-    fi
-
-    if [ -n "$copy_cmd" ]; then
-        echo -e "Install cypress related files"
-        $copy_cmd "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
-        $copy_cmd "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
-    fi
 fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -881,7 +881,6 @@ if [ "${IS_WORKER}" == 0 ]; then
     if [ "${VAGRANT}" == 1 ]; then
         rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
         rsync -rtz "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
-    fi
     # copy if we are on CI and not vagrant
     elif [ "${IS_CI}" == 1 ]; then
         cp -r "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -871,3 +871,20 @@ else
     "${SUBMITTY_INSTALL_DIR}/sbin/update_worker_sysinfo.sh" UpdateDockerImages
     "${SUBMITTY_INSTALL_DIR}/sbin/update_worker_sysinfo.sh" UpdateSystemInfo
 fi
+
+################################################################################################################
+################################################################################################################
+# Install cypress fixtures if not in worker mode
+if [ "${IS_WORKER}" == 0 ]; then
+    echo -e "Install cypress fixtures"
+    # rsync if we are on vagrant
+    if [ "${VAGRANT}" == 1 ]; then
+        rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
+        rsync -rtz "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
+    fi
+    # copy if we are on CI and not vagrant
+    elif [ "${IS_CI}" == 1 ]; then
+        cp -r "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
+        cp -r "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
+    fi
+fi

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -874,9 +874,9 @@ fi
 
 ################################################################################################################
 ################################################################################################################
-# Install cypress fixtures if not in worker mode
+# Install cypress related files if not in worker mode
 if [ "${IS_WORKER}" == 0 ]; then
-    echo -e "Install cypress fixtures"
+    echo -e "Install cypress related files"
     # rsync if we are on vagrant
     if [ "${VAGRANT}" == 1 ]; then
         rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"

--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -275,12 +275,6 @@ if [ "${IS_WORKER}" == 0 ]; then
     # copy the files from the repo
     rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples" "${SUBMITTY_INSTALL_DIR}"
 
-    # copy more_autograding_examples in order to make cypress autograding work
-    if [ "${VAGRANT}" == 1 ]; then 
-        rsync -rtz "${SUBMITTY_REPOSITORY}/more_autograding_examples/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_more_autograding_examples/"
-        rsync -rtz "${SUBMITTY_REPOSITORY}/sample_files/" "${SUBMITTY_REPOSITORY}/site/cypress/fixtures/copy_of_sample_files/"
-    fi
-
     # root will be owner & group of these files
     chown -R  root:root "${SUBMITTY_INSTALL_DIR}/more_autograding_examples"
     # but everyone can read all that files & directories, and cd into all the directories

--- a/.setup/install_submitty/get_globals.sh
+++ b/.setup/install_submitty/get_globals.sh
@@ -25,6 +25,12 @@ IS_VAGRANT="$([[ -d "${SUBMITTY_REPOSITORY:?}/.vagrant" ]] && echo 1 || echo 0)"
 IS_UTM="$([[ -d "${SUBMITTY_REPOSITORY:?}/.utm" ]] && echo 1 || echo 0)"
 IS_CI="$([[ -f "${SUBMITTY_REPOSITORY:?}/.github_actions_ci_flag" ]] && echo 1 || echo 0)"
 
+echo "IS_WORKER: ${IS_WORKER:?}"
+echo "IS_VAGRANT: ${IS_VAGRANT:?}"
+echo "IS_UTM: ${IS_UTM:?}"
+echo "IS_CI: ${IS_CI:?}"
+exit 1
+
 # Because shellcheck is run with the python wrapper we need to disable the 'Not following' error
 # shellcheck disable=SC1091
 source "${SUBMITTY_REPOSITORY:?}/.setup/bin/versions.sh"

--- a/.setup/install_submitty/get_globals.sh
+++ b/.setup/install_submitty/get_globals.sh
@@ -29,7 +29,7 @@ echo "IS_WORKER: ${IS_WORKER:?}"
 echo "IS_VAGRANT: ${IS_VAGRANT:?}"
 echo "IS_UTM: ${IS_UTM:?}"
 echo "IS_CI: ${IS_CI:?}"
-# exit 1
+exit 1
 
 # Because shellcheck is run with the python wrapper we need to disable the 'Not following' error
 # shellcheck disable=SC1091

--- a/.setup/install_submitty/get_globals.sh
+++ b/.setup/install_submitty/get_globals.sh
@@ -20,8 +20,6 @@ fi
 SUBMITTY_INSTALL_DIR="$(jq -r '.submitty_install_dir' "${SUBMITTY_CONFIG_DIR:?}/submitty.json")"
 SUBMITTY_REPOSITORY="$(jq -r '.submitty_repository' "${SUBMITTY_CONFIG_DIR:?}/submitty.json")"
 
-# every github ci action has is_ci.
-# all vagrant actions, including vagrant on ci, have is_vagrant.
 IS_WORKER="$([[ "$(jq -r '.worker' "${SUBMITTY_INSTALL_DIR:?}/config/submitty.json")" == "true" ]] && echo 1 || echo 0)"
 IS_VAGRANT="$([[ -d "${SUBMITTY_REPOSITORY:?}/.vagrant" ]] && echo 1 || echo 0)"
 IS_UTM="$([[ -d "${SUBMITTY_REPOSITORY:?}/.utm" ]] && echo 1 || echo 0)"

--- a/.setup/install_submitty/get_globals.sh
+++ b/.setup/install_submitty/get_globals.sh
@@ -29,7 +29,7 @@ echo "IS_WORKER: ${IS_WORKER:?}"
 echo "IS_VAGRANT: ${IS_VAGRANT:?}"
 echo "IS_UTM: ${IS_UTM:?}"
 echo "IS_CI: ${IS_CI:?}"
-exit 1
+# exit 1
 
 # Because shellcheck is run with the python wrapper we need to disable the 'Not following' error
 # shellcheck disable=SC1091

--- a/.setup/install_submitty/get_globals.sh
+++ b/.setup/install_submitty/get_globals.sh
@@ -20,16 +20,12 @@ fi
 SUBMITTY_INSTALL_DIR="$(jq -r '.submitty_install_dir' "${SUBMITTY_CONFIG_DIR:?}/submitty.json")"
 SUBMITTY_REPOSITORY="$(jq -r '.submitty_repository' "${SUBMITTY_CONFIG_DIR:?}/submitty.json")"
 
+# every github ci action has is_ci.
+# all vagrant actions, including vagrant on ci, have is_vagrant.
 IS_WORKER="$([[ "$(jq -r '.worker' "${SUBMITTY_INSTALL_DIR:?}/config/submitty.json")" == "true" ]] && echo 1 || echo 0)"
 IS_VAGRANT="$([[ -d "${SUBMITTY_REPOSITORY:?}/.vagrant" ]] && echo 1 || echo 0)"
 IS_UTM="$([[ -d "${SUBMITTY_REPOSITORY:?}/.utm" ]] && echo 1 || echo 0)"
 IS_CI="$([[ -f "${SUBMITTY_REPOSITORY:?}/.github_actions_ci_flag" ]] && echo 1 || echo 0)"
-
-echo "IS_WORKER: ${IS_WORKER:?}"
-echo "IS_VAGRANT: ${IS_VAGRANT:?}"
-echo "IS_UTM: ${IS_UTM:?}"
-echo "IS_CI: ${IS_CI:?}"
-exit 1
 
 # Because shellcheck is run with the python wrapper we need to disable the 'Not following' error
 # shellcheck disable=SC1091


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
The change is necessary as every time you want to copy a file, you would have to add it to ci, in addition to adding an rsync to the directory. This refactor aims to combine the two elements by putting it directly into `install_submitty.sh`, which both ci and developers run

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Whenever we are in the ci, we should copy the files. whenever we are a developer vm, we should rsync the files.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
