### PR TITLE
[Bugfix:Forum] Prevent multiple onclick handlers

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -2003,7 +2003,7 @@ function sortTable(sort_element_index, reverse = false) {
 }
 
 function loadThreadHandler() {
-    $('a.thread_box_link').click(async function (event) {
+    $('a.thread_box_link').off('click').click(async function (event) {
         // if a thread is clicked on the full-forum-page just follow normal GET request else continue with ajax request
         if (window.location.origin + window.location.pathname === buildCourseUrl(['forum'])) {
             return;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Whenever the sidebar is updated while using the discussion forum, a new onclick handler is added to all posts in the sidebar, causing many requests to be made if many posts are updated before refreshing.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
All stale click event handlers are cleared before adding the correct one after the sidebar is updated.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. View the discussion forum on main
2. Like/unlike a few posts
3. Notice that 1 + likes * 2 requests are made when changing threads
4. Switch to the branch and see that there is only ever one request

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
