### PR TITLE
[Feature:Autograding] Add regrade_by to autograding history

### DIFF
--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -123,7 +123,7 @@ class Logger:
 def just_write_grade_history(json_file, assignment_deadline, submission_time, seconds_late,
                              first_access_time, access_duration, queue_time, batch_regrade, grading_began,
                              wait_time, grading_finished, grade_time, autograde_total,
-                             revision):
+                             revision, regrade_by):
 
     #####################################
     # LOAD THE PREVIOUS HISTORY
@@ -160,6 +160,8 @@ def just_write_grade_history(json_file, assignment_deadline, submission_time, se
             blob["autograde_max_possible"] = int(autograde_array[5])
     if revision:
         blob["revision"] = revision
+    if regrade_by:
+        blob["regrade_by"] = regrade_by
 
     #####################################
     #  ADD IT TO THE HISTORY

--- a/autograder/autograder/autograding_utils.py
+++ b/autograder/autograder/autograding_utils.py
@@ -576,7 +576,8 @@ def archive_autograding_results(
                                  grading_finished_longstring,
                                  int(gradingtime),
                                  grade_result,
-                                 queue_obj.get("revision", None))
+                                 queue_obj.get("revision", None),
+                                 queue_obj.get("regrade_by", None))
 
         with open(os.path.join(tmp_logs, "overall.txt"), 'a') as f:
             f.write("FINISHED GRADING!\n")

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1526,7 +1526,8 @@ def try_short_circuit(config: dict, queue_file: str) -> bool:
             dateutils.write_submitty_date(grading_finished),
             int(grading_time),
             autograde_result_msg,
-            queue_obj.get('revision', None)
+            queue_obj.get('revision', None),
+            queue_obj.get('regrade_by', None)
         )
 
         results_zip_path = os.path.join(base_dir, 'results.zip')

--- a/autograder/tests/test_write_grade_history.py
+++ b/autograder/tests/test_write_grade_history.py
@@ -11,6 +11,7 @@ from autograder import autograding_utils
 
 class TestWriteGradeHistory(unittest.TestCase):
     """Unittest TestCase."""
+    maxDiff = None
 
     def test_write_history(self):
         """
@@ -38,7 +39,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None
+                None,
             )
 
             expected = []
@@ -82,7 +83,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 30 / 30",
                 2,
-                None
+                None,
             )
 
             expected.append(OrderedDict({
@@ -133,7 +134,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None
+                None,
             )
 
             expected = []
@@ -190,7 +191,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None
+                None,
             )
 
             expected = []
@@ -242,7 +243,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'assignment_deadline': '2019-05-23 23:59:59-0400',
                 'submission_time': '2019-05-23 20:47:12-0400',
                 'queue_time': '2019-05-23 20:47:12-0400',
-                'batch_regrade': True, # all regrades have batch_regrade as true
+                'batch_regrade': True,# all regrades have batch_regrade as true
                 'first_access_time': '2019-05-23 23:59:49-0400',
                 'access_duration': 10,
                 'grading_began': '2019-05-23 20:47:32-0400',

--- a/autograder/tests/test_write_grade_history.py
+++ b/autograder/tests/test_write_grade_history.py
@@ -38,7 +38,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None,
+                None
             )
 
             expected = []
@@ -57,7 +57,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 25 / 30',
                 'autograde_total': 25,
                 'autograde_max_possible': 30,
-                'revision': 1,
+                'revision': 1
             }))
 
             with history_file.open() as open_file:
@@ -82,7 +82,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 30 / 30",
                 2,
-                None,
+                None
             )
 
             expected.append(OrderedDict({
@@ -99,7 +99,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 30 / 30',
                 'autograde_total': 30,
                 'autograde_max_possible': 30,
-                'revision': 2,
+                'revision': 2
             }))
 
             with history_file.open() as open_file:
@@ -133,7 +133,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None,
+                None
             )
 
             expected = []
@@ -152,7 +152,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 25 / 30',
                 'autograde_total': 25,
                 'autograde_max_possible': 30,
-                'revision': 1,
+                'revision': 1
             }))
 
             with history_file.open() as open_file:
@@ -190,7 +190,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 23,
                 "Automatic grading total: 25 / 30",
                 1,
-                None,
+                None
             )
 
             expected = []
@@ -209,7 +209,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 25 / 30',
                 'autograde_total': 25,
                 'autograde_max_possible': 30,
-                'revision': 1,
+                'revision': 1
             }))
 
             with history_file.open() as open_file:

--- a/autograder/tests/test_write_grade_history.py
+++ b/autograder/tests/test_write_grade_history.py
@@ -11,7 +11,6 @@ from autograder import autograding_utils
 
 class TestWriteGradeHistory(unittest.TestCase):
     """Unittest TestCase."""
-    maxDiff = None
 
     def test_write_history(self):
         """

--- a/autograder/tests/test_write_grade_history.py
+++ b/autograder/tests/test_write_grade_history.py
@@ -37,7 +37,8 @@ class TestWriteGradeHistory(unittest.TestCase):
                 "2019-05-23 20:39:55-0400",
                 23,
                 "Automatic grading total: 25 / 30",
-                1
+                1,
+                None
             )
 
             expected = []
@@ -56,7 +57,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 25 / 30',
                 'autograde_total': 25,
                 'autograde_max_possible': 30,
-                'revision': 1
+                'revision': 1,
             }))
 
             with history_file.open() as open_file:
@@ -80,7 +81,8 @@ class TestWriteGradeHistory(unittest.TestCase):
                 "2019-05-23 20:47:55-0400",
                 23,
                 "Automatic grading total: 30 / 30",
-                2
+                2,
+                None
             )
 
             expected.append(OrderedDict({
@@ -97,7 +99,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 30 / 30',
                 'autograde_total': 30,
                 'autograde_max_possible': 30,
-                'revision': 2
+                'revision': 2,
             }))
 
             with history_file.open() as open_file:
@@ -130,7 +132,8 @@ class TestWriteGradeHistory(unittest.TestCase):
                 "2019-05-28 20:39:55-0400",
                 23,
                 "Automatic grading total: 25 / 30",
-                1
+                1,
+                None
             )
 
             expected = []
@@ -149,7 +152,108 @@ class TestWriteGradeHistory(unittest.TestCase):
                 'autograde_result': 'Automatic grading total: 25 / 30',
                 'autograde_total': 25,
                 'autograde_max_possible': 30,
-                'revision': 1
+                'revision': 1,
+            }))
+
+            with history_file.open() as open_file:
+                actual = json.load(open_file, object_pairs_hook=OrderedDict)
+
+            self.assertEqual(len(expected), len(actual))
+            for i in range(len(expected)):
+                self.assertDictEqual(expected[i], actual[i])
+
+    def test_regrading_submission(self):
+        """
+        Test writing regrade information to a json file.
+
+        If the file does not exist, create it to write to, else
+        read from the file, append the information, and then
+        write the full array out. The order of the elements of
+        the json file is important.
+        """
+        with TemporaryDirectory() as tmpdirname:
+            history_file = Path(tmpdirname, 'history.json')
+
+            # Normal submission
+            autograding_utils.just_write_grade_history(
+                str(history_file),
+                "2019-05-23 23:59:59-0400",
+                "2019-05-23 20:39:12-0400",
+                0,
+                "2019-05-23 23:59:49-0400",  # first access
+                10,  # access_duration
+                "2019-05-23 20:39:12-0400",
+                "",
+                "2019-05-23 20:39:32-0400",
+                20,
+                "2019-05-23 20:39:55-0400",
+                23,
+                "Automatic grading total: 25 / 30",
+                1,
+                None
+            )
+
+            expected = []
+
+            expected.append(OrderedDict({
+                'assignment_deadline': '2019-05-23 23:59:59-0400',
+                'submission_time': '2019-05-23 20:39:12-0400',
+                'queue_time': '2019-05-23 20:39:12-0400',
+                'batch_regrade': False,
+                'first_access_time': '2019-05-23 23:59:49-0400',
+                'access_duration': 10,
+                'grading_began': '2019-05-23 20:39:32-0400',
+                'wait_time': 20,
+                'grading_finished': '2019-05-23 20:39:55-0400',
+                'grade_time': 23,
+                'autograde_result': 'Automatic grading total: 25 / 30',
+                'autograde_total': 25,
+                'autograde_max_possible': 30,
+                'revision': 1,
+            }))
+
+            with history_file.open() as open_file:
+                actual = json.load(open_file, object_pairs_hook=OrderedDict)
+
+            self.assertEqual(len(expected), len(actual))
+            for i in range(len(expected)):
+                self.assertEqual(expected[i], actual[i])
+
+            # Regrade submission
+            autograding_utils.just_write_grade_history(
+                str(history_file),
+                "2019-05-23 23:59:59-0400",
+                "2019-05-23 20:47:12-0400",
+                0,
+                "2019-05-23 23:59:49-0400",  # first access
+                10,  # access_duration
+                "2019-05-23 20:47:12-0400",
+                True, # regrade
+                "2019-05-23 20:47:32-0400",
+                20,
+                "2019-05-23 20:47:55-0400",
+                23,
+                "Automatic grading total: 30 / 30",
+                2,
+                "instructor"
+            )
+
+            expected.append(OrderedDict({
+                'assignment_deadline': '2019-05-23 23:59:59-0400',
+                'submission_time': '2019-05-23 20:47:12-0400',
+                'queue_time': '2019-05-23 20:47:12-0400',
+                'batch_regrade': True, # all regrades have batch_regrade as true
+                'first_access_time': '2019-05-23 23:59:49-0400',
+                'access_duration': 10,
+                'grading_began': '2019-05-23 20:47:32-0400',
+                'wait_time': 20,
+                'grading_finished': '2019-05-23 20:47:55-0400',
+                'grade_time': 23,
+                'autograde_result': 'Automatic grading total: 30 / 30',
+                'autograde_total': 30,
+                'autograde_max_possible': 30,
+                'revision': 2,
+                'regrade_by': "instructor"
             }))
 
             with history_file.open() as open_file:

--- a/autograder/tests/test_write_grade_history.py
+++ b/autograder/tests/test_write_grade_history.py
@@ -229,7 +229,7 @@ class TestWriteGradeHistory(unittest.TestCase):
                 "2019-05-23 23:59:49-0400",  # first access
                 10,  # access_duration
                 "2019-05-23 20:47:12-0400",
-                True, # regrade
+                "BATCH", # regrades are all batch
                 "2019-05-23 20:47:32-0400",
                 20,
                 "2019-05-23 20:47:55-0400",

--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import time
 import datetime
 import pause
+import getpass
 
 from submitty_utils import dateutils
 
@@ -57,6 +58,7 @@ def is_active_version(directory):
 # For the specified interval, walks over the log file and creates
 # queue files for these submissions.
 def replay(starttime,endtime):
+    sudo_user = os.getenv("SUDO_USER") or getpass.getuser()
     replay_starttime=datetime.datetime.now()
     print (replay_starttime,"replay start: ",starttime)
 
@@ -115,7 +117,8 @@ def replay(starttime,endtime):
                     "required_capabilities": "default",
                     "queue_time": queue_time,
                     "regrade": True,
-                    "max_possible_grading_time" : -1 }
+                    "max_possible_grading_time" : -1,
+                    "regrade_by": sudo_user }
             file_name = "__".join([item['term'], item['course'], item['gradeable'], item['who'], item['version']])
             file_name = os.path.join(SUBMITTY_DATA_DIR, "to_be_graded_queue", file_name)
             with open(file_name, "w") as open_file:
@@ -129,6 +132,8 @@ def main():
     data_dir = os.path.join(SUBMITTY_DATA_DIR, "courses")
     data_dirs = data_dir.split(os.sep)
     grade_queue = []
+    # try to find who ran the command
+    sudo_user = os.getenv("SUDO_USER") or getpass.getuser()
     if not args.times is None:
         starttime = dateutils.read_submitty_date(args.times[0])
         endtime = dateutils.read_submitty_date(args.times[1])
@@ -244,7 +249,8 @@ def main():
                        "required_capabilities" : required_capabilities,
                        "queue_time":queue_time,
                        "regrade":True,
-                       "max_possible_grading_time" : max_grading_time}
+                       "max_possible_grading_time" : max_grading_time,
+                       "regrade_by": sudo_user }
 
                 if is_vcs_checkout:
                     obj['revision'] = revision

--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -1054,6 +1054,7 @@ class SubmissionController extends AbstractController {
                     "max_possible_grading_time" => $gradeable->getAutogradingConfig()->getMaxPossibleGradingTime(),
                     "queue_time" => $this->core->getDateTimeNow()->format("Y-m-d H:i:sO"),
                     'regrade' => true,
+                    'regrade_by' => $this->core->getUser()->getId(),
                     "required_capabilities" => $gradeable->getAutogradingConfig()->getRequiredCapabilities(),
                     "term" => $this->core->getConfig()->getTerm(),
                     "team" => $team_id,


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Whenever we click regrade, we have no idea who the submission has been graded by. If we want to include students regrading, we should have an idea of who regraded the submission. Therefore, we should add this in the queue file, which adds it to the history file.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Adds the user who regrades into the queue and history file

### What steps should a reviewer take to reproduce or test the bug or new feature?
Make sure that autograding does not break. I have tested team, vcs, and notebook submissions. I have also verified that the history with regrade_by is written to the file.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
Unit tests are included. E2E tests would still have to be written.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

