### PR TITLE
[Fix:Notebook] Enable scrolling for overflowing long-answer codeboxes

### DIFF
--- a/site/public/css/gradeable-notebook.css
+++ b/site/public/css/gradeable-notebook.css
@@ -117,6 +117,8 @@ img {
     resize: horizontal;
     min-width: 150px;
     max-width: 50em;
+    /* Allow horizontal scrolling when content overflows the max-width */
+    overflow: auto;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -124,6 +126,8 @@ img {
     resize: vertical;
     min-height: 30px;
     max-height: 80vh;
+    /* Allow vertical scrolling when content overflows the max-height */
+    overflow: auto;
 }
 
 /* Fixes Safari spacing issue */


### PR DESCRIPTION
## Description
This PR fixes a bug where graders couldn't scroll to see the full content of long answers in the grading interface.

## Problem
When grading submissions with long-answer questions, if the content exceeded the visible area of the codebox, no scrollbar appeared. This prevented graders from viewing the complete student response.

## Solution
Added `overflow: auto` to both small and large CodeMirror containers:
- `.small-mirror .CodeMirror` - enables horizontal scrolling when content exceeds max-width (50em)
- `.large-mirror .CodeMirror` - enables vertical scrolling when content exceeds max-height (80vh)

## Testing
1. Open the grading interface for an assignment with long-answer questions
2. Select a submission with a long answer that overflows the visible area
3. Verify that scrollbars now appear and allow viewing the full content

## Files Changed
- `site/public/css/gradeable-notebook.css`

Fixes the issue described in the bug report where graders couldn't scroll overflowing long-answer content.