### PR TITLE
[Bugfix:TAGrading] Fix component auto-open

### DIFF
--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -2889,40 +2889,38 @@ async function openComponentGrading(component_id: number) {
  * @return {void}
  */
 function scrollToPage(page_num: number) {
-    const files = $('.openable-element-submissions');
+    const files = $('.openable-element-submissions, .openable-element-submissions_processed');
     const activeView = $('#file-view').is(':visible');
     let lastLoadedFile = activeView ? $('#grading_file_name').text().trim() : localStorage.getItem('ta-grading-files-full-view-last-opened') ?? 'upload.pdf';
     if (lastLoadedFile.charAt(0) === '.') {
         lastLoadedFile = lastLoadedFile.substring(1);
     }
-    if (lastLoadedFile.startsWith('upload_page_')) {
-        const lastLoadedFilePageNum = parseInt(lastLoadedFile.split('_')[2].split('.')[0]);
-        if (activeView && page_num === lastLoadedFilePageNum) {
-            return;
-        }
-        let maxPage = -1;
-        let maxPageName = '';
-        let maxPageLoc = '';
-        for (let i = 0; i < files.length; i++) {
-            const filename = files[i].innerText.trim();
-            const filenameNoPeriod = filename.charAt(0) === '.' ? filename.substring(1) : filename;
-            if (filenameNoPeriod.startsWith('upload_page_')) {
-                const currPageNum = parseInt(filename.split('_')[2].split('.')[0]);
-                if (page_num === currPageNum) {
-                    void viewFileFullPanel(filename, files[i].getAttribute('file-url')!);
-                    return;
-                }
-                else if (currPageNum > maxPage) {
-                    maxPage = currPageNum;
-                    maxPageName = filename;
-                    maxPageLoc = files[i].getAttribute('file-url')!;
-                }
+    const lastLoadedFilePageNum = parseInt(lastLoadedFile.split('_')[2].split('.')[0]);
+    if (activeView && page_num === lastLoadedFilePageNum) {
+        return;
+    }
+    let maxPage = -1;
+    let maxPageName = '';
+    let maxPageLoc = '';
+    for (let i = 0; i < files.length; i++) {
+        const filename = files[i].innerText.trim();
+        const filenameNoPeriod = filename.charAt(0) === '.' ? filename.substring(1) : filename;
+        if (filenameNoPeriod.startsWith('upload_page_')) {
+            const currPageNum = parseInt(filename.split('_')[2].split('.')[0]);
+            if (page_num === currPageNum) {
+                void viewFileFullPanel(filename, files[i].getAttribute('file-url')!);
+                return;
+            }
+            else if (currPageNum > maxPage) {
+                maxPage = currPageNum;
+                maxPageName = filename;
+                maxPageLoc = files[i].getAttribute('file-url')!;
             }
         }
-        if (maxPage !== -1) {
-            void viewFileFullPanel(maxPageName, maxPageLoc);
-            return;
-        }
+    }
+    if (maxPage !== -1) {
+        void viewFileFullPanel(maxPageName, maxPageLoc);
+        return;
     }
     for (let i = 0; i < files.length; i++) {
         if (files[i].innerText.trim() === 'upload.pdf') {

--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -2895,32 +2895,34 @@ function scrollToPage(page_num: number) {
     if (lastLoadedFile.charAt(0) === '.') {
         lastLoadedFile = lastLoadedFile.substring(1);
     }
-    const lastLoadedFilePageNum = parseInt(lastLoadedFile.split('_')[2].split('.')[0]);
-    if (activeView && page_num === lastLoadedFilePageNum) {
-        return;
-    }
-    let maxPage = -1;
-    let maxPageName = '';
-    let maxPageLoc = '';
-    for (let i = 0; i < files.length; i++) {
-        const filename = files[i].innerText.trim();
-        const filenameNoPeriod = filename.charAt(0) === '.' ? filename.substring(1) : filename;
-        if (filenameNoPeriod.startsWith('upload_page_')) {
-            const currPageNum = parseInt(filename.split('_')[2].split('.')[0]);
-            if (page_num === currPageNum) {
-                void viewFileFullPanel(filename, files[i].getAttribute('file-url')!);
-                return;
-            }
-            else if (currPageNum > maxPage) {
-                maxPage = currPageNum;
-                maxPageName = filename;
-                maxPageLoc = files[i].getAttribute('file-url')!;
+    if (!lastLoadedFile.includes('pdf')) {
+        const lastLoadedFilePageNum = parseInt(lastLoadedFile.split('_')[2].split('.')[0]);
+        if (activeView && page_num === lastLoadedFilePageNum) {
+            return;
+        }
+        let maxPage = -1;
+        let maxPageName = '';
+        let maxPageLoc = '';
+        for (let i = 0; i < files.length; i++) {
+            const filename = files[i].innerText.trim();
+            const filenameNoPeriod = filename.charAt(0) === '.' ? filename.substring(1) : filename;
+            if (filenameNoPeriod.startsWith('upload_page_')) {
+                const currPageNum = parseInt(filename.split('_')[2].split('.')[0]);
+                if (page_num === currPageNum) {
+                    void viewFileFullPanel(filename, files[i].getAttribute('file-url')!);
+                    return;
+                }
+                else if (currPageNum > maxPage) {
+                    maxPage = currPageNum;
+                    maxPageName = filename;
+                    maxPageLoc = files[i].getAttribute('file-url')!;
+                }
             }
         }
-    }
-    if (maxPage !== -1) {
-        void viewFileFullPanel(maxPageName, maxPageLoc);
-        return;
+        if (maxPage !== -1) {
+            void viewFileFullPanel(maxPageName, maxPageLoc);
+            return;
+        }
     }
     for (let i = 0; i < files.length; i++) {
         if (files[i].innerText.trim() === 'upload.pdf') {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Before this nothing in submissions_processed would be considered for auto open and pdfs would be opened by default

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Files in submissions_processed are considered for auto open and pngs would be opened by default.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create a bulk upload for an exam
2. Create components assigned to specific pages
3. Open the components and see what gets opened on main vs this pr

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
