### PR TITLE
[Dependency] Add python3-venv installation to setup

### DIFF
--- a/.setup/distro_setup/ubuntu/22.04/setup_distro.sh
+++ b/.setup/distro_setup/ubuntu/22.04/setup_distro.sh
@@ -24,7 +24,7 @@ add-apt-repository -y ppa:ondrej/php
 apt-get -qqy update
 
 apt-get install -qqy apt-transport-https ca-certificates curl software-properties-common
-apt-get install -qqy python3 python3-dev libpython3.6 python3-pip
+apt-get install -qqy python3 python3-dev libpython3.6 python3-pip python3-venv
 
 ############################
 # NTP: Network Time Protocol

--- a/migration/migrator/migrations/system/20250807110111_add_venvs.py
+++ b/migration/migrator/migrations/system/20250807110111_add_venvs.py
@@ -1,0 +1,28 @@
+"""Migration for the Submitty system."""
+
+
+import os
+import subprocess
+
+
+def up(config):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    subprocess.check_call(
+        ["apt-get", "install", "-qqy", "python3-venv"],
+        env=os.environ.copy()
+    )
+
+
+def down(config):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    """
+    pass


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
As part of the upgrade to ubuntu 24.04, we want to move all of our python dependencies to virtual environments, but currently the `python3-venv` package is not installed so they cannot be created.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
This PR installs the python3-venv package so we can manage our venvs. No venvs are created in this PR since the first will likely be the migrator itself.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Run `migrator -e system migrate`
2. Verify `python3 -m venv /path/to/venv` creates venv successfully

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
1. There is no automated testing of this PR, but as venvs are added those will need testing.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
