### PR TITLE
[Bugfix:TAGrading] Persistent Full Left Column

### DIFF
--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -132,7 +132,7 @@ function initializeTaLayout() {
     }
     else if (taLayoutDet.numOfPanelsEnabled) {
         togglePanelLayoutModes(true);
-        if (taLayoutDet.isFullLeftColumnMode && $('#silent-edit-id').length !== 0) {
+        if (taLayoutDet.isFullLeftColumnMode) {
             toggleFullLeftColumnMode(true);
         }
         // initialize the layout\


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12221
The `side-by-side, taller left` panel option in the TAGrading interface could be successfully toggled, but was not persistent upon page reload. This issue only affected non-instructors because the initialization logic for the interface was checking that **both** the user preference for the panel was true, **and** that the silent edit checkbox existed on the DOM, which is a feature for instructors only.

### What is the New Behavior?
Removed the second check, and now the initialization logic works as expected, making the user's left column preference persistent. I can't think of how silent regrading and panel preferences are/were related, perhaps its just the result of many years of changes to the TA grading code.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Replicate issue on main (as TA)
2. Verify that the issue is resolved on this branch

### Automated Testing & Documentation
There are no tests for this change. It may be a good idea to make a Cypress test in a future PR for **all** of these preferences to ensure they are working as expected.

### Other information
This is not a breaking change.
