### PR TITLE
[Bugfix:Autograding] system calls on pdf_notes_page gradeables

### DIFF
--- a/more_autograding_examples/test_notes_upload/config/config.json
+++ b/more_autograding_examples/test_notes_upload/config/config.json
@@ -14,10 +14,7 @@
 
     // needed for /usr/bin/mv
     "allow_system_calls" : [
-        "COMMUNICATIONS_AND_NETWORKING_SIGNALS",
-        "FILE_MANAGEMENT_MOVE_DELETE_RENAME_FILE_DIRECTORY",
-        "PROCESS_CONTROL_ADVANCED",
-        "PROCESS_CONTROL_NEW_PROCESS_THREAD"
+        "ALLOW_ALL_RESTRICTED_SYSTEM_CALLS"
     ],
 
     "autograding" : {

--- a/more_autograding_examples/test_notes_upload_3page/config/config.json
+++ b/more_autograding_examples/test_notes_upload_3page/config/config.json
@@ -14,10 +14,7 @@
 
     // needed for /usr/bin/mv
     "allow_system_calls" : [
-        "COMMUNICATIONS_AND_NETWORKING_SIGNALS",
-        "FILE_MANAGEMENT_MOVE_DELETE_RENAME_FILE_DIRECTORY",
-        "PROCESS_CONTROL_ADVANCED",
-        "PROCESS_CONTROL_NEW_PROCESS_THREAD"
+        "ALLOW_ALL_RESTRICTED_SYSTEM_CALLS"
     ],
 
     "autograding_method": "docker",


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The list of allowed systems calls for pdflatex on the notes page gradeables needs to be updated.

### What is the New Behavior?
Before the change, the pdf in testcase #2 containing the instructor 'exam' with the student notes attached was not viewable.
The pdf was not produced/was corrupted because a system call was failing during one of the pdf processing steps.
After the change, the pdf is viewable.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
We should continue to add more automated testing of these gradeables.  

### Other information
