### PR TITLE
[Bugfix:InstructorUI] Notebook Permissions fix

### DIFF
--- a/site/app/libraries/FileUtils.php
+++ b/site/app/libraries/FileUtils.php
@@ -696,12 +696,13 @@ class FileUtils {
      * - File or directory at $path is writable
      *
      * @param string $path Absolute path to file or directory
+     * @param string|null $current_user Current user, used to do a more thorough group check
      * @param string|null $expected_owner Expected owner name of the file, or null to omit this check
      * @param string|null $expected_group Expected group name owner of the file, or null to omit this check
      * @return array Empty array if no errors were detected or an array containing one or more error message strings if
      *               errors were detected.
      */
-    public static function checkForPermissionErrors(string $path, ?string $expected_owner, ?string $expected_group): array {
+    public static function checkForPermissionErrors(string $path, ?string $current_user, ?string $expected_owner, ?string $expected_group): array {
         $results = [];
 
         // Check exists
@@ -721,9 +722,13 @@ class FileUtils {
         }
 
         // Check group
-        if ($expected_group) {
+        if ($expected_group && $current_user) {
             $group_id = filegroup($path);
-            $group_name = posix_getgrgid($group_id)['name'];
+            $group = posix_getgrgid($group_id);
+            $group_name = $group['name'];
+            if (!in_array($current_user, $group['members'])) {
+                $results[] = "Current user '{$current_user}' is not in the group '{$group_name}' that owns '{$path}'.";
+            }
             if ($group_name !== $expected_group) {
                 $results[] = "Expected '{$path}' to have group '{$expected_group}' but instead got '{$group_name}'.";
             }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
On our production system, the TA's group is course_<courseName>_tas_www, but the notebook builder expects <courseName>_tas_www. In addition to not being able to make new notebook gradeables on the course, the permissions if we were to make the gradeables would be wrong as well, as the group would not exist. 

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Uses a more dynamic method of determining the group. I cannot find a better solution than looking at the config file.

### What steps should a reviewer take to reproduce or test the bug or new feature?
https://submitty.org/sysadmin/configuration/course_creation
Make the group course_<courseName>_tas_www. Make the course just <courseName>. See the error. See that it fixed with this PR

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
We do not have testing that test command line method of creating courses and users.

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
