### PR TITLE
[Bugfix:Developer] Fix Sidebar Cypress Test

### DIFF
--- a/site/cypress/e2e/Cypress-UI/sidebar.spec.js
+++ b/site/cypress/e2e/Cypress-UI/sidebar.spec.js
@@ -133,7 +133,7 @@ describe('Test sidebars', () => {
         // assert that we dont begin with any custom sidebar elements
         sidebarElements.forEach((element) => {
             cy.get(`[data-testid="${element}-delete-button"]`).should('not.exist');
-            cy.get(`[data-testid="${element}-upload-input"]`).attachFile(`copy_of_sample_files/site_theme/${element}`);
+            cy.get(`[data-testid="${element}-upload-input"]`).selectFile(`cypress/fixtures/copy_of_sample_files/site_theme/${element}`);
             cy.get(`[data-testid="${element}-upload-button"]`).click();
         });
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Currently, the sidebar cypress test fails on main due to a cypress version mismatch with an external plugin.
Before, in this situation we were using 'attachFile' which is from an external plugin.

### What is the New Behavior?
Now, we are using the built-in function 'selectFile' which uses a different location, but it's easily changed. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
Mainly, just review the code, and check that the tests are now passing in CI. 

### Other information
This will fix one of the many failing tests in Main. 

