### PR TITLE
[Bugfix:InstructorUI] Improve Autograding Config UI/UX

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -4,9 +4,9 @@
     <div class="option-title">
         What are students allowed to do?
     </div>
-    <div>
+    <div class="perm-container">
         <fieldset>
-            <legend>View the gradeable on the course home page?</legend>
+            <legend class="legend-header">View the gradeable on the course home page?</legend>
             <input type="radio" id="no_student_view_after_grades" name="student_view_after_grades" value="false"
                     {{ gradeable.isStudentView() and not gradeable.isStudentViewAfterGrades() ? 'checked' : '' }}/> <label for="no_student_view_after_grades">Yes</label>
             <input type="radio" id="no_student_view" name="student_view" value="false"
@@ -20,12 +20,13 @@
         </fieldset>
     </div>
 
-    <div id="student_download_view">
+    <div id="student_download_view" class="perm-container">
         <div>
-            <fieldset><legend>View and download submitted files? 
-            {% if gradeable.isBulkUpload() %}
-            <span class="red-message" id="view-files-warning"> WARNING: Students will see the grading score and TA feedback but will not be able to download the scanned and uploaded file.</span></legend>
-            {% endif %}
+            <fieldset><legend class="legend-header">View and download submitted files? 
+                {% if gradeable.isBulkUpload() %}
+                    <span class="red-message" id="view-files-warning"> WARNING: Students will see the grading score and TA feedback but will not be able to download the scanned and uploaded file.</span>
+                {% endif %}
+            </legend>
             <input type="radio" id="yes_student_download" name="student_download" value="true"
                     {{ gradeable.canStudentDownload() ? 'checked' : '' }}/> <label for="yes_student_download">Yes</label>
             <input type="radio" id="no_student_download" name="student_download" value="false"
@@ -33,9 +34,9 @@
         </div>
     </div>
 
-    <div id="student_submit_view">
+    <div id="student_submit_view" class="perm-container">
         <div>
-            <fieldset><legend>Make new submissions and access all prior versions?</legend>
+            <fieldset><legend class="legend-header">Make new submissions and access all prior versions?</legend>
             <input type="radio" id="yes_student_submit" name="student_submit" value="true"
                     {{ gradeable.isStudentSubmit() ? 'checked' : '' }}/> <label for="yes_student_submit">Yes</label>
             <input type="radio" id="no_student_submit" name="student_submit" value="false"
@@ -71,10 +72,9 @@
 
     <div class="option-title">Choose an autograding configuration:</div>
             <p> You may specify your <a target=_blank href="https://submitty.org/instructor/assignment_configuration/configuration_path#course-autograding-configuration-directory">
-                "Course Autograding Config Directory"<i style="font-style:normal;" class="fa-question-circle"></i></a>
+                Course Autograding Config Directory<i style="font-style:normal;" class="fa-question-circle"></i></a>
                 from the Course Settings Page. </p>
-            <p> Manually type the full path to a configuration file, or select from the list below. </p>
-    <p> The dropdown list has all existing configurations that contain the current text.</p>
+            <p> Type the path or choose from the filtered dropdown. </p>
     {% for error_message in repository_error_messages %}
         <div class="config_search_error">({{error_message}})</div>
     {% endfor %}
@@ -85,7 +85,7 @@
         {% endif %}
     </div>
 
-    <div class="settings">
+    <div class="select-config-container">
         <div>
             <div class="drop-down" id="config-drop-down">
                 <select name="autograding_config_path" id="autograding_config_selector">
@@ -99,20 +99,8 @@
         <a data-testid="config-button" class="btn btn-primary" style="margin-top: 6px" href="{{ upload_config_url }}">Upload a custom autograding configuration</a>
     </div>
 
-    <div class="notebook-builder-info">
-        <div class="option-title">Notebook Builder:</div>
-        <div>
-            <a class="btn btn-primary" href="{{ notebook_builder_url ~ '/new' }}" data-testid="start-new-notebook">Start New</a>
-            <span>Start a new configuration with notebook builder.</span>
-        </div>
-        <div class="notebook-builder-edit-button-div">
-            <a class="btn btn-primary" href="{{ notebook_builder_url ~ '/edit' }}" data-testid="edit-existing-notebook">Edit Existing</a>
-            <span>Edit the currently selected configuration with notebook builder.</span>
-        </div>
-    </div>
-
     <div class="raw-config-info">
-    <input type="file" id="hidden-config-file-input" class="hidden-file-input" />
+        <input type="file" id="hidden-config-file-input" class="hidden-file-input" />
         <div class="option-title raw-config-info-header">
             <span>Edit Uploaded Configuration:</span>
             <p class="not-available-message" id="editor-not-available">
@@ -145,18 +133,37 @@
                 </div>
                 <div id="gradeable-config-edit-bar">
                     <div class="customize-editor-container">
-                        <button type="button" class="customize-editor-button" id="toggle-line-nums" onClick="toggleLineNums()">
+                        <button type="button"
+                                class="customize-editor-button"
+                                id="toggle-line-nums"
+                                onClick="toggleLineNums()"
+                                title="Toggle line numbers">
                             <i class="fas fa-list-ol customize-editor-button-icon"></i>
                         </button>
-                        <button type="button" class="customize-editor-button" onClick="toggleTabLength()">
+                        <button type="button"
+                                class="customize-editor-button"
+                                onClick="toggleTabLength()"
+                                title="Toggle tab length">
                             <i class="fas fa-2 customize-editor-button-icon" id="toggle-tab-length"></i>
                         </button>
                     </div>
-                    <textarea id="gradeable-config-edit" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>
+                    <textarea id="gradeable-config-edit" class="underlying-textarea" data-edited="false" aria-label="Edit Gradeable Configuration" spellcheck="false"></textarea>
                     <a class="btn btn-primary" onclick="saveGradeableConfigEdit('{{ gradeable.getId() }}')">Save Changes</a>
                     <a class="btn btn-default" onclick="cancelGradeableConfigEdit()">Cancel</a>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <div class="notebook-builder-info">
+        <div class="option-title">Notebook Builder:</div>
+        <div>
+            <a class="btn btn-primary notebook-btn" href="{{ notebook_builder_url ~ '/new' }}" data-testid="start-new-notebook">Start New</a>
+            <span>Start a new configuration with notebook builder.</span>
+        </div>
+        <div class="notebook-builder-edit-button-div">
+            <a class="btn btn-primary notebook-btn" href="{{ notebook_builder_url ~ '/edit' }}" data-testid="edit-existing-notebook">Edit Existing</a>
+            <span>Edit the currently selected configuration with notebook builder.</span>
         </div>
     </div>
 
@@ -298,7 +305,7 @@
                         <i class="fas fa-trash file-action-delete" onclick="removeFile('{{ g_id|e('js') }}', '{{ file.path|e('js') }}', false)"></i>
                     {% endif %}
                     <span class="fas fa-file config-file-icon"></span>
-                    <a class="key_to_click" onclick="updateGradeableEditor('{{ g_id }}', '{{ file.path }}')">{{ name }}</a>
+                    <a class="key_to_click" onclick="markLastClicked(this); updateGradeableEditor('{{ g_id }}', '{{ file.path }}')">{{ name }}</a>
                 {% endif %}
             </div>
         {% endfor %}

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -43,7 +43,7 @@ select {
 }
 
 .perm-container {
-    margin-top: 10px
+    margin-top: 10px;
 }
 
 .legend-header {
@@ -470,6 +470,7 @@ body::-webkit-scrollbar-track {
     margin-left: 0.5em;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .key_to_click.selected {
     color: var(--standard-mediumorchid);
     font-weight: bold;
@@ -536,14 +537,20 @@ body::-webkit-scrollbar-track {
 /* Since we are working with CodeMirror and using a new instance each time we change files,
 we need the underlying text area to have the same styling to ensure the transition is smooth. */
 
-.CodeMirror, .CodeMirror-lines {
+/* stylelint-disable-next-line selector-class-pattern */
+.CodeMirror,
+/* stylelint-disable-next-line selector-class-pattern */
+.CodeMirror-lines {
     padding: 0;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 pre.CodeMirror-line {
-    padding: 0px 8px !important;
+    /* stylelint-disable-next-line declaration-no-important */
+    padding: 0 8px !important;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .CodeMirror-linenumbers {
     margin-right: 4px;
 }
@@ -566,7 +573,6 @@ pre.CodeMirror-line {
     margin-bottom: 0.75em;
     resize: vertical;
     font-size: 14px;
-    vertical-align: middle;
     line-height: normal;
     padding: 4px 8px;
 }

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -42,6 +42,14 @@ select {
     min-width: 60px;
 }
 
+.perm-container {
+    margin-top: 10px
+}
+
+.legend-header {
+    font-weight: 600;
+}
+
 .question-icon {
     display: block;
     float: left;
@@ -183,11 +191,6 @@ input[type="checkbox"] {
     vertical-align: middle;
 }
 
-.settings {
-    padding: 8px;
-    border-radius: 4px;
-}
-
 /* stylelint-disable-next-line selector-id-pattern */
 #electronic_file {
     padding-left: 20px;
@@ -240,6 +243,11 @@ table#grader-history td {
 
 #repository {
     margin-top: 20px;
+}
+
+.select-config-container {
+    margin-top: 7px;
+    margin-bottom: 30px;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -350,12 +358,17 @@ form.dropdown {
 
 .notebook-builder-info {
     margin-top: 30px;
-    margin-bottom: 30px;
+    margin-bottom: 60px;
 }
 
 .notebook-builder-info div {
     margin-top: 10px;
     margin-bottom: 10px;
+}
+
+.notebook-btn {
+    width: 98px;
+    margin-right: 12px;
 }
 
 .select-label-itempool {
@@ -457,6 +470,11 @@ body::-webkit-scrollbar-track {
     margin-left: 0.5em;
 }
 
+.key_to_click.selected {
+    color: var(--standard-mediumorchid);
+    font-weight: bold;
+}
+
 .select-config-box {
     display: none;
 }
@@ -484,7 +502,6 @@ body::-webkit-scrollbar-track {
     display: flex;
     flex-grow: 1;
     justify-content: flex-end;
-    margin-bottom: 2px;
 }
 
 .customize-editor-button {
@@ -516,6 +533,21 @@ body::-webkit-scrollbar-track {
     background: var(--standard-plum-purple);
 }
 
+/* Since we are working with CodeMirror and using a new instance each time we change files,
+we need the underlying text area to have the same styling to ensure the transition is smooth. */
+
+.CodeMirror, .CodeMirror-lines {
+    padding: 0;
+}
+
+pre.CodeMirror-line {
+    padding: 0px 8px !important;
+}
+
+.CodeMirror-linenumbers {
+    margin-right: 4px;
+}
+
 /* stylelint-disable-next-line selector-class-pattern */
 #gradeable-config-edit-bar .CodeMirror {
     /* The below instances of !important are identical to those used in gradeable-notebook.css.
@@ -533,6 +565,21 @@ body::-webkit-scrollbar-track {
     margin-top: 0.75em;
     margin-bottom: 0.75em;
     resize: vertical;
+    font-size: 14px;
+    vertical-align: middle;
+    line-height: normal;
+    padding: 4px 8px;
+}
+
+.underlying-textarea {
+    height: 500px;
+    margin-bottom: 0.75em;
+    margin-top: 0.75em;
+    font-size: 14px;
+    line-height: normal;
+    padding: 4px 16px;
+    background-color: var(--standard-input-background);
+    border: 1px solid var(--standard-light-gray);
 }
 
 #gradeable-config-edit-bar {

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1146,7 +1146,7 @@ function cancelGradeableConfigEdit() {
     isConfigEdited = false;
     current_g_id = null;
     current_file_path = null;
-    document.querySelectorAll('.key_to_click').forEach(link => {
+    document.querySelectorAll('.key_to_click').forEach((link) => {
         link.classList.remove('selected');
     });
 
@@ -1405,7 +1405,7 @@ function updateEditorIcons() {
 
 function markLastClicked(el) {
     // Remove highlight from all
-    document.querySelectorAll('.key_to_click').forEach(link => {
+    document.querySelectorAll('.key_to_click').forEach((link) => {
         link.classList.remove('selected');
     });
     // Highlight the clicked one

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -1038,7 +1038,7 @@ window.addEventListener('beforeunload', (event) => {
 
 // When the text editor opens, the user shouldn't have to manually scroll to see the contents
 function scrollToBottom() {
-    window.scrollTo({ top: 935, left: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 820, left: 0, behavior: 'smooth' });
 }
 
 function updateGradeableEditor(g_id, file_path) {
@@ -1095,7 +1095,7 @@ function loadGradeableEditor(g_id, file_path) {
                 scrollToBottom();
             }
             catch {
-                displayErrorMessage('Error parsing data. Please try again');
+                displayErrorMessage('Error parsing data. File type not supported in the editor.');
             }
         },
     });
@@ -1146,6 +1146,9 @@ function cancelGradeableConfigEdit() {
     isConfigEdited = false;
     current_g_id = null;
     current_file_path = null;
+    document.querySelectorAll('.key_to_click').forEach(link => {
+        link.classList.remove('selected');
+    });
 
     closeCodeMirrorInstance();
 }
@@ -1398,4 +1401,13 @@ function updateEditorIcons() {
     const tabLength = localStorage.getItem('setTabLength') || '2';
     tabLengthIcon.classList.remove('fa-2', 'fa-4');
     tabLengthIcon.classList.add(`fa-${tabLength}`);
+}
+
+function markLastClicked(el) {
+    // Remove highlight from all
+    document.querySelectorAll('.key_to_click').forEach(link => {
+        link.classList.remove('selected');
+    });
+    // Highlight the clicked one
+    el.classList.add('selected');
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The current Submissions/Autograding tab in edit gradeable has a messy UI.

### What is the New Behavior?
Made many small changes to the page and gradeable config editor to improve UI/UX:
1. Added spacing and improved readability of student permissions at the top.
2. Added spacing and rephrased autograding config selector to be more readable.
3. Swapped notebook builder and config editor so that it is right below the config upload.
4. Made notebook builder buttons the same size and increased their right margins.

**In the gradeable config editor:**
1. Selected file now has a different color so the user knows what is in the editor.
2. Smoothened out the transition between files by matching Code Mirror and underlying textarea styling (before it would shrink to the unstyled textarea which was jarring for the user).
3. Added tooltips for the line number and tab size toggles.
4. Made error message when file can't be opened more descriptive.

#### Before
<img width="2235" height="957" alt="full page before" src="https://github.com/user-attachments/assets/756431ad-1613-4465-ac4d-9ed1c7870eff" />

#### After
<img width="2245" height="1018" alt="full page new" src="https://github.com/user-attachments/assets/713cec2a-249f-4567-b1ad-fa0f4b95e8c9" />

#### Gradeable Config Selected File
<img width="1148" height="262" alt="view selected new" src="https://github.com/user-attachments/assets/bea64c72-1927-4596-927a-a79629ab9586" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
Go to the Submissions/Autograding tab in edit gradeable, make sure there is no new styling issues, and no other changes that should be made.

The main changes to verify is selected file color, and file changing transition (should be much smoother than main).

### Other information
This is not a breaking change.
