### PR TITLE
[Feature:System] Display All Notifications on Home Page

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -396,7 +396,7 @@ class GlobalController extends AbstractController {
         // ALL USERS
         $sidebar_buttons[] = new NavButton($this->core, [
             "href" => $this->core->buildUrl(['home']),
-            "title" => "Activity Dashboard",
+            "title" => "My Courses",
             "icon" => "fa-book-reader"
         ]);
 

--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -396,7 +396,7 @@ class GlobalController extends AbstractController {
         // ALL USERS
         $sidebar_buttons[] = new NavButton($this->core, [
             "href" => $this->core->buildUrl(['home']),
-            "title" => "My Courses",
+            "title" => "Activity Dashboard",
             "icon" => "fa-book-reader"
         ]);
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5425,7 +5425,7 @@ AND gc_id IN (
                 FROM notifications
                 WHERE to_user_id = ? AND created_at >= current_timestamp - INTERVAL '7 days'
                 ORDER BY created_at DESC
-                LIMIT 10;
+                LIMIT 5;
             ";
             $course_db->query($query, [$user_id]);
             $rows = $course_db->rows();
@@ -5452,7 +5452,12 @@ AND gc_id IN (
             );
 
             $this->core->loadCourseConfig($row['semester'], $row['course']);
-            $notification_url = $this->core->buildCourseUrl(['notifications', $row['id']]);
+            if ($row['metadata']) {
+                $notification_url = $this->core->buildCourseUrl(['notifications', $row['id']]);
+            }
+            else {
+                $notification_url = null;
+            }
 
             $results[] = [
                 'id' => $row['id'],

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5425,7 +5425,7 @@ AND gc_id IN (
                 FROM notifications
                 WHERE to_user_id = ? AND created_at >= current_timestamp - INTERVAL '7 days'
                 ORDER BY created_at DESC
-                LIMIT 5;
+                LIMIT 10;
             ";
             $course_db->query($query, [$user_id]);
             $rows = $course_db->rows();

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -54,6 +54,8 @@ class HomePageView extends AbstractView {
             $statuses[$course_type_name] = $ranks;
         }
 
+        $user_id = $this->core->getUser()->getId();
+
         $this->core->getOutput()->enableMobileViewport();
         $this->output->setPageName('Homepage');
         return $this->output->renderTwigTemplate('Vue.twig', [
@@ -61,6 +63,7 @@ class HomePageView extends AbstractView {
             "name" => "HomePage",
             "args" => [
                 "statuses" => $statuses,
+                "notifications" => $this->core->getQueries()->getAllRecentUserNotifications($user_id, $this->core->getQueries()->getCourseForUserId($user_id)),
             ]
         ]);
     }

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -23,6 +23,7 @@
     --hover-light-border-actionable-blue: #2e6da4;
     --hover-border-actionable-blue: #204d74;
     --hover-dark-border-actionable-blue: #122b40;
+    --home-panel-gray: #e6f3f9;
     --standard-lightskyblue: #87cefa;
     --standard-mediumorchid: #ba55d3;
     --info-blue: #5bc0de;
@@ -275,6 +276,7 @@
     --btn-default-active: #6d6d6d;
     --btn-default-white: #515151;
     --btn-default-hover: #595959;
+    --home-panel-gray: #3d3d3d;
     --standard-hover-light-gray: #2b2b2b;
     --standard-light-gray: #757575;
     --standard-medium-gray: #a3a3a3;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -23,7 +23,7 @@
     --hover-light-border-actionable-blue: #2e6da4;
     --hover-border-actionable-blue: #204d74;
     --hover-dark-border-actionable-blue: #122b40;
-    --home-panel-gray: #ffffff;
+    --hover-notification: #dfdfdf;
     --standard-lightskyblue: #87cefa;
     --standard-mediumorchid: #ba55d3;
     --info-blue: #5bc0de;
@@ -276,7 +276,7 @@
     --btn-default-active: #6d6d6d;
     --btn-default-white: #515151;
     --btn-default-hover: #595959;
-    --home-panel-gray: #3d3d3d;
+    --hover-notification: #283e57;
     --standard-hover-light-gray: #2b2b2b;
     --standard-light-gray: #757575;
     --standard-medium-gray: #a3a3a3;

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -23,7 +23,7 @@
     --hover-light-border-actionable-blue: #2e6da4;
     --hover-border-actionable-blue: #204d74;
     --hover-dark-border-actionable-blue: #122b40;
-    --home-panel-gray: #e6f3f9;
+    --home-panel-gray: #ffffff;
     --standard-lightskyblue: #87cefa;
     --standard-mediumorchid: #ba55d3;
     --info-blue: #5bc0de;

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
     notifications: Notification[];
 }>();
 
-const showUnseenOnly = ref(false);
+const showUnseenOnly = ref(true);
 
 onMounted(() => {
     const pref = localStorage.getItem('notification-preference');
@@ -36,9 +36,7 @@ function toggleUnseenOnly() {
     );
 }
 
-const showingMore = ref(false);
-
-const visibleCount = computed(() => showingMore.value ? 10 : 5);
+const visibleCount = 10;
 
 const filteredNotifications = computed(() =>
     showUnseenOnly.value
@@ -47,7 +45,7 @@ const filteredNotifications = computed(() =>
 );
 
 const visibleNotifications = computed(() =>
-    filteredNotifications.value.slice(0, visibleCount.value),
+    filteredNotifications.value.slice(0, visibleCount),
 );
 
 function goToNotificationLink(notification_url: string) {
@@ -91,6 +89,13 @@ function goToNotificationLink(notification_url: string) {
     >
       No notifications to view.
     </p>
+    <p
+      v-if="filteredNotifications.length === 0"
+      id="no-recent-notifications"
+      class="no-recent"
+    >
+      No unseen notifications.
+    </p>
     <div
       v-else
       id="recent-notifications"
@@ -121,20 +126,6 @@ function goToNotificationLink(notification_url: string) {
                 </a>
             -->
       </div>
-      <a
-        v-if="filteredNotifications.length > 5 && !showingMore"
-        class="show-more"
-        @click="showingMore = true"
-      >
-        Show More
-      </a>
-      <a
-        v-else-if="filteredNotifications.length > 5 && showingMore"
-        class="show-more"
-        @click="showingMore = false"
-      >
-        Show Less
-      </a>
     </div>
   </div>
 </template>

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -1,30 +1,65 @@
-<script>
+<script setup lang="ts">
+import { ref, computed } from 'vue';
 
+interface Notification {
+    id: number;
+    component: string;
+    metadata: string;
+    content: string;
+    seen: boolean;
+    elapsed_time: number;
+    created_at: string;
+    notify_time: string,
+    semester: string;
+    course: string;
+    notification_url: string;
+}
+
+const props = defineProps<{
+    notifications: Notification[];
+}>();
+
+const showingMore = ref(false);
+const visibleCount = computed(() => showingMore.value ? 10 : 5);
+
+const visibleNotifications = computed(() =>
+    props.notifications.slice(0, visibleCount.value)
+);
 </script>
 <template>
     <div class="notification-body">
         <h1 class="notifications-header">Notifications</h1>
-        <!--<p class="no-recent" id="no-recent-notifications">No recent notifications.</p>-->
-        <div id="recent-notifications">
-            <div class="notification" v-for="n in 12" :key="n">
+        <p class="no-recent" id="no-recent-notifications" v-if="notifications.length === 0">No recent notifications.</p>
+        <div id="recent-notifications" v-else>
+            <div class="notification" v-for="n in visibleNotifications" :key="n.id" :class="{ unseen: !n.seen }">
                     <i class="fas fa-comments notification-type" title="Forum"></i>
                 <div class="notification-content">
                         <div class="notification-contents">
                             <div class="notification-content">
-                                This is the content of the notification
+                                <a class="notification-link" href="{{ n.notification_url }}/{{ n.id }}?seen={{ n.seen ? 1 : 0 }}">
+                                    {{ n.content }}
+                                </a>
                             </div>
                         </div>
                     <div class="notification-time">
-                        41 minutes ago
+                        {{ n.course }} - {{ n.notify_time }}
                     </div>
                 </div>
-                <a class="notification-seen black-btn" title="Mark as seen" aria-label="Mark as seen">
-                    <i class="fas fa-external-link"></i>
-                </a>
-                <a class="notification-seen black-btn" title="Mark as seen" aria-label="Mark as seen">
-                    <i class="far fa-envelope-open"></i>
-                </a>
             </div>
+            <a
+                v-if="props.notifications.length > 5 && !showingMore"
+                @click="showingMore = true"
+                class="show-more"
+                >
+                Show More
+            </a>
+            <a
+                v-else-if="props.notifications.length > 5 && showingMore"
+                @click="showingMore = false"
+                class="show-more"
+                >
+                Show Less
+            </a>
         </div>
     </div>
 </template>
@@ -34,15 +69,15 @@
 }
 
 .notification-body {
-  background-color: var(--home-panel-gray);
-  padding: 20px;
-  max-height: 500px;
-  overflow-y: scroll;
+    background-color: var(--home-panel-gray);
+    padding: 20px;
+    height: auto;
 }
 
 .no-recent {
     padding-top: 10px;
     font-style: italic;
+    margin-bottom: 30px;
 }
 
 #notifications {
@@ -56,9 +91,15 @@
     border-bottom: 1px solid var(--standard-light-gray);
     padding: 9px 0;
     align-items: center;
+    padding-left: 20px;
+    padding-right: 20px;
 }
 
-.notification:nth-last-child(1) {
+.notification.unseen {
+    background-color: var(--viewed-content);
+}
+
+div.notification:last-of-type {
     border-bottom: none;
 }
 
@@ -92,5 +133,10 @@
     text-align: center;
     flex: 0 0 auto;
     padding: 10px 16px;
+}
+
+a.show-more {
+    display: inline-block;
+    margin-top: 10px;
 }
 </style>

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -2,23 +2,95 @@
 
 </script>
 <template>
-    <div class="notification-content">
-        <h1>Notifications</h1>
-        <p class="no-recent" id="no-recent-notifications">No recent notifications.</p>
+    <div class="notification-body">
+        <h1 class="notifications-header">Notifications</h1>
+        <!--<p class="no-recent" id="no-recent-notifications">No recent notifications.</p>-->
         <div id="recent-notifications">
-
+            <div class="notification" v-for="n in 12" :key="n">
+                    <i class="fas fa-comments notification-type" title="Forum"></i>
+                <div class="notification-content">
+                        <div class="notification-contents">
+                            <div class="notification-content">
+                                This is the content of the notification
+                            </div>
+                        </div>
+                    <div class="notification-time">
+                        41 minutes ago
+                    </div>
+                </div>
+                <a class="notification-seen black-btn" title="Mark as seen" aria-label="Mark as seen">
+                    <i class="fas fa-external-link"></i>
+                </a>
+                <a class="notification-seen black-btn" title="Mark as seen" aria-label="Mark as seen">
+                    <i class="far fa-envelope-open"></i>
+                </a>
+            </div>
         </div>
     </div>
 </template>
 <style scoped>
-.notification-content {
-  grid-column: 2;
-  background-color: #3d3d3d;
-  padding: 20px;
-  height: 500px;
+.notifications-header {
+    padding-bottom: 5px;
 }
+
+.notification-body {
+  background-color: var(--home-panel-gray);
+  padding: 20px;
+  max-height: 500px;
+  overflow-y: scroll;
+}
+
 .no-recent {
     padding-top: 10px;
     font-style: italic;
+}
+
+#notifications {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.notification {
+    display: flex;
+    border-bottom: 1px solid var(--standard-light-gray);
+    padding: 9px 0;
+    align-items: center;
+}
+
+.notification:nth-last-child(1) {
+    border-bottom: none;
+}
+
+.notification > * {
+    display: block;
+    align-items: center;
+}
+
+.notification-type {
+    margin-right: 1em;
+}
+
+.notification-contents {
+    display: flex;
+    flex-wrap: wrap;
+    flex-grow: 1;
+}
+
+.notification-content {
+    flex: 1;
+}
+
+.notification-time {
+    font-size: 0.9rem;
+    color: var(--standard-medium-dark-gray);
+    flex: 1 0 90%;
+    margin-top: 2px;
+}
+
+.notification-seen {
+    text-align: center;
+    flex: 0 0 auto;
+    padding: 10px 16px;
 }
 </style>

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -1,0 +1,24 @@
+<script>
+
+</script>
+<template>
+    <div class="notification-content">
+        <h1>Notifications</h1>
+        <p class="no-recent" id="no-recent-notifications">No recent notifications.</p>
+        <div id="recent-notifications">
+
+        </div>
+    </div>
+</template>
+<style scoped>
+.notification-content {
+  grid-column: 2;
+  background-color: #3d3d3d;
+  padding: 20px;
+  height: 500px;
+}
+.no-recent {
+    padding-top: 10px;
+    font-style: italic;
+}
+</style>

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -89,7 +89,7 @@ function goToNotificationLink(notification_url: string) {
       id="no-recent-notifications"
       class="no-recent"
     >
-      No recent notifications.
+      No notifications to view.
     </p>
     <div
       v-else
@@ -179,7 +179,7 @@ function goToNotificationLink(notification_url: string) {
 
 .notification:hover {
     cursor: pointer;
-    background-color: var(--hover-notification) !important; /* Override seen and normal notification on hover */
+    background-color: var(--hover-notification) !important; /* Override seen/unseen bg on hover */
 }
 
 .notification.unseen {

--- a/site/vue/src/components/AllNotificationsDisplay.vue
+++ b/site/vue/src/components/AllNotificationsDisplay.vue
@@ -9,7 +9,7 @@ interface Notification {
     seen: boolean;
     elapsed_time: number;
     created_at: string;
-    notify_time: string,
+    notify_time: string;
     semester: string;
     course: string;
     notification_url: string;
@@ -22,18 +22,18 @@ const props = defineProps<{
 const showUnseenOnly = ref(false);
 
 onMounted(() => {
-  const pref = localStorage.getItem('notification-preference');
-  if (pref === 'unseen') {
-    showUnseenOnly.value = true;
-  }
+    const pref = localStorage.getItem('notification-preference');
+    if (pref === 'unseen') {
+        showUnseenOnly.value = true;
+    }
 });
 
 function toggleUnseenOnly() {
-  showUnseenOnly.value = !showUnseenOnly.value;
-  localStorage.setItem(
-    'notification-preference',
-    showUnseenOnly.value ? 'unseen' : 'all'
-  );
+    showUnseenOnly.value = !showUnseenOnly.value;
+    localStorage.setItem(
+        'notification-preference',
+        showUnseenOnly.value ? 'unseen' : 'all',
+    );
 }
 
 const showingMore = ref(false);
@@ -41,73 +41,119 @@ const showingMore = ref(false);
 const visibleCount = computed(() => showingMore.value ? 10 : 5);
 
 const filteredNotifications = computed(() =>
-  showUnseenOnly.value
-    ? props.notifications.filter(n => !n.seen)
-    : props.notifications
+    showUnseenOnly.value
+        ? props.notifications.filter((n) => !n.seen)
+        : props.notifications,
 );
 
 const visibleNotifications = computed(() =>
-  filteredNotifications.value.slice(0, visibleCount.value)
+    filteredNotifications.value.slice(0, visibleCount.value),
 );
+
+function goToNotificationLink(notification_url: string) {
+    window.location.href = notification_url;
+}
 </script>
 <template>
-    <div class="notification-body shadow">
-        <div class="notifications-header-container">
-            <h1 class="notifications-header">Notifications</h1>
-            <a class="notification-seen black-btn" title="See All" aria-label="See All"  @click="toggleUnseenOnly" v-if="!showUnseenOnly && notifications.length !== 0">
-                <i class="fas fa-eye"></i>
-            </a>
-            <a class="notification-seen black-btn" title="Unseen Only" aria-label="Unseen Only"  @click="toggleUnseenOnly" v-if="showUnseenOnly && notifications.length !== 0">
-                <i class="fas fa-eye-slash"></i>
-            </a>
+  <div class="notification-panel shadow">
+    <div class="notifications-header-container">
+      <h1 class="notifications-header">
+        Notifications
+      </h1>
+      <a
+        v-if="!showUnseenOnly && notifications.length !== 0"
+        class="notification-seen black-btn"
+        title="See All"
+        aria-label="See All"
+        @click="toggleUnseenOnly"
+      >
+        <i class="fas fa-eye" />
+      </a>
+      <a
+        v-if="showUnseenOnly && notifications.length !== 0"
+        class="notification-seen black-btn"
+        title="Unseen Only"
+        aria-label="Unseen Only"
+        @click="toggleUnseenOnly"
+      >
+        <i class="fas fa-eye-slash" />
+      </a>
+      <!-- FUTURE FEATURE: mark all notifications on the home page as seen
             <a class="btn btn-primary">
                 Mark all as seen
             </a>
+        -->
+    </div>
+    <p
+      v-if="notifications.length === 0"
+      id="no-recent-notifications"
+      class="no-recent"
+    >
+      No recent notifications.
+    </p>
+    <div
+      v-else
+      id="recent-notifications"
+    >
+      <div
+        v-for="n in visibleNotifications"
+        :key="n.id"
+        class="notification"
+        :class="{ unseen: !n.seen }"
+        @click="n.notification_url && goToNotificationLink(`${n.notification_url}/?seen=${n.seen ? 1 : 0}`)"
+      >
+        <i
+          v-if="n.component === 'forum'"
+          class="fas fa-comments notification-type"
+          title="Forum"
+        />
+        <div class="notification-content">
+          <span class="notification-link">
+            {{ n.content }}
+          </span>
+          <div class="notification-time">
+            {{ n.course }} - {{ n.notify_time }}
+          </div>
         </div>
-        <p class="no-recent" id="no-recent-notifications" v-if="notifications.length === 0">No recent notifications.</p>
-        <div id="recent-notifications" v-else>
-            <div class="notification" v-for="n in visibleNotifications" :key="n.id" :class="{ unseen: !n.seen }">
-                    <i class="fas fa-comments notification-type" title="Forum" v-if="n.component === 'forum'"></i>
-                <div class="notification-content">
-                    <a class="notification-link" :href="`${n.notification_url}/?seen=${n.seen ? 1 : 0}`" v-if="n.notification_url">
-                        {{ n.content }}
-                    </a>
-                    <span class="notification-link" v-else>
-                        {{ n.content }}
-                    </span>
-                    <div class="notification-time">
-                        {{ n.course }} - {{ n.notify_time }}
-                    </div>
-                </div>
+        <!-- FUTURE FEATURE: individual mark as seen
                 <a class="notification-seen black-btn" title="Mark as seen" aria-label="Mark as seen" v-if="!n.seen">
                     <i class="far fa-envelope-open"></i>
                 </a>
-            </div>
-            <a v-if="filteredNotifications.length > 5 && !showingMore" @click="showingMore = true" class="show-more">
-                Show More
-            </a>
-            <a v-else-if="filteredNotifications.length > 5 && showingMore" @click="showingMore = false" class="show-more">
-                Show Less
-            </a>
-        </div>
+            -->
+      </div>
+      <a
+        v-if="filteredNotifications.length > 5 && !showingMore"
+        class="show-more"
+        @click="showingMore = true"
+      >
+        Show More
+      </a>
+      <a
+        v-else-if="filteredNotifications.length > 5 && showingMore"
+        class="show-more"
+        @click="showingMore = false"
+      >
+        Show Less
+      </a>
     </div>
+  </div>
 </template>
 <style scoped>
+.notification-panel {
+    background-color: var(--default-white);
+    height: auto;
+    padding: 20px
+}
+
 .notifications-header-container {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start; 
+  align-items: flex-start;
   margin-bottom: 5px;
 }
 
 .notifications-header {
     flex-grow: 1;
-}
-
-.notification-body {
-    background-color: var(--home-panel-gray);
-    padding: 20px;
-    height: auto;
 }
 
 .no-recent {
@@ -129,6 +175,11 @@ const visibleNotifications = computed(() =>
     align-items: center;
     padding-left: 20px;
     padding-right: 20px;
+}
+
+.notification:hover {
+    cursor: pointer;
+    background-color: var(--hover-notification) !important; /* Override seen and normal notification on hover */
 }
 
 .notification.unseen {

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -3,6 +3,20 @@ import { defineProps } from 'vue';
 import { buildUrl } from '../../../ts/utils/server';
 import AllNotificationsDisplay from '@/components/AllNotificationsDisplay.vue';
 
+interface Notification {
+    id: number;
+    component: string;
+    metadata: string;
+    content: string;
+    seen: boolean;
+    elapsed_time: number;
+    created_at: string;
+    notify_time: string,
+    semester: string;
+    course: string;
+    notification_url: string;
+}
+
 type Status = 'unarchived_courses' | 'dropped_courses' | 'self_registration_courses' | 'archived_courses';
 type Rank = {
     title: string;
@@ -18,6 +32,7 @@ type Course = {
 
 interface Props {
     statuses: { [key in Status]: { [key: string]: Rank } };
+    notifications: Notification[];
 }
 
 type SemesterCourses = {
@@ -118,7 +133,7 @@ const buildCourseUrl = (course: Course) => {
         </div>
       </template>
     </div>
-    <AllNotificationsDisplay/>
+    <AllNotificationsDisplay  :notifications="notifications" />
   </div>
 </template>
 
@@ -126,6 +141,8 @@ const buildCourseUrl = (course: Course) => {
 .grid-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-auto-rows: auto;
+  align-items: start; 
   grid-gap: 30px;
 }
 .div1 {

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -91,7 +91,10 @@ const buildCourseUrl = (course: Course) => {
           <br v-if="index > 0" />
           <br v-if="index > 0" />
 
-          <h1 class="courses-header" data-testid="courses-header">
+          <h1
+            class="courses-header"
+            data-testid="courses-header"
+          >
             {{ getCourseTypeHeader(course_type) }}
           </h1>
 

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { defineProps } from 'vue';
 import { buildUrl } from '../../../ts/utils/server';
+import AllNotificationsDisplay from '@/components/AllNotificationsDisplay.vue';
 
 type Status = 'unarchived_courses' | 'dropped_courses' | 'self_registration_courses' | 'archived_courses';
 type Rank = {
@@ -27,16 +28,16 @@ defineProps<Props>();
 
 const getCourseTypeHeader = (course_type: Status) => {
     if (course_type === 'self_registration_courses') {
-        return 'Courses Available for Self Registration';
+        return 'Available for Self Registration';
     }
-    let message = '';
+    let message = 'Active';
     if (course_type === 'dropped_courses') {
         message = 'Recently Dropped ';
     }
     else if (course_type === 'archived_courses') {
         message = 'Archived ';
     }
-    return `My ${message}Courses`;
+    return `My ${message} Courses`;
 };
 
 const groupCoursesBySemester = (courses: Course[]) => {
@@ -60,65 +61,76 @@ const buildCourseUrl = (course: Course) => {
 
 <template>
   <div
-    id="courses"
-    class="content"
-    data-testid="courses-list"
-  >
-    <template
-      v-for="(ranks, course_type, index) in statuses"
-      :key="course_type"
+    class="content grid-container">
+    <div
+      id="courses"
+      class="div1"
+      data-testid="courses-list"
     >
-      <div v-if="index === 0 || (ranks && Object.keys(ranks).length > 0)">
-        <br v-if="index > 0" />
-        <br v-if="index > 0" />
+      <template
+        v-for="(ranks, course_type, index) in statuses"
+        :key="course_type"
+      >
+        <div v-if="index === 0 || (ranks && Object.keys(ranks).length > 0)">
+          <br v-if="index > 0" />
+          <br v-if="index > 0" />
 
-        <h1 data-testid="courses-header">
-          {{ getCourseTypeHeader(course_type) }}
-        </h1>
-
-        <div
-          v-for="rank in ranks"
-          :key="rank.title"
-        >
-          <h2 v-if="course_type !== 'dropped_courses' && course_type !== 'self_registration_courses'">
-            As {{ rank.title }}
-          </h2>
+          <h1 data-testid="courses-header">
+            {{ getCourseTypeHeader(course_type) }}
+          </h1>
 
           <div
-            v-for="(courses, semester) in groupCoursesBySemester(rank.courses)"
-            :key="semester"
+            v-for="rank in ranks"
+            :key="rank.title"
           >
-            <h3>{{ semester }}</h3>
-            <ul class="bare-list course-list">
-              <li
-                v-for="course in courses"
-                :key="`${course.semester}_${course.title}`"
-              >
-                <a
-                  :id="`${course.semester}_${course.title}`"
-                  class="btn btn-primary btn-block btn-course"
-                  :href="buildCourseUrl(course)"
-                  :data-testid="`${course.title}-button`"
+            <h3 v-if="course_type !== 'dropped_courses' && course_type !== 'self_registration_courses'">
+              As {{ rank.title }}
+            </h3>
+
+            <div
+              v-for="(courses, semester) in groupCoursesBySemester(rank.courses)"
+              :key="semester"
+            >
+              <ul class="bare-list course-list">
+                <li
+                  v-for="course in courses"
+                  :key="`${course.semester}_${course.title}`"
                 >
-                  {{ course.display_semester }} &nbsp; &nbsp;
-                  {{ course.title.toUpperCase() }} &nbsp; &nbsp;
-                  <template v-if="course.display_name">
-                    {{ course.display_name }} &nbsp; &nbsp;
-                  </template>
-                  <template v-if="course.registration_section !== null">
-                    (Section {{ course.registration_section }})
-                  </template>
-                </a>
-              </li>
-            </ul>
+                  <a
+                    :id="`${course.semester}_${course.title}`"
+                    class="btn btn-primary btn-block btn-course"
+                    :href="buildCourseUrl(course)"
+                    :data-testid="`${course.title}-button`"
+                  >
+                    {{ course.display_semester }} &nbsp; &nbsp;
+                    {{ course.title.toUpperCase() }} &nbsp; &nbsp;
+                    <template v-if="course.display_name">
+                      {{ course.display_name }} &nbsp; &nbsp;
+                    </template>
+                    <template v-if="course.registration_section !== null">
+                      (Section {{ course.registration_section }})
+                    </template>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
-    </template>
+      </template>
+    </div>
+    <AllNotificationsDisplay/>
   </div>
 </template>
 
 <style scoped>
+.grid-container {
+  display: grid; /* Enables CSS Grid layout */
+  grid-template-columns: 1fr 1fr; /* Creates two columns of equal width */
+  grid-gap: 30px; /* Adds a 20px gap between the columns */
+}
+.div1 {
+  grid-column: 1; /* Places Div 1 in the first column */
+}
 .course-list li {
     margin: 3px 0;
 }

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -11,7 +11,7 @@ interface Notification {
     seen: boolean;
     elapsed_time: number;
     created_at: string;
-    notify_time: string,
+    notify_time: string;
     semester: string;
     course: string;
     notification_url: string;
@@ -76,10 +76,11 @@ const buildCourseUrl = (course: Course) => {
 
 <template>
   <div
-    class="content grid-container">
+    class="home-content grid-container"
+  >
     <div
       id="courses"
-      class="div1"
+      class="div1 shadow"
       data-testid="courses-list"
     >
       <template
@@ -90,7 +91,7 @@ const buildCourseUrl = (course: Course) => {
           <br v-if="index > 0" />
           <br v-if="index > 0" />
 
-          <h1 data-testid="courses-header">
+          <h1 class="courses-header" data-testid="courses-header">
             {{ getCourseTypeHeader(course_type) }}
           </h1>
 
@@ -133,20 +134,31 @@ const buildCourseUrl = (course: Course) => {
         </div>
       </template>
     </div>
-    <AllNotificationsDisplay  :notifications="notifications" />
+    <AllNotificationsDisplay :notifications="notifications" />
   </div>
 </template>
 
 <style scoped>
+.home-content {
+    padding: 20px;
+    margin: 10px;
+}
+
 .grid-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  grid-auto-rows: auto;
-  align-items: start; 
-  grid-gap: 30px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-auto-rows: auto;
+    align-items: start;
+    grid-gap: 30px;
+}
+
+.courses-header {
+  margin-bottom: 5px;
 }
 .div1 {
   grid-column: 1;
+  padding: 20px;
+  background-color: var(--default-white);
 }
 .course-list li {
     margin: 3px 0;

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -153,7 +153,7 @@ const buildCourseUrl = (course: Course) => {
 }
 
 .courses-header {
-  margin-bottom: 5px;
+    margin-bottom: 5px !important; /* Override submitty-vue.css */
 }
 .div1 {
   grid-column: 1;

--- a/site/vue/src/pages/HomePage.vue
+++ b/site/vue/src/pages/HomePage.vue
@@ -124,12 +124,12 @@ const buildCourseUrl = (course: Course) => {
 
 <style scoped>
 .grid-container {
-  display: grid; /* Enables CSS Grid layout */
-  grid-template-columns: 1fr 1fr; /* Creates two columns of equal width */
-  grid-gap: 30px; /* Adds a 20px gap between the columns */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-gap: 30px;
 }
 .div1 {
-  grid-column: 1; /* Places Div 1 in the first column */
+  grid-column: 1;
 }
 .course-list li {
     margin: 3px 0;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
closes #4207
Currently, notifications are per course, and there is no way to see all of them in one place. Additionally, Submitty's home page has an excess of wasted space as only the user's courses are displayed on the page.

### What is the New Behavior?
Added a panel to the `My Courses` page displaying all of the most recent notifications (max of 10 displayed) from all active courses. This was implemented by looping through each of the user's courses, and querying the 10 most recent notifications from each.

**Full Screen Light Mode - NOTE: I used forum viewed/unviewed colors for seen/unseen**

<img width="3838" height="2011" alt="Full screen light mode notifications" src="https://github.com/user-attachments/assets/e530f4b5-2b58-41a3-ade5-1f80f651df54" />

**Full Screen Dark Mode**

<img width="3838" height="2016" alt="full screen dark mode notifications" src="https://github.com/user-attachments/assets/df18db16-8f3f-42e9-947f-5bab50e8df75" />

**Just the Notifications Panel**
<img width="1629" height="1050" alt="image" src="https://github.com/user-attachments/assets/8061f78a-fd1c-4c29-9262-83a7987164c5" />

**No Notifications to View**
<img width="1640" height="389" alt="image" src="https://github.com/user-attachments/assets/1a572b76-087a-42f3-af61-a510d6f9286b" />

**No Unseen Notifications**
<img width="1635" height="405" alt="image" src="https://github.com/user-attachments/assets/61cbf63b-5c9f-4c1d-9fba-d35a2ff5339c" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
Here are the features that should be verified:
1. Courses and notifications panel scale properly on different screen sizes.
2. Colors look good in both light and dark mode
3. All/Unseen toggle defaults to unseen only
4. Notifications are clickable, have hover background, and their content wraps when it is too large
5. Notification links work, and they are correctly marked as seen after clicking
6. When a user has no notifications, text should say "No notifications to view", and the All/Unseen filter should not be visible.
7. When a user has no unseen notifications, text should say "No unseen notifications.".

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
The entire notification system does not yet have adequate e2e testing (see #11908). Perhaps the solution to that issue can include this new feature.

### Other information
This is not a breaking change. If there is no way to optimize the query, we should add `/home` to `.performance_warning_ignore.json`.

**FOR REVIEWERS:** Should we call it seen/unseen or viewed/unviewed? I think either would make sense as we currently use seen/unseen for notifications, but we use viewed/unviewed for the forum. In my code, I am using seen/unseen.

**FUTURE PRs**
1. Add individual mark as seen
2. Add mark all as seen
3. Add some sort of count so the user knows total unseen (each course already does this)
4. Make the course notifications page a Vue component that uses the same code as this page
5. Add more panels (grade summaries, gradeables, etc) and turn the home page into a dashboard.