### PR TITLE
[Bugfix:RainbowGrades] Fix Rainbow Grades Configuration Title

### DIFF
--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -683,7 +683,7 @@ class ReportController extends AbstractController {
             $this->core->getOutput()->addInternalJs('rainbow-customization.js');
             $this->core->getOutput()->addInternalCss('rainbow-customization.css');
             $this->core->getOutput()->addInternalCss('grade-report.css');
-            $this->core->getOutput()->addBreadcrumb('Rainbow Grades Customization');
+            $this->core->getOutput()->addBreadcrumb('Rainbow Grades Configuration');
             $this->core->getOutput()->addSelect2WidgetCSSAndJs();
             $students = $this->core->getQueries()->getAllUsers();
             $student_full = Utils::getAutoFillData($students);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Currently, the Grades Configuration button on the left of the page leads to a page with "Submitty > Sample > Rainbow Grades Customization" at the top, even though the page title just below says "Rainbow Grades Configuration". This is awkward looking and somewhat confusing as to the actual page title.

Before: (Firefox)
<img width="1580" height="788" alt="RainbowGradesCustomization" src="https://github.com/user-attachments/assets/455a3f3b-5c2a-4d2e-8a70-4d6a3168dd0f" />

### What is the New Behavior?
Now the top reads "Submitty > Sample > Rainbow Grades Configuration" which matches the title of the page just below. This helps with both clarity in navigating the site, as well as improving the consistency of site page naming.

After: (Firefox)
<img width="1582" height="739" alt="RainbowGradesConfiguration" src="https://github.com/user-attachments/assets/42fac7fc-e625-4213-9c0a-134ce536607e" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
Click on Grades Configuration and confirm that the top banner page title matches the main title of the page below it, and that both say "Rainbow Grades Configuration".

### Automated Testing & Documentation

### Other information
This is not a breaking change.
