### PR TITLE
[Bugfix:InstructorUI] Fix Gradeable JSON Boolean Fields

### DIFF
--- a/site/app/models/gradeable/Component.php
+++ b/site/app/models/gradeable/Component.php
@@ -96,10 +96,10 @@ class Component extends AbstractModel {
         $this->setStudentComment($details['student_comment']);
         $this->setPoints($details);
         $this->setText(Utils::getBooleanValue($details['text']));
-        $this->setPeerComponent(Utils::getBooleanValue($details['peer_component'] ?? false));
+        $this->setPeerComponent(Utils::getBooleanValue($details['peer_component']));
         $this->setOrder($details['order']);
         $this->setPage($details['page']);
-        $this->setIsItempoolLinked(Utils::getBooleanValue($details['is_itempool_linked'] ?? false));
+        $this->setIsItempoolLinked(Utils::getBooleanValue($details['is_itempool_linked']));
         $this->setItempool($details['itempool'] ?? "");
         $this->any_grades = ($details['any_grades'] ?? false) === true;
         $this->modified = false;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Fixes #12151.
As described in the issue, uploading a Gradeable JSON currently results in peer grading being enabled regardless of the assignment of the `peer_component` property. This bug is caused by the Gradeable construction logic not interpretting certain values in the JSON as boolean, which results in a string being parsed instead. This has now been fixed via invocation of the  `Utils::getBooleanValue` method.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Download the Gradeable JSON of _Bulk Upload Scanned Exam_ in the _Sample_ course. Edit the JSON so that the `id` field is different (i.e. add `_1` to the existing `id`) and ensure that for one of the rubric sections, `peer_component` is set to `true` and that for another it is set to `false`. Create a new Gradeable in the _Sample_ course by uploading this JSON. Note how both of the rubric sections are highlighted purple (indicating peer grading).
Checkout this branch, repeat the same steps, and note how the peer grading sections are assigned properly.
