### PR TITLE
[Bugfix:Submission] Fix download from submissions_processed

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -48,7 +48,7 @@
                                         <button class = 'btn btn-default' onclick='popOutSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Pop up the file in a new window"> View
                                             <i class="fas fa-window-restore" title="Pop up the file in a new window"></i></button>
                                     {% endif %}
-                                    <button class = 'btn btn-primary' onclick='downloadFile("{{ file.path|url_encode }}", "submissions")' aria-label="Download {{file.relative_name}}"> Download
+                                    <button class = 'btn btn-primary' onclick='downloadFile("{{ file.path|url_encode }}", "submissions_processed")' aria-label="Download {{file.relative_name}}"> Download
                                         <i class="fas fa-download" title="Download the file"></i></button>
                                 </div>
                             {% endif %}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently there is a frog robot error whenever a student a student downloads a file from submissions_processed as described in #12082

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Fixes #12082 and all other downloads from submissions_processed

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Have a file in submissions processed and attempt to download it as a student on main
2. See frog robot
3. Re-attempt on branch
4. See downloaded file

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
