### PR TITLE
[Bugfix:Developer] Cypress test for TA Grading

### DIFF
--- a/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/rubric_grading.spec.js
@@ -127,5 +127,12 @@ describe('Test cases for TA grading page', () => {
         cy.get('[data-testid="save-tools-save"]').click();
         cy.get('[data-testid="component-64"]').should('contain', 'Read Me');
         cy.contains('Full Credit').should('not.be.visible');
+        cy.get('body').type('{downArrow}');
+        cy.get('[data-testid="component-64"] [data-testid="save-tools-save"]')
+            .should('contain', 'Save');
+        cy.get('body').type('{1}');
+        cy.get('[data-testid="component-64"]').should('contain', 'Full Credit');
+        cy.get('[data-testid="save-tools-save"]').click();
+        cy.contains('Full Credit').should('not.be.visible');
     });
 });


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12220

Previously, there was an issue #12083, where the collapsed view of a graded component for a TA did not match the student's view. This was resolved by PR #12131 .

### What is the New Behavior?
To ensure this problem remains fully resolved, this Cypress test logs in as a TA, assigns a mark that is not marked "show to all students", and then collapses the component. The test verifies that only the assigned mark, and the show-to-all mark, are the only two visible in this graded component.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Review the code and make sure test is passing.

### Automated Testing & Documentation

### Other information
This is not a breaking change.
