### PR TITLE
[Bugfix:CourseMaterials] Improve Course Materials Editor

### DIFF
--- a/site/app/templates/course/CourseMaterials.twig
+++ b/site/app/templates/course/CourseMaterials.twig
@@ -99,7 +99,7 @@
                         data-release-time="{{ course_material.getReleaseDate|date(date_format) }}"
                         data-is-link="{{ course_material.isLink }}" data-title="{{ title_name }}"
                         data-link-url="{{ url_url }}"
-                        data-path = "{{ path }}"
+                        data-path = "{{ course_material.getPath() }}"
                     >
                         <i class="fas fa-pencil-alt black-btn" aria-hidden="true" style="font-size: 16px; margin: 5px;"></i>
                     </a>

--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -5,22 +5,24 @@
     {{ add_twig_module_js('courseMaterials/upload.js') }}
     <div id="material-edit-form" class="flex-col flex-col-space" data-directory = "Check">
         <label id="file-path-label">
-            <span><strong>File Path / URL </strong></span>
+            <span><strong>Directory</strong></span>
             <span id="edit-location-drop-down">
                 <select id="new-file-name">
-                    <option value="">.</option>
+                    <option value=""> (Top Directory) </option>
                     {% for folder_path in folder_paths %}
-                        <option value="{{ folder_path }}/">{{ folder_path }}</option>
+                        <option value="{{ folder_path }}">{{ folder_path }}</option>
                     {% endfor %}
                 </select>
             </span>
         </label>
-
         <label id="edit-title-label">
             <span><strong>File Name </strong></span>
-            <input type="text" id="edit-title" class="full-width" onchange="editFilePathRecommendations()" />
+            <input type="text" id="edit-title" class="full-width" />
         </label>
-
+        <label hidden id="edit-url-url-label">
+            <span><strong>Link URL</strong></span>
+            <input id="edit-url-url" type="text" class="full-width" disabled>
+        </label>
         <fieldset id="edit_sections">
             <legend class="black-message">
                 Do you want to restrict this course material to some sections?
@@ -71,12 +73,6 @@
             <em><strong>Note:</strong> Hidden course materials are omitted from the course materials directory listing; however, these materials can still be accessed via the URL. </em> <br>
             <em>These materials will always be available to course staff (full and limited access graders), regardless of release date. </em>
         </p>
-        <label hidden id="edit-url-url-label">
-            <span>
-                <strong>Edit link url:</strong>
-            </span>
-            <input id="edit-url-url" type="text" size="26" disabled>
-        </label>
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
     </div>
     <script>

--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -1375,23 +1375,22 @@ function handleEditCourseMaterials(csrf_token, hide_from_students, id, sectionsE
         formData.append('link_url', link_url);
     }
 
-    if (file_path !== null && file_path !== '') {
+    if (file_path !== null) {
         if (file_path.startsWith('/')) {
             alert('The file path cannot start with the root directory “/”, use a relative path.');
             return;
         }
-        const file_name = file_path.split('/').pop();
-        if (link_url !== null) {
-            const lastSlashIndex = file_path.lastIndexOf('/');
-            const new_file_name = encodeURIComponent(`link-${file_path.substring(lastSlashIndex + 1)}`);
-            file_path = `${file_path.substring(0, lastSlashIndex + 1)}${new_file_name}`;
-        }
-        if (!window.isValidFilePath(file_path)) {
+        // For editing, file_path is the directory path, not the full file path
+        // Validate that it doesn't contain invalid characters for directories
+        if (file_path.includes('..')) {
+            alert('Directory path cannot contain ".."');
             return;
         }
-        if (window.isValidFileName(file_name)) {
-            formData.append('file_path', file_path);
+        // Add placeholder to give form of a file path for validation (only for non-empty paths)
+        if (file_path !== '' && !window.isValidFilePath(file_path + '/placeholder')) {
+            return;
         }
+        formData.append('file_path', file_path);
     }
 
     if (title !== null && window.isValidFileName(title)) {
@@ -1403,6 +1402,7 @@ function handleEditCourseMaterials(csrf_token, hide_from_students, id, sectionsE
     }
     else {
         if (title !== null) {
+            alert('Invalid filename');
             return;
         }
     }

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -445,15 +445,40 @@ function newEditCourseMaterialsForm(tag) {
         }
     }
 
-    editFilePathRecommendations();
-    if (is_link === 1) {
-        path.val(decodeURIComponent(file_path.substring(file_path.indexOf('course_materials/') + 17).replace('link-', '')));
-    }
-    else {
-        path.val(file_path.substring(1));
-    }
     registerSelect2Widget('new-file-name', 'material-edit-form');
 
+    // Set the directory value after select2 is initialized
+    const pathElement = $('#new-file-name');
+    let valueToSet;
+    // Extract directory path from full path for both files and links
+    let lastSlashIndex = file_path.lastIndexOf('/');
+    
+    if (lastSlashIndex === -1) {
+        // Material is in root directory
+        valueToSet = '';
+    } else {
+        // Extract directory path relative to course_materials
+        let fullDirPath = file_path.substring(0, lastSlashIndex);
+        let courseMaterialsIndex = fullDirPath.indexOf('course_materials/');
+        
+        if (courseMaterialsIndex !== -1) {
+            valueToSet = fullDirPath.substring(courseMaterialsIndex + 17);
+        } else {
+            valueToSet = '';
+        }
+    }
+    // Wait for select2 to be fully initialized by checking for the select2 container
+    const waitForSelect2 = () => {
+        if (pathElement.next('.select2-container').length > 0) {
+            // Select2 is initialized, set the value
+            pathElement.val(valueToSet).trigger('change');
+        } else {
+            // Not ready yet, try again
+            setTimeout(waitForSelect2, 50);
+        }
+    };
+
+    setTimeout(waitForSelect2, 100);    
     $('#material-edit-form', form).attr('data-id', id);
     $('#edit-picker', form).attr('value', release_time);
     $('#edit-sort', form).attr('value', dir);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Fixes #11589. In addition to the fix, there are design changes to the course materials editor to improve usability.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Initially, a course materials with content `test/temp.txt` would appear on the page as follows:
<img width="925" height="121" alt="image" src="https://github.com/user-attachments/assets/adf152c5-c26d-4419-bb41-ebaa5985f327" />
Subsequently, an instructor opening the editor would be presented with this view in which the "File Path / URL" field would display the entirety of the local path. While potentially useful, it largely contributes to the bug noted in the attached issue.
<img width="926" height="306" alt="image" src="https://github.com/user-attachments/assets/0267eddd-d122-4f13-ac47-0978255e9adc" />



Now, the "File Path / URL" field has been renamed to "Directory" and only displays the directory-subdirectory(ies) path:
<img width="647" height="558" alt="image" src="https://github.com/user-attachments/assets/5d4b4526-bc40-46d9-b6c6-7cbdb735e3d7" />
Further, including file extensions (via use of the `.` character), has been prohibited so that this functionality is exceptionally clear.
<img width="607" height="300" alt="image" src="https://github.com/user-attachments/assets/32ca2f4c-2d5a-4e22-929b-d21d8369e575" />

These features apply to course materials which are hyperlinks as well. The editor for the case where the material is a link has been changed so that the URL itself is higher up in the editor UI:
<img width="587" height="495" alt="image" src="https://github.com/user-attachments/assets/a4634a80-857c-428e-bfa2-8a8af4ad0ab7" />



In totality, the course materials editor is more streamlined for instructors.


### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
