### PR TITLE
[Bugfix:System] update footer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ System instructions located at [https://submitty.org/](https://submitty.org/)
 # Background
 
 [Submitty](https://submitty.org) is an open source course management, assignment submission, exam and grading system
-from the [Rensselaer Center for Open Source Software (RCOS)](https://rcos.io/),
-[Department of Computer Science](https://science.rpi.edu/computer-science) at
+from the [Rensselaer Center for Open Source Software (RCOS)](https://new.rcos.io/),
+[Department of Computer Science](https://compsci.rpi.edu/) at
 [Rensselaer Polytechnic Institute](https://www.rpi.edu/).
 
 The Submitty project is hosted on [GitHub](https://github.com/Submitty).

--- a/site/app/templates/GlobalFooter.twig
+++ b/site/app/templates/GlobalFooter.twig
@@ -7,8 +7,8 @@
                     &copy; {{ "now"|date("Y") }}
                     <a href="https://submitty.org" target="_blank" class="black-btn">Submitty</a>
                     <a href="https://github.com/Submitty/Submitty/releases/tag/{{ latest_tag }}" target="_blank" title = "{{ latest_tag }} {{ latest_commit }}" class="black-btn">{{ latest_tag }}</a>
-                    <span class="footer-separator">|</span> <a href="https://github.com/Submitty/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
-                    <span class="footer-separator">|</span> <a href="https://rcos.io" target="_blank" class="black-btn">An RCOS project</a>
+                    <span class="footer-separator">|</span> <a href="https://github.com/Submitty" target="_blank" title="Visit our GitHub" aria-label="Visit our GitHub" class="black-btn"><i class="fab fa-github fa-lg"></i></a>
+                    <span class="footer-separator">|</span> <a href="https://new.rcos.io" target="_blank" class="black-btn">An RCOS project</a>
 
                     {% for link in footer_links %}
                         <span class="footer-separator">|</span>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

The default/global footer links are stale/broken.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

Fixed the broken RCOS link & updated the Submitty Github link.