### PR TITLE
[Bugfix:InstructorUI] Fix Admin Gradeable's Team Lock Date

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2665,7 +2665,7 @@ class Gradeable extends AbstractModel {
         return $this->team_size_max;
     }
 
-    public function getTeamLockDate(): \DateTime {
+    public function getTeamLockDate(): ?\DateTime {
         return $this->team_lock_date;
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
#11702 Magic Methods PR stated that team_lock_date is ?DateTime, which is true, but getting the value actually returns a DateTime, casuing a frog robot crash 
```
Oh no! Something irrecoverable has happened...
app\exceptions\OutputException (Code: 0) thrown in /usr/local/submitty/site/app/libraries/Output.php (Line 412) by:
            throw new OutputException("{$e->getMessage()} in {$e->getFile()}:{$e->getLine()}");
Message:
An exception has been thrown during the rendering of a template ("app\models\gradeable\Gradeable::getTeamLockDate(): Return value must be of type DateTime, null returned") in "admin/admin_gradeable/AdminGradeableDates.twig" at line 14. in /usr/local/submitty/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig:14
Stack Trace:
#0 /usr/local/submitty/site/app/libraries/Output.php(425): app\libraries\Output->renderTwigTemplate()
#1 /usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php(617): app\libraries\Output->renderTwigOutput()
#2 /usr/local/submitty/site/app/controllers/admin/AdminGradeableController.php(32): app\controllers\admin\AdminGradeableController->editPage()
#3 unknown file(unknown line): app\controllers\admin\AdminGradeableController->editGradeableRequest()
#4 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(254): call_user_func_array()
#5 /usr/local/submitty/site/app/libraries/routers/WebRouter.php(232): app\libraries\routers\WebRouter->run()
#6 /usr/local/submitty/site/public/index.php(147): app\libraries\routers\WebRouter::getWebResponse()
USER: instructor
```

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Like all other dates, team lock date now returns the correct value, `?\DateTime`

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
We should check creating and modifying dates for a checkpoint gradeables
#11982 11982

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
