### PR TITLE
Fix TA grading preview to match student view

### DIFF
--- a/site/public/js/gradeable.js
+++ b/site/public/js/gradeable.js
@@ -227,6 +227,8 @@ function renderGradingComponent(grader_id, component, graded_component, graders,
         if (is_student) {
             component.ta_comment = '';
         }
+        //Fix: Show only selected or display-to-all" marks.
+        component.marks = component.marks.filter(mark => mark.selected || mark.grader_show_to_all);
         // TODO: i don't think this is async
         resolve(Twig.twig({ ref: 'GradingComponent' }).render({
             component: component,


### PR DESCRIPTION
Filters out unselected marks in TA preview so it matches what students see. Updated gradeable.js logic and verified display consistency.
