### PR TITLE
[Bugfix:Autograding] Render Jupyter Notebook TypeError

### DIFF
--- a/site/app/libraries/NotebookUtils.php
+++ b/site/app/libraries/NotebookUtils.php
@@ -50,7 +50,7 @@ class NotebookUtils {
         // Process each cell in the notebook
         foreach ($filedata['cells'] as $cell) {
             // Skip empty cells
-            if (!isset($cell['source']) || count($cell['source']) === 0) {
+            if (!isset($cell['source']) || (is_array($cell['source']) && count($cell['source']) === 0) || (is_string($cell['source']) && trim($cell['source']) === '')) {
                 continue;
             }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
This change is necessary because it fixes a TypeError that occurs when trying to render a Jupyter Notebook with a cell source that is only a string and not a list.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Rendering the notebook should now successfully account for a string source, as it did prior to #11891. 

Before
<img width="1627" height="607" alt="image" src="https://github.com/user-attachments/assets/76da0a8d-ab09-45b7-b2e0-55f63bdd7306" />

After
Notebook successfully renders.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Reviewer can modify an existing notebook example metadata such that a cell's source attribute is a string.
2. Create any gradeable.
3. Submit the modified notebook example.
4. View rendered example via popup.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
No tests needed for UI.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
