### PR TITLE
Update EditCourseMaterialsForm.twig and server.js to replace dropdown…

### DIFF
--- a/site/app/templates/course/EditCourseMaterialsForm.twig
+++ b/site/app/templates/course/EditCourseMaterialsForm.twig
@@ -5,20 +5,14 @@
     {{ add_twig_module_js('courseMaterials/upload.js') }}
     <div id="material-edit-form" class="flex-col flex-col-space" data-directory = "Check">
         <label id="file-path-label">
-            <span><strong>File Path / URL </strong></span>
-            <span id="edit-location-drop-down">
-                <select id="new-file-name">
-                    <option value="">.</option>
-                    {% for folder_path in folder_paths %}
-                        <option value="{{ folder_path }}/">{{ folder_path }}</option>
-                    {% endfor %}
-                </select>
-            </span>
+            <span><strong>Folder Path</strong></span>
+            <input type="text" id="edit-folder-path" class="full-width" placeholder="Enter folder path" />
         </label>
+        <input type="hidden" id="file_path" name="file_path" />
 
-        <label id="edit-title-label">
+        <label id="edit-filename-label">
             <span><strong>File Name </strong></span>
-            <input type="text" id="edit-title" class="full-width" onchange="editFilePathRecommendations()" />
+            <input type="text" id="edit-filename" class="full-width" placeholder="Enter file name" />
         </label>
 
         <fieldset id="edit_sections">
@@ -103,10 +97,10 @@
                 if({{ reg_sections|json_encode|raw }} == null || $("#all-sections-showing-no").is(':checked') == true){
                     sectionsEdit = null;
                 }
-                let title = document.getElementById("edit-title").value;
+                let title = document.getElementById("edit-filename").value;
                 let url_url = document.getElementById("edit-url-url");
                 let url_url_val = url_url.disabled ? null : url_url.value;
-                let file_path = document.getElementById("new-file-name").value;
+                let file_path = document.getElementById("file_path").value;
                 let overwrite = false;
                 let overwrite_elem = $('#overwrite-submit');
                 if (overwrite_elem.length && (overwrite_elem.attr('is-edit-form') === "1")) {
@@ -168,6 +162,16 @@
     $('.form-body').on('scroll', function() {
         edit_fp._positionCalendar();
     });
+
+    function updateFullPath() {
+    const folder = document.getElementById("edit-folder-path").value.trim();
+    const filename = document.getElementById("edit-filename").value.trim();
+    document.getElementById("file_path").value = folder ? folder + "/" + filename : filename;
+    }
+
+    document.getElementById("edit-folder-path").addEventListener("input", updateFullPath);
+    document.getElementById("edit-filename").addEventListener("input", updateFullPath);
+
     </script>
 {% endblock %}
 {% block close_click_action %}closePopup('{{ block('popup_id') }}'); window.location.reload();{% endblock %}

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -439,20 +439,27 @@ function newEditCourseMaterialsForm(tag) {
         url.val(link_url);
     }
     else {
-        titleVal.val(file_path.substring(file_path.lastIndexOf('/') + 1));
+    const folder = file_path.substring(0, file_path.lastIndexOf('/'));
+    const filename = file_path.substring(file_path.lastIndexOf('/') + 1);
+
+    $('#edit-folder-path').val(folder);
+    $('#edit-filename').val(filename);
+
+    $('#file_path').val(folder ? folder + "/" + filename : filename);
+
         if (url_label.css('display') !== 'none') {
             url_label.css('display', 'none');
         }
     }
 
-    editFilePathRecommendations();
-    if (is_link === 1) {
-        path.val(decodeURIComponent(file_path.substring(file_path.indexOf('course_materials/') + 17).replace('link-', '')));
-    }
-    else {
-        path.val(file_path.substring(1));
-    }
-    registerSelect2Widget('new-file-name', 'material-edit-form');
+    //editFilePathRecommendations();
+    // if (is_link === 1) {
+    //     path.val(decodeURIComponent(file_path.substring(file_path.indexOf('course_materials/') + 17).replace('link-', '')));
+    // }
+    // else {
+    //     path.val(file_path.substring(1));
+    // }
+    // registerSelect2Widget('new-file-name', 'material-edit-form');
 
     $('#material-edit-form', form).attr('data-id', id);
     $('#edit-picker', form).attr('value', release_time);


### PR DESCRIPTION
… with text inputs and update edit popup logic

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Answer: This change is important because it increases the user functionality and makes the file naming more consistent. 

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

Answer: The folder name and file name are now two separate fields that the user can enter test into. The two fields concatenate behind the scenes in order to create a consistent file path with updated naming conventions. 

### What steps should a reviewer take to reproduce or test the bug or new feature?

Answer: Clone the repository and use remote ssh through an IDE to get the program running. Additionally, navigate to the "course documents" section and click on the pencil next to the file name to test the functionality. 

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

Answer: Yes, I have tested it and it works as stated in the issue. 

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

Answer: No, there are no security concerns, this is just a simple visual fix!