### PR TITLE
[Bugfix:Forum] Fix server crash editing markdown

### DIFF
--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -370,7 +370,7 @@ function syncMarkdownToggle() {
         class="screen-reader"
       >{{ markdownAreaId }}</label>
       <textarea
-        v-if="mode === 'edit'"
+        v-show="mode === 'edit'"
         :id="markdownAreaId"
         ref="textareaRef"
         v-model="content"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Fixes #12130 

There has been a rare but recurring server crash on the forum when editing posts due to an expected input not existing. After investigation, this is related to markdown, specifically clicking "Update Post" while the markdown editor is in "preview" mode.

Repro Steps:

- Open the edit page for a post
- Enable markdown
- Switch editor to "preview" mode
- Click "Update Post" button and observe failure

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

This occurs because the relevant textarea is conditionally rendered using `v-if`, which removes it from the DOM when unrendered. By switching this to `v-show`, this input remains in the DOM and its contents can be accessed and sent with the edit submission.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
