### PR TITLE
[Bugfix:Developer] Fix Failing Live Chat Test

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/live_chat.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/live_chat.spec.js
@@ -532,7 +532,7 @@ describe('Tests for creating, editing and using tests', () => {
                             Authorization: key,
                         },
                     }).then(() => {
-                        cy.get('[data-testid="message-container"]').should('not.exist');
+                        cy.get('[data-testid="message-container"]', { timeout: 10000 }).should('not.exist');
                     });
                 });
             });


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The live chat clearing test module of `live_chat.spec.js` is failing on CI. This failure was introduced in commit b66259f of #12008 when I merged main into it. There were other live lecture chat features (namely #11863) introduced in this merge, however, I could not locate a failing test for the clear socket on any of them.

### What is the New Behavior?
N / A. I assume the change has to come from `ChatroomController.php`. It is not the Cypress test that is broken, but rather the websocket for live chat clearing.

### How to Test
Delete all of the tests in `live_chat_spec.js` except for the bottom so you don't have to wait 5 minutes for it to pass.

### Other information
This is not a breaking change. This PR is currently marked as a draft since I have been unable to come up with a fix. The current diff was from when I thought the issue