### PR TITLE
[Feature:Notifications] Mark Viewed for Home Page

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -113,6 +113,42 @@ class HomePageController extends AbstractController {
         );
     }
 
+    #[Route("/home/mark_seen", methods: ["POST"])]
+    public function markNotificationsAsSeen() {
+        $action = $_POST['action'];
+        $user_id = $this->core->getUser()->getId();
+        $courses = $this->courses;
+        $original_config = clone $this->core->getConfig();
+
+        switch ($action) {
+            case 'single':
+                $course_title = $_POST['course'];
+                $notification_id = $_POST['notification_id'];
+                foreach ($courses as $course) {
+                    if($course->getTitle() === $course_title) {
+                        $semester = $course->getTerm();
+                        $this->core->loadCourseConfig($semester, $course_title);
+                        $this->core->loadCourseDatabase();
+                        $this->core->getQueries()->markNotificationAsSeen($user_id, $notification_id);
+                        break;
+                    }
+                }
+                $this->core->setConfig($original_config);
+                return;
+
+            case 'all':
+                foreach ($courses as $course) {
+                    $semester = $course->getTerm();
+                    $course_name = $course->getTitle();
+                    $this->core->loadCourseConfig($semester, $course_name);
+                    $this->core->loadCourseDatabase();
+                    $this->core->getQueries()->markNotificationAsSeen($user_id, -1);
+                }
+                $this->core->setConfig($original_config);
+                return;
+        }
+    }
+
     /**
      * Returns recent notifications for a user
      * @return array<int, Notification>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The home page does not have any way to mark notifications as seen, besides clicking them and going to the link. This can be cumbersome, especially with the new gradeable notifications whenever submissions open.

### What is the New Behavior?
Added a `Mark all as seen` button in the top right of the notifications panel. Clicking this button marks ALL of the user's notifications as seen, not just the ones displayed on the page. The request to the backend is not made when the user has no unread notifications in any of their 10 most recent from each of their active courses. I chose the blue color for this button while keeping `Show All` white because users will be clicking it frequently.

Added an open mail icon next to each individual notification that is unseen. Clicking this icon marks that individual notification as seen, and does not redirect the user to its source. This icon is not visible on seen notifications.

<img width="1629" height="1444" alt="image" src="https://github.com/user-attachments/assets/c2f12ec1-b504-492c-bbbd-384674da1c37" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
[OPTIONAL] Run `recreate_sample_course` to have many notifications for `Submissions Open`.
Verify that Individual and Mark All buttons function correctly.

### Automated Testing & Documentation
This feature is not yet sufficiently tested with E2E tests. I will make a follow-up PR for this.

### Other information
This is not a breaking change. I am considering indexing the `seen` column of the notifications table to make `Mark all as viewed` more efficient, since currently it is scanning Courses x Notifications.
