### PR TITLE
[Bugfix:InstructorUI] Fix decoding of eg_thread_ids

### DIFF
--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -941,7 +941,7 @@ CREATE TABLE public.electronic_gradeable (
     eg_grade_inquiry_allowed boolean DEFAULT true NOT NULL,
     eg_grade_inquiry_per_component_allowed boolean DEFAULT false NOT NULL,
     eg_grade_inquiry_due_date timestamp(6) with time zone NOT NULL,
-    eg_thread_ids json DEFAULT '{}'::json NOT NULL,
+    eg_thread_ids json DEFAULT '[]'::json NOT NULL,
     eg_has_discussion boolean DEFAULT false NOT NULL,
     eg_limited_access_blind integer DEFAULT 1,
     eg_peer_blind integer DEFAULT 3,

--- a/migration/migrator/migrations/course/20250804212849_default_thread_ids_value.py
+++ b/migration/migrator/migrations/course/20250804212849_default_thread_ids_value.py
@@ -1,0 +1,43 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+
+    database.execute("""
+        ALTER TABLE electronic_gradeable
+        ALTER COLUMN eg_thread_ids SET DEFAULT '[]';
+    """)
+
+    database.execute("""
+        UPDATE electronic_gradeable
+        SET eg_thread_ids = '[]'::json
+        WHERE eg_thread_ids::jsonb = '"{}"'::jsonb;
+    """)
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    pass

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -340,13 +340,7 @@ class Gradeable extends AbstractModel {
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
             $this->setDiscussionBased($details['discussion_based']);
             if (is_string($details['discussion_thread_ids']) && strlen($details['discussion_thread_ids']) > 0) {
-                $thread_ids = json_decode($details['discussion_thread_ids'], true);
-
-                // Covering the edge case of default ""{}"" value
-                if (is_string($thread_ids)) {
-                    $thread_ids = json_decode($thread_ids, true);
-                }
-                $this->setDiscussionThreadId($thread_ids);
+                $this->setDiscussionThreadId(json_decode($details['discussion_thread_ids'], true));
             }
             $this->setAllowCustomMarks($details['allow_custom_marks']);
             $this->setAllowedMinutes($details['allowed_minutes'] ?? null);

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -340,7 +340,13 @@ class Gradeable extends AbstractModel {
             $this->setGradeInquiryPerComponentAllowed($details['grade_inquiry_per_component_allowed']);
             $this->setDiscussionBased($details['discussion_based']);
             if (is_string($details['discussion_thread_ids']) && strlen($details['discussion_thread_ids']) > 0) {
-                $this->setDiscussionThreadId(json_decode($details['discussion_thread_ids'], true));
+                $thread_ids = json_decode($details['discussion_thread_ids'], true);
+
+                // Covering the edge case of default ""{}"" value
+                if (is_string($thread_ids)) {
+                    $thread_ids = json_decode($thread_ids, true);
+                }
+                $this->setDiscussionThreadId($thread_ids);
             }
             $this->setAllowCustomMarks($details['allow_custom_marks']);
             $this->setAllowedMinutes($details['allowed_minutes'] ?? null);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
From #11702,
On production, we have gradeables that have already been created. When the gradeable gets created, we `json_encode('{}')` as the default value. This means that when it gets inserted into the database, instead of `{}` being inserted, we actually insert `"{}"` instead, which is a string. This means that the new code, which decodes it once, will not work as it will be decoded to `"{}"` instead of `[]`, which throws of frog robot.  
We can either:

1. Decoding it twice would allow for us to get `[]` instead of string `"{}"`.
2. Make a database migration for this situation where we specifically patch this one instance

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Make a database migration for this situation where we specifically patch this one instance. I feel like this is better and the other way is a little hacky

### What steps should a reviewer take to reproduce or test the bug or new feature?
Make a gradeable before #11702. Move to after #11702, edit gradeable, see error

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
This could not have been prevented that easily with e2e test. The initial state would have to be from the previous course creations, and then switching to the new version. We could do this to prevent this error, but it would be very hard.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->