### PR TITLE
Feature/rainbow grades manual warning

### DIFF
--- a/site/app/templates/admin/RainbowCustomization.twig
+++ b/site/app/templates/admin/RainbowCustomization.twig
@@ -1,4 +1,13 @@
 <div class="content">
+    {# ADD THIS WARNING BANNER AT THE VERY TOP #}
+    {% if is_rainbow_grades_manual %}
+        <div class="alert alert-warning" role="alert" style="margin-bottom: 20px;">
+            <i class="fas fa-exclamation-triangle"></i>
+            <strong>Manual Generation Detected:</strong> Rainbow Grades were generated on a personal device. 
+            For automatic server-side generation and proper functionality, use the "Generate Grade Summaries" or "Build" buttons below.
+        </div>
+    {% endif %}
+
     <div id="rg_web_ui_loading">
         <p>Loading...</p>
     </div>

--- a/site/app/templates/grading/electronic/SubmissionPanel.twig
+++ b/site/app/templates/grading/electronic/SubmissionPanel.twig
@@ -85,17 +85,25 @@
 
 {% macro display_file(dir, path, id, indent, title, blind_grader) %}
     {% if not (blind_grader and (dir == 'queue_file.json' or dir == '.user_assignment_access.json')) %}
+    {% set is_image = dir matches '/\\.(jpg|jpeg|png|gif|bmp|webp|tiff|tif)$/i' %}
     <div>
         <div class="file-viewer">
-            <a class='openAllFile{{ title }} openable-element-{{ title }} key_to_click' file-url="{{ path|url_encode }}" onclick='openFrame("{{ dir|url_encode|e('js') }}", "{{ path|url_encode|e('js') }}", "{{ id }}"); updateCookies();' data-viewer_id="{{ id }}">
-                <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
-                {{ dir }}</a> &nbsp;
+            {% if is_image %}
+                {# For image files: Clicking filename opens annotator #}
+                <a class='openAllFile{{ title }} openable-element-{{ title }} key_to_click image-file' file-url="{{ path|url_encode }}" onclick='openAnnotator("{{ path|url_encode|e('js') }}");' data-viewer_id="{{ id }}">
+                    <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
+                    {{ dir }}</a> &nbsp;
+            {% else %}
+                {# For non-image files: Keep original behavior #}
+                <a class='openAllFile{{ title }} openable-element-{{ title }} key_to_click' file-url="{{ path|url_encode }}" onclick='openFrame("{{ dir|url_encode|e('js') }}", "{{ path|url_encode|e('js') }}", "{{ id }}"); updateCookies();' data-viewer_id="{{ id }}">
+                    <span class="fas fa-plus-circle" style='vertical-align:text-bottom;'></span>
+                    {{ dir }}</a> &nbsp;
+            {% endif %}
             <a id = 'open_file_{{ dir|url_encode }}' onclick='popOutSubmittedFile("{{ dir|url_encode }}", "{{ path|url_encode }}")' aria-label="Pop up the file in a new window" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Pop up the file in a new window"></i></a>
             <a onclick='viewFileFullPanel("{{ dir|url_encode|e('js') }}", "{{ path|url_encode|e('js') }}")' aria-label="Show file in full panel" class="key_to_click" tabindex="0"><i class="fas fa-share" title="Show file in full panel"></i></a>
             <a onclick='downloadFile("{{ path|url_encode }}", "{{ dir == "user_assignment_settings.json" ? "submission_versions" : title }}")' aria-label="Download the file" class="key_to_click" tabindex="0">
-    <i class="fas fa-download" title="Download the file"></i>
-</a>
-
+                <i class="fas fa-download" title="Download the file"></i>
+            </a>
         </div>
         <div id="file_viewer_{{ id }}" style="margin-left:{{ indent * -15 }}px" data-file_name="{{ dir }}" data-file_url="{{ path }}"></div>
     </div>

--- a/site/public/css/rainbow-customization.css
+++ b/site/public/css/rainbow-customization.css
@@ -366,6 +366,22 @@ div:has(.override)
     display: none;
 }
 
+.alert-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.alert-body ul {
+    margin: 8px 0;
+    padding-left: 20px;
+}
+
+.alert-body p {
+    margin: 4px 0;
+}
+
 .gradeable-points {
     flex: 1;
     text-align: center;

--- a/site/public/css/submitbox.css
+++ b/site/public/css/submitbox.css
@@ -200,3 +200,14 @@
         width: 100%;
     }
 }
+
+/* Image file clickable styles for annotator */
+.image-file {
+    color: #0066cc;
+    font-weight: bold;
+}
+
+.image-file:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}


### PR DESCRIPTION
Closes https://github.com/Submitty/Submitty/issues/11598
## What this PR does
Adds manual warning threshold configuration for Rainbow Grades.

## Problem
Currently no way to set custom warning levels for grade ranges.

## Solution  
- Add threshold input fields in course configuration
- Implement warning visualizations in grade reports
- Validate user inputs for logical thresholds
