### PR TITLE
[Feature:Livechat] Improve livechat anonymous naming

### DIFF
--- a/site/app/templates/chat/ChatroomRow.twig
+++ b/site/app/templates/chat/ChatroomRow.twig
@@ -45,9 +45,6 @@
             <button data-testid="clear-chatroom" class="btn btn-danger" onclick="clearChatroom('{{ id|e('js') }}', '{{ title|e('js') }}')">
                 Clear
             </button>
-            <button data-testid="shuffle-anonname" class="btn btn-primary" onclick="shuffleAnonName('{{ id|e('js') }}')">
-                Shuffle Names
-            </button>
         </td>
     </tr>
 {% else %}

--- a/site/public/js/chatroom.js
+++ b/site/public/js/chatroom.js
@@ -300,21 +300,6 @@ function clearChatroom(chatroomId, chatroomTitle) {
     }
 }
 
-function shuffleAnonName(roomId) {
-    fetch(`/chat/${roomId}/regenerateAnonName`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({})
-    })
-    .then(res => res.json())
-    .then(data => {
-        document.querySelector('#anon-name-display').textContent = data.newName;
-    })
-    .catch(err => console.error('Error shuffling name:', err));
-}
-
 document.addEventListener('DOMContentLoaded', () => {
     const pageDataElement = document.getElementById('page-data');
     if (pageDataElement) {


### PR DESCRIPTION
Note: As of 12/15/25, this PR will be closed. For this PR to be merged, the changes would need to implement an actual random naming structure. A recommendation for this would be to use a similar method to "blind" grading, which uses replaces student names with randomly generated strings.

### Why is this Change Important & Necessary?
Partially addresses #11999

Currently, anonymous names are generated with user id, chatroom id, and chatroom session start time. There was a concern that the names generated could end up with duplicates within the same room, and that the names are not complex enough / too easy to reverse-engineer.

### What is the New Behavior?
Now, the anonymous name is more complex and difficult to guess. A trailing number sequence ensures no duplicates anonymous names exist within a chatroom. With the addition of a numerical string of 0-9999, the number of possible names has increased considerably. 

The anonymous name will remain unique to each live chat room, and will not be changed or removed upon refresh or logout.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Log in to the test site > Sample > Course Settings > Enable Live Chat ( if needed) > Live Chat

Actions to test:
1. Create / join multiple live chat rooms as anonymous, check if your anonymous name is different between them
2. Leave / rejoin these rooms to check if your anonymous name remains the same, but unique to each room
3. Refresh the browser / re enter chat room to see if your anonymous name has changed
4. Logout/ clear cookies, log back in and enter the rooms as anonymous. Your anonymous name should remain the same

### Automated Testing & Documentation

### Other information
This is not a breaking change.
