### PR TITLE
[Refactor:System] Fix randint types in sample course data

### DIFF
--- a/.setup/bin/sample_courses/models/course/course_create_gradeables.py
+++ b/.setup/bin/sample_courses/models/course/course_create_gradeables.py
@@ -358,8 +358,8 @@ class Course_create_gradeables:
                                     if status == 0 or random.random() < 0.4:
                                         score = 0
                                     else:
-                                        max_value_score = random.randint(component.lower_clamp * 2, component.max_value * 2) / 2
-                                        uppser_clamp_score = random.randint(component.lower_clamp * 2, component.upper_clamp * 2) / 2
+                                        max_value_score = random.randint(int(component.lower_clamp * 2), int(component.max_value * 2)) / 2
+                                        uppser_clamp_score = random.randint(int(component.lower_clamp * 2), int(component.upper_clamp * 2)) / 2
                                         score = generate_probability_space({0.7: max_value_score, 0.2: uppser_clamp_score, 0.08: -max_value_score, 0.02: -99999})
                                     grade_time = gradeable.grade_start_date.strftime("%Y-%m-%d %H:%M:%S%z")
                                     self.conn.execute(
@@ -404,7 +404,7 @@ class Course_create_gradeables:
                             elif gradeable.type == 1:
                                 score = generate_probability_space({0.2: 0, 0.1: 0.5}, 1)
                             else:
-                                score = random.randint(component.lower_clamp * 2, component.upper_clamp * 2) / 2
+                                score = random.randint(int(component.lower_clamp * 2), int(component.upper_clamp * 2)) / 2
                             grade_time = gradeable.grade_start_date.strftime("%Y-%m-%d %H:%M:%S%z")
                             self.conn.execute(
                                 insert(self.gradeable_component_data).values(


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently we pass floats to `random.randint` when setting up sample courses, and this currently is supported but will not be when our python version upgrades along with ubuntu 24.04.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Floats are casted to ints before being passed to `random.randint`

### What steps should a reviewer take to reproduce or test the bug or new feature?
Verify that the sample courses are created and function normally.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
Almost all of our tests are based on the sample data, so this change is thoroughly covered.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
