### PR TITLE
[Feature:TAGrading] Make active graders an outline

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -9,31 +9,31 @@
         <div class="markers-container">
             <ul id="details-legend">
                 <li>
-                    <i class="fas fa-circle grader-NULL"></i>
+                    <i class="grading-example-circle grader-NULL"></i>
                     Ungraded component
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-3"></i>
+                    <i class="grading-example-circle grader-3"></i>
                     Component graded by a limited access grader
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-4"></i>
+                    <i class="grading-example-circle grader-4"></i>
                     Peer component graded by a student
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-1"></i>
+                    <i class="grading-example-circle grader-1"></i>
                     Component graded by a full access grader
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-verified"></i>
+                    <i class="grading-example-circle grader-verified"></i>
                     Limited access grader verified
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-double"></i>
+                    <i class="grading-example-circle grader-double"></i>
                     Component double-graded by a full access grader or instructor
                 </li>
                 <li>
-                    <i class="fas fa-circle grader-active"></i>
+                    <i class="grading-example-circle grader-active grader-NULL"></i>
                     Component actively being graded
                 </li>
             </ul>
@@ -420,23 +420,24 @@
                     {% set user_id = graded_gradeable.getSubmitter().getId() %}
                     {% set user_graders = active_graders[user_id] is defined ? active_graders[user_id] : {} %}
                     {% set component_graders = user_graders[graded_gradeable.getGradeable().getComponents()[index].getId()] is defined ? user_graders[graded_gradeable.getGradeable().getComponents()[index].getId()] : {} %}
-
+                    {% set class_list = ['grading-circle'] %}
+                    {% set title = graded_gradeable.getGradeable().getComponents()[index].getTitle() %}
                     {% if component_graders is not empty %}
-                        <i title="Currently being graded by: {{ component_graders | map(grader => grader.grader_id) | join(', ') }}" class="fas fa-circle grader-active"></i>
-                    {%  elseif graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0%}
-                        <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-NULL"></i>
+                        {% set class_list = class_list | merge(['grader-active']) %}
+                        {% set title = title ~ " (Currently being graded by: " ~ (component_graders | map(grader => grader.grader_id) | join(', ')) ~ ")" %}
+                    {% endif %}
+                    {% if graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0%}
+                        {% set class_list = class_list | merge(['grader-NULL']) %}
                     {% else %}
                         {% if info.graded_groups[index] =="peer-null"   %}
                             {# Indicates Peer Component #}
-                            <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-NULL"></i>
-                        {% elseif info.graded_groups[index] == 4   %}
-                            {# Indicates Graded Peer Component #}
-                            <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-{{- info.graded_groups[index] -}}"></i>
+                            {% set class_list = class_list | merge(['grader-NULL']) %}
                         {% else %}
                             {# Indicates Non-Peer Component (Visible)#}
-                            <i title="{{graded_gradeable.getGradeable().getComponents()[index].getTitle()}}" class="fas fa-circle grader-{{- info.graded_groups[index] -}}"></i>
+                            {% set class_list = class_list | merge(['grader-' ~ info.graded_groups[index]]) %}
                         {% endif %}
                     {% endif %}
+                    <div title="{{ title }}" class="{{ class_list | join(' ') }}"></div>
             {% endif %}
             {# Peer View for Stoplights #}
             {% if core.getUser().getGroup() == 4 %}

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1419,28 +1419,34 @@ end of styles used in the admin gradeable page
 /* color for no grader */
 /* stylelint-disable-next-line selector-class-pattern */
 .grader-NULL {
-    color: var(--default-white);
-    text-shadow:
-        -1px -1px 0 var(--text-black),
-        1px -1px 0 var(--text-black),
-        -1px 1px 0 var(--text-black),
-        1px 1px 0 var(--text-black);
+    background-color: var(--default-white);
+    border: 1px solid var(--text-black);
 }
 
 .grader-active {
-    color: var(--standard-vibrant-red);
+    border: 1px solid var(--standard-vibrant-red);
+}
+
+.grading-circle {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.grading-example-circle {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%; /* Makes the element a circle */
+    display: inline-block;
 }
 
 /* styles for the colors for the electronic grader details page */
 
 /* color for no grader (PEER) */
 .grader-peer-null {
-    color: var(--default-white);
-    text-shadow:
-        -1px -1px 0 var(--text-black),
-        1px -1px 0 var(--text-black),
-        -1px 1px 0 var(--text-black),
-        1px 1px 0 var(--text-black);
+    background-color: var(--default-white);
+    border: 1px solid var(--text-black);
 }
 
 /* color for limited access graders who were verifed */
@@ -1451,28 +1457,22 @@ end of styles used in the admin gradeable page
         var(--standard-vibrant-yellow) 50%,
         var(--standard-vibrant-green) 50%
     );
-    background-clip: text;
-    color: transparent;
-    border-radius: 50%;
-
-    /* chrome & safari */
-    -webkit-text-fill-color: transparent;
 }
 
 /* color for student/peer grading */
 .grader-4 {
-    color: var(--standard-plum-purple); /* purple */
+    background-color: var(--standard-plum-purple); /* purple */
 }
 
 /* color for a limited access grader */
 .grader-3 {
-    color: var(--important-post); /* yellow */
+    background-color: var(--important-post); /* yellow */
 }
 
 /* color for an instructor or full access grader */
 .grader-2,
 .grader-1 {
-    color: var(--standard-vibrant-green); /* green */
+    background-color: var(--standard-vibrant-green); /* green */
 }
 
 .hide-highlights {
@@ -1481,7 +1481,7 @@ end of styles used in the admin gradeable page
 
 /* color for double graded */
 .grader-double {
-    color: var(--standard-vibrant-dark-blue); /* dark blue */
+    background-color: var(--standard-vibrant-dark-blue); /* dark blue */
 }
 
 .grader-grade-inquiry {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Active grader indicators were full red circles, which made it impossible to see the status of the component outside of whether or not it is being graded.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
The new behavior is that whether or not a component is being graded is represented by a red outline on the component circle.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Start actively grading a component
2. View the grading details view on both main and the PR

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
