### PR TITLE
[Feature:IntructorUI] Config Editor Line Count & Tab Size

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -143,9 +143,13 @@
                     </div>
                 </div>
                 <div id="gradeable-config-edit-bar">
-                    <div style="display: flex; flex-grow: 1; justify-content: flex-end;">
-                        <i class="fas fa-list-ol" id="toggle-line-nums" style="margin-right: 16px" onClick="toggleLineNums()"></i>
-                        <i class="fas fa-2" id="toggle-tab-length" style="margin-right:10px" onClick="toggleTabLength()"></i>
+                    <div style="display: flex; flex-grow: 1; justify-content: flex-end; margin-bottom: 2px;">
+                        <button type="button" style="margin-right:6px; width:25px; height:25px" id="toggle-line-nums" onClick="toggleLineNums()">
+                            <i class="fas fa-list-ol"></i>
+                        </button>
+                        <button type="button" style="width:25px; height:25px" onClick="toggleTabLength()">
+                            <i class="fas fa-2" id="toggle-tab-length"></i>
+                        </button>
                     </div>
                     <textarea id="gradeable-config-edit" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>
                     <a class="btn btn-primary" onclick="saveGradeableConfigEdit('{{ gradeable.getId() }}')">Save Changes</a>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -143,6 +143,10 @@
                     </div>
                 </div>
                 <div id="gradeable-config-edit-bar">
+                    <div style="display: flex; flex-grow: 1; justify-content: flex-end;">
+                        <i class="fas fa-list-ol" id="toggle-line-nums" style="margin-right: 16px" onClick="toggleLineNums()"></i>
+                        <i class="fas fa-2" id="toggle-tab-length" style="margin-right:10px" onClick="toggleTabLength()"></i>
+                    </div>
                     <textarea id="gradeable-config-edit" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>
                     <a class="btn btn-primary" onclick="saveGradeableConfigEdit('{{ gradeable.getId() }}')">Save Changes</a>
                     <a class="btn btn-default" onclick="cancelGradeableConfigEdit()">Cancel</a>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -143,12 +143,12 @@
                     </div>
                 </div>
                 <div id="gradeable-config-edit-bar">
-                    <div style="display: flex; flex-grow: 1; justify-content: flex-end; margin-bottom: 2px;">
-                        <button type="button" style="margin-right:6px; width:25px; height:25px" id="toggle-line-nums" onClick="toggleLineNums()">
-                            <i class="fas fa-list-ol"></i>
+                    <div class="customize-editor-container">
+                        <button type="button" class="customize-editor-button" onClick="toggleLineNums()">
+                            <i class="fas fa-list-ol icon" class="customize-editor-button-icon"></i>
                         </button>
-                        <button type="button" style="width:25px; height:25px" onClick="toggleTabLength()">
-                            <i class="fas fa-2" id="toggle-tab-length"></i>
+                        <button type="button" class="customize-editor-button" onClick="toggleTabLength()">
+                            <i class="fas fa-2" id="toggle-tab-length" class="customize-editor-button-icon"></i>
                         </button>
                     </div>
                     <textarea id="gradeable-config-edit" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -144,11 +144,11 @@
                 </div>
                 <div id="gradeable-config-edit-bar">
                     <div class="customize-editor-container">
-                        <button type="button" class="customize-editor-button" onClick="toggleLineNums()">
-                            <i class="fas fa-list-ol icon" class="customize-editor-button-icon"></i>
+                        <button type="button" class="customize-editor-button" id="toggle-line-nums" onClick="toggleLineNums()">
+                            <i class="fas fa-list-ol customize-editor-button-icon"></i>
                         </button>
                         <button type="button" class="customize-editor-button" onClick="toggleTabLength()">
-                            <i class="fas fa-2" id="toggle-tab-length" class="customize-editor-button-icon"></i>
+                            <i class="fas fa-2 customize-editor-button-icon" id="toggle-tab-length"></i>
                         </button>
                     </div>
                     <textarea id="gradeable-config-edit" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -480,8 +480,37 @@ body::-webkit-scrollbar-track {
     margin-right: 6px;
 }
 
+.customize-editor-container {
+    display: flex;
+    flex-grow: 1;
+    justify-content: flex-end;
+    margin-bottom: 2px;
+}
+
+.customize-editor-button {
+    margin-left: 6px;
+    width: 25px;
+    height: 25px;
+    outline: none;
+    box-shadow: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background-color: var(--btn-default-white);
+}
+
+.customize-editor-button-icon {
+    pointer-events: none;
+    color: var(--text-black);
+}
+
 .line-nums-selected {
-    background-color: var(--standard-deep-blue);
+    background-color: var(--standard-light-blue);
+}
+
+[data-theme="dark"] .line-nums-selected {
+    background: var(--standard-plum-purple);
 }
 
 /* stylelint-disable-next-line selector-class-pattern */

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -498,11 +498,14 @@ body::-webkit-scrollbar-track {
     justify-content: center;
     padding: 0;
     background-color: var(--btn-default-white);
+    border-radius: 4px;
+    border-width: 2px;
+    color: var(--text-black);
+    cursor: pointer;
 }
 
 .customize-editor-button-icon {
     pointer-events: none;
-    color: var(--text-black);
 }
 
 .line-nums-selected {

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -480,6 +480,10 @@ body::-webkit-scrollbar-track {
     margin-right: 6px;
 }
 
+.line-nums-selected {
+    background-color: var(--standard-deep-blue);
+}
+
 /* stylelint-disable-next-line selector-class-pattern */
 #gradeable-config-edit-bar .CodeMirror {
     /* The below instances of !important are identical to those used in gradeable-notebook.css.

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1238,21 +1238,19 @@ function removeFile(g_id, path, isFolder) {
     });
 }
 
-const enableLineNums = 'enableLineNums';
-const setTabLength = 'setTabLength';
-
 function loadCodeMirror() {
     codeMirrorInstance = CodeMirror.fromTextArea(
         document.getElementById('gradeable-config-edit'),
         {
             mode: { name: 'json', json: true },
             theme: localStorage.theme === 'light' ? 'eclipse' : 'monokai',
-            lineNumbers: localStorage.getItem(enableLineNums) === 'true',
-            tabSize: Number(localStorage.getItem(setTabLength)) === 2 ? 2 : 4,
-            indentUnit: 2,
+            lineNumbers: localStorage.getItem('enableLineNums') === 'true',
+            tabSize: Number(localStorage.getItem('setTabLength')) === 2 ? 2 : 4,
+            indentUnit: Number(localStorage.getItem('setTabLength')) === 2 ? 2 : 4,
             lineWrapping: true,
         },
     );
+    updateEditorIcons();
     codeMirrorInstance.on('change', () => {
         const currentContent = codeMirrorInstance.getValue();
         isConfigEdited = currentContent !== originalConfigContent;
@@ -1261,16 +1259,16 @@ function loadCodeMirror() {
 
 // Toggle line nums in gradeable editor
 function toggleLineNums() {
-    const current = localStorage.getItem(enableLineNums);
-    localStorage.setItem(enableLineNums, (!current || current === 'false') ? 'true' : 'false');
+    const current = localStorage.getItem('enableLineNums');
+    localStorage.setItem('enableLineNums', (!current || current === 'false') ? 'true' : 'false');
     reloadCodeMirror();
 }
 
 // Toggle between tab length of 2 and 4 for gradeable editor
 function toggleTabLength() {
-    const tabLength = Number(localStorage.getItem(setTabLength));
+    const tabLength = Number(localStorage.getItem('setTabLength'));
     const newLength = (!tabLength || tabLength === 2) ? 4 : 2;
-    localStorage.setItem(setTabLength, newLength);
+    localStorage.setItem('setTabLength', newLength);
     reloadCodeMirror();
 
     // Update icon
@@ -1281,7 +1279,6 @@ function toggleTabLength() {
     }
 }
 
-
 function reloadCodeMirror() {
     if (codeMirrorInstance) {
         const currentContent = codeMirrorInstance.getValue();
@@ -1291,3 +1288,20 @@ function reloadCodeMirror() {
     loadCodeMirror();
 }
 
+function updateEditorIcons() {
+    // Line Number Icon
+    const enableLineNumsIcon = document.getElementById('toggle-line-nums');
+    const lineNums = localStorage.getItem('enableLineNums');
+    if (lineNums === 'true') {
+        enableLineNumsIcon.classList.add('line-nums-selected');
+    }
+    else {
+        enableLineNumsIcon.classList.remove('line-nums-selected');
+    }
+    
+    // Tab Length Icon
+    const tabLengthIcon = document.getElementById('toggle-tab-length');
+    const tabLength = localStorage.getItem('setTabLength');
+    tabLengthIcon.classList.remove('fa-2', 'fa-4');
+    tabLengthIcon.classList.add(`fa-${tabLength}`);
+}

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1259,10 +1259,20 @@ function loadCodeMirror() {
 
 // Toggle line nums in gradeable editor
 function toggleLineNums() {
+    const icon = document.getElementById('toggle-line-nums');
     const current = localStorage.getItem('enableLineNums');
-    localStorage.setItem('enableLineNums', (!current || current === 'false') ? 'true' : 'false');
+    const newState = (!current || current === 'false') ? 'true' : 'false';
+
+    localStorage.setItem('enableLineNums', newState);
     reloadCodeMirror();
+
+    if (newState === 'true') {
+        icon.classList.add('line-nums-selected');
+    } else {
+        icon.classList.remove('line-nums-selected');
+    }
 }
+
 
 // Toggle between tab length of 2 and 4 for gradeable editor
 function toggleTabLength() {

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1311,7 +1311,7 @@ function updateEditorIcons() {
     
     // Tab Length Icon
     const tabLengthIcon = document.getElementById('toggle-tab-length');
-    const tabLength = localStorage.getItem('setTabLength');
+    const tabLength = localStorage.getItem('setTabLength') || '2';
     tabLengthIcon.classList.remove('fa-2', 'fa-4');
     tabLengthIcon.classList.add(`fa-${tabLength}`);
 }

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1238,14 +1238,17 @@ function removeFile(g_id, path, isFolder) {
     });
 }
 
+const enableLineNums = 'enableLineNums';
+const setTabLength = 'setTabLength';
+
 function loadCodeMirror() {
     codeMirrorInstance = CodeMirror.fromTextArea(
         document.getElementById('gradeable-config-edit'),
         {
             mode: { name: 'json', json: true },
             theme: localStorage.theme === 'light' ? 'eclipse' : 'monokai',
-            lineNumbers: false,
-            tabSize: 2,
+            lineNumbers: localStorage.getItem(enableLineNums) === 'true',
+            tabSize: Number(localStorage.getItem(setTabLength)) === 2 ? 2 : 4,
             indentUnit: 2,
             lineWrapping: true,
         },
@@ -1255,3 +1258,36 @@ function loadCodeMirror() {
         isConfigEdited = currentContent !== originalConfigContent;
     });
 }
+
+// Toggle line nums in gradeable editor
+function toggleLineNums() {
+    const current = localStorage.getItem(enableLineNums);
+    localStorage.setItem(enableLineNums, (!current || current === 'false') ? 'true' : 'false');
+    reloadCodeMirror();
+}
+
+// Toggle between tab length of 2 and 4 for gradeable editor
+function toggleTabLength() {
+    const tabLength = Number(localStorage.getItem(setTabLength));
+    const newLength = (!tabLength || tabLength === 2) ? 4 : 2;
+    localStorage.setItem(setTabLength, newLength);
+    reloadCodeMirror();
+
+    // Update icon
+    const icon = document.getElementById('toggle-tab-length');
+    if (icon) {
+        icon.classList.remove('fa-2', 'fa-4');
+        icon.classList.add(`fa-${newLength}`);
+    }
+}
+
+
+function reloadCodeMirror() {
+    if (codeMirrorInstance) {
+        const currentContent = codeMirrorInstance.getValue();
+        codeMirrorInstance.toTextArea();
+        document.getElementById('gradeable-config-edit').value = currentContent;
+    }
+    loadCodeMirror();
+}
+


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Code Mirror is highly customizable. The gradeable config does not take advantage of these options.

### What is the New Behavior?
Added 2 buttons to the top right of the gradeable config editor:
<img width="142" height="60" alt="image" src="https://github.com/user-attachments/assets/cffb60fc-6688-4e77-b611-ad60dbe48257" />
<img width="142" height="60" alt="image" src="https://github.com/user-attachments/assets/b667ab0e-99b8-46b0-9cb3-370ec86d02ed" />
The one on the left toggles the visibility of line count. The one on the right toggles between a tabSize/default indentation of 2, and 4.

Settings persist via local storage.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1) Upload a custom autograding configuration
2) Use the Gradeable Editor and verify that toggles work and persist on reload.

### Other information
This is not a breaking change.
