### PR TITLE
[Bugfix:InstructorUI] Fix Rubric Rendering on Firefox

### DIFF
--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -12,11 +12,17 @@ const DECIMAL_PRECISION = 3;
 // eslint-disable-next-line no-var
 var itempool_items = {};
 
+let loadedTemplates = false;
+
 /**
  * Asynchronously load all of the templates
  * @return {Promise}
  */
 function loadTemplates() {
+    if (loadedTemplates) {
+        return Promise.resolve();
+    }
+    loadedTemplates = true;
     const templates = [
         { id: 'GradingGradeable', href: '/templates/grading/GradingGradeable.twig' },
         { id: 'PeerGradeable', href: '/templates/grading/PeerGradeable.twig' },


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
When using the edit page on firefox, the rubric sometimes fails to render. This might be because `loadTemplates()` is both called for the rubric and for rendering the redactions page. Fixing the double rendering fixes the issue.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
There are two solutions, one is to prevent it from double rendering, which can be inconsistent as firefox event loop issues keep popping up. The other solution, which is the new behavior, forces the rendering to only be once, making it more reliable in the future.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Load firefox before PR. Refresh constantly and watch rubric constantly break. Load firefox after PR, should not be breaking rubric.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

Editing to add image of reported issue

Left is Firefox, right is Chrome.
<img width="1393" height="585" alt="Screenshot 2025-09-04 at 1 33 26 PM" src="https://github.com/user-attachments/assets/157549f1-d029-4f3c-8ada-6aa785eec13f" />
