### PR TITLE
[Bugfix:Autograding] Fix team autograding

### DIFF
--- a/autograder/autograder/insert_database_version_data.py
+++ b/autograder/autograder/insert_database_version_data.py
@@ -63,7 +63,7 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
     engine = create_engine(conn_string)
     db = engine.connect()
     metadata = MetaData()
-    autograding_metrics = Table('autograding_metrics', metadata, autoload_with=db)
+    autograding_metrics = Table('autograding_metrics', metadata, autoload_with=engine)
     db.execute(
         delete(autograding_metrics)
         .where(autograding_metrics.c.user_id == bindparam('u_id'))
@@ -122,7 +122,7 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
         non_hidden_non_ec += nonhidden_diff
         # hidden_non_ec += hidden_diff
 
-    data_table = Table('electronic_gradeable_data', metadata, autoload_with=db)
+    data_table = Table('electronic_gradeable_data', metadata, autoload_with=engine)
 
     """
     The data row should have been inserted by PHP when the student uploads the submission, requiring
@@ -218,7 +218,8 @@ def insert_into_database(config, semester, course, gradeable_id, user_id, team_i
                 "autograding_complete": True
             }
         )
-        db.commit()
+    
+    db.commit()
     db.close()
     engine.dispose()
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Current production is broken right now with team gradeables. This is because the update portion of the team gradeable does not have a `connection.commit()`, which the non-team gradeable has. Putting the commit statement outside of both if and else if is going to fix the issue.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Putting the commit statement outside of both if and else if is going to fix the issue.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
We need to do more testing of team gradeables

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
