### PR TITLE
[Bugfix:System] Fix first start of daemon jobs handler

### DIFF
--- a/sbin/submitty_daemon_jobs/submitty_jobs/handler.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/handler.py
@@ -160,20 +160,24 @@ def killStaleDaemonJobs():
     previous runs.
     """
     logMessage("Checking for stale submitty_daemon_jobs.py processes")
-    # all pids for python3 processes
-    python_pids = list(map(int, subprocess.check_output(["pidof", "-c", 'python3']).split()))
-    # all pids for processes with "submitty_daemon_jobs.py" argument
-    main_py_pids = list(map(int, subprocess.check_output(["pgrep", "-f",
+    try:
+        # all pids for python3 processes
+        python_pids = list(map(int, subprocess.check_output(["pidof", "-c", 'python3']).split()))
+        # all pids for processes with "submitty_daemon_jobs.py" argument
+        main_py_pids = list(map(int, subprocess.check_output(["pgrep", "-f",
                                                           "submitty_daemon_jobs.py"]).split()))
-    python_main_py_pid = set(python_pids).intersection(main_py_pids)
-    myself = os.getpid()
-    for i in python_main_py_pid:
-        if i == myself:
-            # don't kill myself
-            continue
-        p = psutil.Process(i)
-        p.terminate()
-        logMessage(f"Stale submitty_daemon_jobs.py process {i} was killed")
+        python_main_py_pid = set(python_pids).intersection(main_py_pids)
+        myself = os.getpid()
+        for i in python_main_py_pid:
+            if i == myself:
+                # don't kill myself
+                continue
+            p = psutil.Process(i)
+            p.terminate()
+            logMessage(f"Stale submitty_daemon_jobs.py process {i} was killed")
+    except subprocess.CalledProcessError:
+        # pidof or pgrep did not find any matching processes
+        pass
 
 
 def main():


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Currently many of our tests are flaky since starting the daemon jobs handler is failing. 

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
I could not reproduce this locally, but looking through the code I found a likely cause, if there is no python3 process running on the machine, or if there is not a process which includes `submitty_daemon_jobs.py` then starting the job handler will fail.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
