### PR TITLE
[Bugfix:Developer] Fix Ansible install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,6 +946,13 @@ jobs:
           ssh -T localhost
           sudo systemctl start postgresql
 
+      - name: Delete unused folders
+        run: |
+          rm -rf /opt/hostedtoolcache
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Run ansible script
         shell: bash
         run: |


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Currently the Ansible install tests are failing because the autograder services can't start because of too much disk space.

### What is the New Behavior?
The same folders that are removed in the normal CI procedures are now removed for Ansible install as well.
The tests should now run and pass.

### What steps should a reviewer take to reproduce or test the bug or new feature?
See the tests now pass in CI.

### Other information
We should investigate more options to reduce space, because it looks like it's ~40+ gb. 
