### PR TITLE
[Bugfix:IntructorUI] Fix Config Editor Text Color

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -566,6 +566,7 @@ pre.CodeMirror-line {
     /* stylelint-disable-next-line declaration-no-important */
     border-radius: 4px !important;
     /* stylelint-disable-next-line declaration-no-important */
+    color: var(--text-black) !important;
     vertical-align: middle !important;
     min-height: 500px;
     overflow: hidden;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Firefox users on MacOS were reporting text color in the gradeable config editor having no contrast against the background in light mode. I was unable to replicate the bug on Windows Firefox, but I believe this could be due to the color not being explicitly set in the text area's CSS.

### What is the New Behavior?
Text color is now explicitly set for the gradeable config editor.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Verify that the gradeable text area has readable text colors on different browsers and themes.

### Other information
Since I can't test it, I used an instance of `!important` to make sure the issue is resolved, but this may not be necessary.