### PR TITLE
[Bugfix:InstructorUI] Fix Simple Gradeable Key

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -28,7 +28,8 @@
             {% if action == 'lab' %}
                 <ul id="details-legend" class="table-bordered">
                     <li>
-                        No Color - No Credit
+                        <p class="simple-no-credit">No Color</p>
+                        No Credit
                     </li>
                     <li>
                         <i class="fas fa-square simple-full-credit simple-icon"></i>

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -67,14 +67,10 @@
 
 #details-legend {
     width: 100%;
-    padding: 6px 6px 6px 0;
+    padding: 6px;
     justify-self: flex-end;
     border: 1px solid var(--standard-medium-gray);
     border-radius: 4px;
-}
-
-#details-legend li i {
-    margin-right: 6px;
 }
 
 .row-wrapper {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1618,9 +1618,12 @@ end of styles used in the admin gradeable page
     max-height: 300px;
 }
 
+#details-legend {
+    padding: 0.75rem;
+}
+
 #details-legend > li {
     list-style: none;
-    padding-left: 15px;
     font-size: 0.75em;
 }
 

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -89,10 +89,6 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow-x: auto;
 }
 
-.simple-no-credit {
-    display: inline;
-}
-
 .simple-full-credit {
     color: var(--simple-full-credit-dark-blue);
 }
@@ -109,8 +105,10 @@ input[type="number"]::-webkit-outer-spin-button {
 .simple-full-credit,
 .simple-half-credit,
 .simple-save-error {
-    min-width: 1.5rem;
-    margin-right: 1.5rem;
+    min-width: 3.5rem;
+    margin-right: 1.25rem;
+    display: inline-block;
+    text-align: center;
 }
 
 /* styling for fields that aren't icons */
@@ -129,7 +127,6 @@ input[type="number"]::-webkit-outer-spin-button {
 .simple-icon {
     transform: scaleX(3);
     width: 20px;
-    margin-left: 20px;
 }
 
 #details-legend li {

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -89,16 +89,28 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow-x: auto;
 }
 
+.simple-no-credit {
+    display: inline;
+}
+
 .simple-full-credit {
-    background-color: var(--simple-full-credit-dark-blue);
+    color: var(--simple-full-credit-dark-blue);
 }
 
 .simple-half-credit {
-    background-color: var(--simple-half-credit-light-blue);
+    color: var(--simple-half-credit-light-blue);
 }
 
 .simple-save-error {
     color: var(--simple-save-error-red);
+}
+
+.simple-no-credit,
+.simple-full-credit,
+.simple-half-credit,
+.simple-save-error {
+    min-width: 1.5rem;
+    margin-right: 1.5rem;
 }
 
 /* styling for fields that aren't icons */
@@ -121,6 +133,5 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 #details-legend li {
-    margin-right: 6px;
     font-size: 0.9em;
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently, the details table for simple gradeables is messy, with labels and keys overlaying on top of each other.
<img width="1109" height="213" alt="simple-margin-old" src="https://github.com/user-attachments/assets/c3ea0177-fe82-47fe-8703-060a53caebe8" />

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Labels and keys are now neatly spaced:
<img width="1278" height="274" alt="simple-margin-new" src="https://github.com/user-attachments/assets/8393a1f5-a3a0-44ac-8c03-5ac3449593fd" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
Go to the sample course --> gradeables --> scroll all the way down to `Grading Grades Released Lab` --> ensure the details table is now evenly spaced

This PR may affect other tables. However, I couldn't find any issues with the ones I found on other pages.

### Other information
This is not a breaking change.
