### PR TITLE
[Bugfix:System] Fix Invalid vue-tsc File Permissions

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -416,7 +416,7 @@ echo "Running esbuild"
 chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
 chmod a+x ${NODE_FOLDER}/vue-tsc/bin/vue-tsc.js
-chmod -R ug+rw ${NODE_FOLDER}/.vue-global-types
+chmod -R u+rw ${NODE_FOLDER}/.vue-global-types
 chmod a+x ${NODE_FOLDER}/vite/bin/vite.js
 chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
@@ -428,7 +428,7 @@ chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
 chmod a-x ${NODE_FOLDER}/vue-tsc/bin/vue-tsc.js
 chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod a-x ${NODE_FOLDER}/vite/bin/vite.js
-chmod -R ug-rw ${NODE_FOLDER}/.vue-global-types
+chmod -R u-rw ${NODE_FOLDER}/.vue-global-types
 chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
 chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs

--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -416,7 +416,7 @@ echo "Running esbuild"
 chmod a+x ${NODE_FOLDER}/esbuild/bin/esbuild
 chmod a+x ${NODE_FOLDER}/typescript/bin/tsc
 chmod a+x ${NODE_FOLDER}/vue-tsc/bin/vue-tsc.js
-chmod -R g+w ${NODE_FOLDER}/.vue-global-types
+chmod -R ug+rw ${NODE_FOLDER}/.vue-global-types
 chmod a+x ${NODE_FOLDER}/vite/bin/vite.js
 chmod g+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod -R u+w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
@@ -428,7 +428,7 @@ chmod a-x ${NODE_FOLDER}/typescript/bin/tsc
 chmod a-x ${NODE_FOLDER}/vue-tsc/bin/vue-tsc.js
 chmod g-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 chmod a-x ${NODE_FOLDER}/vite/bin/vite.js
-chmod -R g-w ${NODE_FOLDER}/.vue-global-types
+chmod -R ug-rw ${NODE_FOLDER}/.vue-global-types
 chmod -R u-w "${SUBMITTY_INSTALL_DIR}/site/incremental_build"
 
 chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Previously, the `.vue-global-types` directory and files were granted only group write permissions (`g+w`), while the owner (`submitty_php`) lacked write access. This caused permission denied (`EACCES`) errors during build steps as the owner. The owner access bits take precedence when the process UID matches the file owner, which causes the following issue.

```
su - ${PHP_USER} -c "cd ${SUBMITTY_INSTALL_DIR}/site && npm run build"

> build
> vue-tsc && node .build.js && vite build vue

Error: EACCES: permission denied, open '/usr/local/submitty/site/node_modules/.vue-global-types/vue_3.5_0.d.ts'
    at Object.openSync (node:fs:574:18)
    at Object.writeFile2 (/usr/local/submitty/site/node_modules/typescript/lib/tsc.js:5180:18)
    at /usr/local/submitty/site/node_modules/typescript/lib/tsc.js:4880:61
    at writeFileEnsuringDirectories (/usr/local/submitty/site/node_modules/typescript/lib/tsc.js:16579:5)
    at sys2.writeFile (/usr/local/submitty/site/node_modules/typescript/lib/tsc.js:4876:46)
    at vueOptions.globalTypesPath (/usr/local/submitty/site/node_modules/@vue/language-core/lib/utils/ts.js:314:13)
    at generateGlobalTypesPath (/usr/local/submitty/site/node_modules/@vue/language-core/lib/codegen/script/index.js:111:56)
    at generateGlobalTypesPath.next (<anonymous>)
    at generateScript (/usr/local/submitty/site/node_modules/@vue/language-core/lib/codegen/script/index.js:28:12)
    at generateScript.next (<anonymous>) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/usr/local/submitty/site/node_modules/.vue-global-types/vue_3.5_0.d.ts'
}
vue/src/components/SolutionPanel.vue:3:26 - error TS2306: File '/usr/local/submitty/site/vue/src/components/MarkdownArea.vue' is not a module.

3 import MarkdownArea from './MarkdownArea.vue';
                           ~~~~~~~~~~~~~~~~~~~~

vue/src/components/SolutionPanel.vue:152:16 - error TS7006: Parameter 'newValue' implicitly has an 'any' type.

152               (newValue) =>
                   ~~~~~~~~


Found 2 errors in the same file, starting at: vue/src/components/SolutionPanel.vue:3

root@ubuntu:/usr/local/submitty# ls -la /usr/local/submitty/site/node_modules/.vue-global-types/vue_3.5_0.d.ts
-r--rw---- 1 submitty_php submitty_php 6581 Aug  5 12:30 [Owner is missing write bit]
```



### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

The updated script now applies recursive owner read/write permissions (`u+rw`) to `.vue-global-types` during the build, ensuring the build process can successfully write necessary type definition files and eliminating these permission issues.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Comment out `chmod -R u+rw ${NODE_FOLDER}/.vue-global-types`
2. Run `submitty_install_site`
3. Notice build errors (none should persist after uncommenting the line)


### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

N/A

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

Fixes bug introduced within #11868.
