### PR TITLE
[Feature:TAGrading] Withdrawn Student Banner

### DIFF
--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -7,12 +7,10 @@
                     <span id="gradeable-version-container" data-gradeable_version="{{ display_version }}" hidden></span>
                     <span class="col grading_label" data-testid="grading-rubric-label">Grading Rubric</span>
                     {# Wrong version warnings #}
-                    {% if not has_active_version %}
+                    {% if not has_active_version and not has_overridden_grades %}
                         {% if has_submission %}
                             {# Cancelled submission #}
                             <div class="red-message">Cancelled Submission</div>
-                        {% elseif has_overridden_grades %}
-                            <div class="yellow-message">Overridden Grades</div>
                         {% else %}
                             {# No submission #}
                             <div class="red-message">No Submission</div>
@@ -21,6 +19,10 @@
                         {# Opened a different version #}
                         <div class="red-message">Select the correct submission version to grade</div>
                         <div id="version-conflict-indicator"></div>
+                    {% elseif is_withdrawn_student %}
+                        <div class="yellow-message">Withdrawn Student</div>
+                    {% elseif has_overridden_grades %}
+                        <div class="yellow-message">Overridden Grades</div>
                     {% endif %}
 
                     {# Verify all button #}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1052,6 +1052,13 @@ HTML;
             "color" => "",
             "message" => ""
         ];
+        // if this is a withdrawn student, we should display it first
+        if (!$gradeable->isTeamAssignment() && $graded_gradeable->getSubmitter()->getUser()->getRegistrationType() === "withdrawn") {
+            $error_message = [
+                "color" => "var(--standard-vibrant-yellow)", // canary yellow
+                "message" => "Withdrawn Student"
+            ];
+        }
         if ($graded_gradeable->hasOverriddenGrades()) {
             $error_message = [
                 "color" => "var(--standard-vibrant-yellow)", // canary yellow
@@ -1672,6 +1679,8 @@ HTML;
         $has_overridden_grades = $graded_gradeable->hasOverriddenGrades();
         $show_clear_conflicts = $graded_gradeable->getTaGradedGradeable()->hasVersionConflict();
 
+        $is_withdrawn_student = !$gradeable->isTeamAssignment() && $graded_gradeable->getSubmitter()->getUser()->getRegistrationType() === "withdrawn";
+
         return $return . $this->core->getOutput()->renderTwigTemplate("grading/electronic/RubricPanel.twig", [
                 "gradeable" => $gradeable,
                 "student_anon_ids" => $student_anon_ids,
@@ -1692,7 +1701,8 @@ HTML;
                 "grader_id" => $this->core->getUser()->getId(),
                 "display_version" => $display_version,
                 "allow_custom_marks" => $gradeable->getAllowCustomMarks(),
-                "is_peer_grader" => $is_peer_grader
+                "is_peer_grader" => $is_peer_grader,
+                "is_withdrawn_student" => $is_withdrawn_student
             ]);
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
There is currently no way for a TA to distinguish who is a withdrawn student or not. If they navigate using the navigating button, they might accidentally grade a withdrawn student, who doesn't actually need grading.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
This PR aims to add banners to distinguish the withdrawn status. In addition, this slightly fixes a bug where a overridden student submits to a gradeable and the text not appearing on the rubric panel.

<img width="1055" height="692" alt="image" src="https://github.com/user-attachments/assets/1f49e419-ffda-4c18-b798-7ccd82f54317" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
#11882 will add withdrawn students, then it would be easier to test

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

