### PR TITLE
[Bugfix:TAGrading] Show autograding stats before TAGrading

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -76,13 +76,9 @@ class ElectronicGraderController extends AbstractController {
 
         // Iterate through all the Scores
         foreach ($overall_scores as $ov) {
-            if ($ov->getTaGradedGradeable() == null) {
-                continue;
-            }
-
             // If Autograded, add the points to the array of autograded scores
-            if ($ov->getAutoGradedGradeable()->getHighestVersion() != 0 && $ov->getTaGradedGradeable() != null) {
-                if ($ov->getTaGradedGradeable()->getGradedGradeable()->getSubmitter()->getRegistrationSection() != null) {
+            if ($ov->getAutoGradedGradeable()->getHighestVersion() != 0) {
+                if ($ov->getAutoGradedGradeable()->getGradedGradeable()->getSubmitter()->getRegistrationSection() != null) {
                     if ($ov->getGradeable()->getAutogradingConfig()->getTotalNonExtraCredit() != 0) {
                         if ($ov->getAutoGradedGradeable()->getTotalPoints() >= 0 || $ov->getAutoGradedGradeable()->getTotalPoints() < 0) {
                             $histogram["bAuto"] = array_merge($histogram["bAuto"], [$ov->getAutoGradedGradeable()->getTotalPoints()]);

--- a/site/phpstan-baseline.neon
+++ b/site/phpstan-baseline.neon
@@ -2463,13 +2463,13 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 25
+			count: 24
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 18
+			count: 17
 			path: app/controllers/grading/ElectronicGraderController.php
 
 		-


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently if a gradeable has autograding but no tagrading or autograding with unfinished tagrading, student that do not have tagrading data will not be included in autograding statistics.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Any student with autograding outside of the null section will be included in autograding statistics.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Submit to a gradeable with autograding on main (I used tutorial 01)
2. Notice that the autograding statistics do not change
3. View on branch

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
