### PR TITLE
[Bugfix:TAGrading] Fix browser specific panel resizing

### DIFF
--- a/site/ts/resizable-panels.ts
+++ b/site/ts/resizable-panels.ts
@@ -32,9 +32,7 @@ export function initializeResizablePanels(panelSel: string, dragBarSel: string, 
     // Width of left side
     const mouseDownHandler = (e: MouseEvent | TouchEvent | Touch) => {
         // Get the current mouse position
-        if (e instanceof TouchEvent) {
-            e = e.touches[0];
-        }
+        e = 'touches' in e ? e.touches[0] : e;
         xPos = e.clientX;
         yPos = e.clientY;
         panelHeight = panelEle.getBoundingClientRect().height;
@@ -68,9 +66,7 @@ export function initializeResizablePanels(panelSel: string, dragBarSel: string, 
     };
 
     const mouseMoveHandler = (e: MouseEvent | TouchEvent | Touch) => {
-        if (e instanceof TouchEvent) {
-            e = e.touches[0];
-        }
+        e = 'touches' in e ? e.touches[0] : e;
         let updateValue;
         if (isHorizontalResize) {
             const dy = e.clientY - yPos;

--- a/site/ts/ta-grading-panels.ts
+++ b/site/ts/ta-grading-panels.ts
@@ -278,7 +278,6 @@ export function updatePanelOptions() {
         '.grade-panel .panel-position-cont option',
     );
     panelOptions.each((idx) => {
-        console.log('panelOptions', panelOptions[idx], panelOptions[idx].value);
         if (panelOptions[idx].value === 'leftTop') {
             if (
                 taLayoutDet.numOfPanelsEnabled === 2

--- a/site/ts/ta-grading-panels.ts
+++ b/site/ts/ta-grading-panels.ts
@@ -278,6 +278,7 @@ export function updatePanelOptions() {
         '.grade-panel .panel-position-cont option',
     );
     panelOptions.each((idx) => {
+        console.log('panelOptions', panelOptions[idx], panelOptions[idx].value);
         if (panelOptions[idx].value === 'leftTop') {
             if (
                 taLayoutDet.numOfPanelsEnabled === 2


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
You currently cannot resize the panels on firefox. This is because TouchEvent on firefox does not exist on systems that do not have touch, like macs. Therefore, it will throw an error whenever we try to see if it is an instance of TouchEvent.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Instead of explicitly checking for touchevent, we can just check if it has certain properties that we would like to strip out

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
We do not test firefox

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
