### PR TITLE
[Feature:Developer] Add regenerate phpstan baseline to submitty_test

### DIFF
--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -10,6 +10,11 @@ run_php_stan() {
     COMPOSER_ALLOW_SUPERUSER=1 composer run-script static-analysis "${@:2}" 2>/dev/null
 }
 
+run_regenerate_baseline() {
+    COMPOSER_ALLOW_SUPERUSER=1 composer install
+    COMPOSER_ALLOW_SUPERUSER=1 composer run-script static-analysis -- --generate-baseline --memory-limit 2G
+}
+
 run_php_cs() {
     COMPOSER_ALLOW_SUPERUSER=1 composer install
     COMPOSER_ALLOW_SUPERUSER=1 composer run-script lint 2>/dev/null
@@ -32,12 +37,13 @@ run_php_unit() {
 
 if [ -z "$1" ] || [ "$1" == "help" ]; then
     echo "
-          phpstan : php static analysis [option: --memory-limit 4G, --generate-baseline ...]
-          phpcs   : php CodeSniffer
-          php-lint: phpcs & phpstan
-          php-unit: run php unit tests
-          js-lint : eslint
-          css-lint: css-stylelint
+          phpstan             : php static analysis [option: --memory-limit 4G, --generate-baseline ...]
+          regenerate-baseline  : shortcut to regenerate phpstan baseline file
+          phpcs                : php CodeSniffer
+          php-lint             : phpcs & phpstan
+          php-unit             : run php unit tests
+          js-lint              : eslint
+          css-lint             : css-stylelint
           "
 elif [ "$1" == "phpstan" ]; then
     run_php_stan "$@"
@@ -52,6 +58,8 @@ elif [ "$1" == "js-lint" ]; then
     run_js_es
 elif [ "$1" == "css-lint" ]; then
     run_css_style
+elif [ "$1" == "regenerate-baseline" ]; then
+    run_regenerate_baseline
 else
     echo "Unknown test type: $1
         use phpstan, phpcs, php-lint, php-unit, js-lint, css-lint


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Whenever I want to regenerate the baseline, i have to pull the documentation [here](https://submitty.org/developer/testing/linting_static_analysis#php-static-analysis) in order to run the command. It would be nice to do this directly from the command line using `submitty_test`. Although `submitty_test` already can handle generating the baseline (by using `submitty_test -- --generate-baseline --memory-limit 2G`), I believe that this is unintuitive for most developers as the first `--` is to pass in the arguments.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Added a shortcut, or alias, to the `submitty_test` script in order to regenerate the baseline more easily

### What steps should a reviewer take to reproduce or test the bug or new feature?
Make a change that would cahnge the baseline. Regenerate the baseline using the command

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
