### PR TITLE
[Bugfix:InstructorUI] Simple Gradeable Checkpoint Fix

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -28,26 +28,26 @@
             {% if action == 'lab' %}
                 <ul id="details-legend" class="table-bordered">
                     <li>
-                        <p class="simple-no-credit">No Color</p>
+                        <p class="simple-key-no-credit">No Color</p>
                         No Credit
                     </li>
                     <li>
-                        <i class="fas fa-square simple-full-credit simple-icon"></i>
+                        <i class="fas fa-square simple-key-full-credit simple-icon"></i>
                         Full Credit
                     </li>
                     <li>
-                        <i class="fas fa-square simple-half-credit simple-icon"></i>
+                        <i class="fas fa-square simple-key-half-credit simple-icon"></i>
                         Half Credit
                     </li>
                     <li>
-                        <i class="fas fa-square simple-save-error simple-icon"></i>
+                        <i class="fas fa-square simple-key-save-error simple-icon"></i>
                         [SAVE ERROR] Refresh Page
                     </li>
                 </ul>
             {% else %}
                 <ul id="details-legend" class="table-bordered">
                     <li>
-                        <i class="fas fa-square simple-save-error simple-icon"></i>
+                        <i class="fas fa-square simple-key-save-error simple-icon"></i>
                         [SAVE ERROR] Refresh Page
                     </li>
                 </ul>

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -89,22 +89,25 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow-x: auto;
 }
 
+.simple-key-full-credit,
 .simple-full-credit {
     color: var(--simple-full-credit-dark-blue);
 }
 
+.simple-key-half-credit,
 .simple-half-credit {
     color: var(--simple-half-credit-light-blue);
 }
 
+.simple-key-save-error,
 .simple-save-error {
     color: var(--simple-save-error-red);
 }
 
-.simple-no-credit,
-.simple-full-credit,
-.simple-half-credit,
-.simple-save-error {
+.simple-key-no-credit,
+.simple-key-full-credit,
+.simple-key-half-credit,
+.simple-key-save-error {
     min-width: 3.5rem;
     margin-right: 1.25rem;
     display: inline-block;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
#12062 fixed the key, but broke simple gradeable checkpoints since they shared the same CSS classes.

<img width="3150" height="1381" alt="simple-gradeable-broken" src="https://github.com/user-attachments/assets/5383a2ce-af31-4736-8f6c-5ef35e8e08aa" />

### What is the New Behavior?
Separated the CSS classes of the key and the checkpoint buttons.

<img width="3134" height="1379" alt="simple-gradeable-fixed" src="https://github.com/user-attachments/assets/1a9f53d9-81f8-458b-b291-af28add17282" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
Go to sample --> Grades Released Lab --> Make sure the page looks normal

### Other information
This is not a breaking change.
