### PR TITLE
[Bugfix:InstructorUI] Bulk upload toast fix

### DIFF
--- a/site/app/templates/submission/homework/BulkUploadBox.twig
+++ b/site/app/templates/submission/homework/BulkUploadBox.twig
@@ -118,7 +118,6 @@
     var is_team_assignment = "{{ team_assignment }}" === "1";
     //autofill data
     $(function(){
-        $("#messages").empty();
         if(sessionStorage.getItem("expected_count")){
             document.getElementById("expected-pages-input").value = sessionStorage.getItem("expected_count");
         }
@@ -127,10 +126,6 @@
             source: students_full
         });
         highlightPageCount();
-    });
-
-    window.addEventListener('onbeforeunload', function(e) {
-        $("#messages").empty();
     });
 
     //gets the raw value entered in the expected page box


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
#11857, we replace all the toasts with vue. however, there was still some places where jquery calls `#messages` which could desync the vue files content. This causes a very weird error, 
```
    TypeError: Cannot read properties of null (reading 'insertBefore')
    at insert (vue.runtime.global.prod.js?v=1755186796:6:53704)
    at O (vue.runtime.global.prod.js?v=1755186796:6:10185)
    at R (vue.runtime.global.prod.js?v=1755186796:6:9733)
    at C (vue.runtime.global.prod.js?v=1755186796:6:9199)
    at Y (vue.runtime.global.prod.js?v=1755186796:6:18714)
    at G (vue.runtime.global.prod.js?v=1755186796:6:17988)
    at U (vue.runtime.global.prod.js?v=1755186796:6:12056)
    at C (vue.runtime.global.prod.js?v=1755186796:6:9160)
    at F (vue.runtime.global.prod.js?v=1755186796:6:11493)
    at D (vue.runtime.global.prod.js?v=1755186796:6:10902)
```
which does not really make sense. This is because of the desync between js and vue.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
This removes allof the references to `#messages`, which causes the bulk upload page to have the notifications.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Make an error on the page, like entering a page count that is too large, and click bulk upload. Nothing should show up, but there should be notifications after viewing this PR

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
