### PR TITLE
[Feature:InstructorUI] Fix Editor File Order & Spacing

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableAuto.twig
@@ -287,12 +287,13 @@
     });
 </script>
 
+{# Loop to display root folders, then loop to display root level files #}
 {% macro display_config_files(files, indent, g_id) %}
     <div class="main-folder-contents">
         {% for name, file in files %}
-            {% set id = file.path | trim('/', 'right') | replace({'/': '_', '.': '_'}) %}
-            <div style="margin-left:{{ indent * 15 }}px">
-                {% if file.files is defined %}
+            {% if file.files is defined %}
+                {% set id = file.path | trim('/', 'right') | replace({'/': '_', '.': '_'}) %}
+                <div style="margin-left:{{ indent * 15 }}px margin-bottom: 4px;">
                     <i class="fas fa-plus file-action-add" onClick="addFile('{{ g_id|e('js') }}', '{{ file.path|e('js') }}')"></i>
                     <i class="fas fa-trash file-action-delete" onclick="removeFile('{{ g_id|e('js') }}', '{{ file.path|e('js') }}', true)"></i>
                     <span id="{{ id }}-span" class="fas fa-folder config-file-icon"></span>
@@ -300,14 +301,25 @@
                     <div id="{{ id }}" class="config-folder-view">
                         {{ _self.display_config_files(file.files, indent + 1, g_id) }}
                     </div>
+                </div>
+            {% endif %}
+        {% endfor %}
+        {% for name, file in files %}
+            {% if file.files is not defined %}
+                {% set id = file.path | trim('/', 'right') | replace({'/': '_', '.': '_'}) %}
+                {% if not (file.path ends with '/config.json' or file.path == 'config.json') %}
+                    <div style="margin-left:{{ indent * 38 }}px; margin-top: 5px;">
+                            <i class="fas fa-trash file-action-delete" onclick="removeFile('{{ g_id|e('js') }}', '{{ file.path|e('js') }}', false)"></i>
+                        <span class="fas fa-file config-file-icon"></span>
+                        <a class="key_to_click" onclick="markLastClicked(this); updateGradeableEditor('{{ g_id }}', '{{ file.path }}')">{{ name }}</a>
+                    </div>
                 {% else %}
-                    {% if not (file.path ends with '/config.json' or file.path == 'config.json') %}
-                        <i class="fas fa-trash file-action-delete" onclick="removeFile('{{ g_id|e('js') }}', '{{ file.path|e('js') }}', false)"></i>
-                    {% endif %}
-                    <span class="fas fa-file config-file-icon"></span>
-                    <a class="key_to_click" onclick="markLastClicked(this); updateGradeableEditor('{{ g_id }}', '{{ file.path }}')">{{ name }}</a>
+                    <div style="margin-left:{{ indent * 61 }}px;">
+                        <span class="fas fa-file config-file-icon"></span>
+                        <a class="key_to_click" onclick="markLastClicked(this); updateGradeableEditor('{{ g_id }}', '{{ file.path }}')">{{ name }}</a>
+                    </div>
                 {% endif %}
-            </div>
+            {% endif %}
         {% endfor %}
     </div>
 {% endmacro %}

--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -428,7 +428,7 @@ body::-webkit-scrollbar-track {
 }
 
 .main-folder {
-    padding-bottom: 0.5em;
+    margin-bottom: 0.80em;
 }
 
 .main-folder-contents {
@@ -466,7 +466,7 @@ body::-webkit-scrollbar-track {
 
 .config-folder-view {
     list-style-type: none;
-    margin-bottom: 0.5em;
+    margin-bottom: 0.80em;
     margin-left: 0.5em;
 }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
The gradeable config editor does not ensure that root-level directories are shown above root-level files. Additionally, the spacing is inconsistent, and could be improved to highlight the nesting of files.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
1. Root-level directories are always above root-level files
2. Spacing is improved to line up root-level files with root-level folders, and to make nesting more clear to the user.

### Here is the order issue:

#### Before
<img width="2751" height="650" alt="image" src="https://github.com/user-attachments/assets/03d744da-c172-4365-94b2-ffbb275af062" />

#### After
<img width="2830" height="713" alt="image" src="https://github.com/user-attachments/assets/9df6ddbd-c5a3-4b29-bf75-cc504eb3f4f7" />

### Here is a better look at the improved spacing:

#### Before
<img width="2940" height="981" alt="image" src="https://github.com/user-attachments/assets/5e691c5a-e07c-4cb6-b66f-4353c815d7e9" />

#### After
<img width="3044" height="1179" alt="image" src="https://github.com/user-attachments/assets/03052207-3854-4c25-8817-528be80f0d7c" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
login as instructor -> go to Development -> edit the C Failures Gradeable, and go to the Submissions / Autograding tab -> Ensure the root-level config file is below the root-level directory

### Other information
This is not a breaking change.
