### PR TITLE
[Bugfix:Notifications] Post Preview for Forum Emails

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -584,9 +584,9 @@ class ForumController extends AbstractController {
 
                 $metadata = json_encode(['url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]), 'thread_id' => $thread_id]);
 
-                $parent_preview = $this->previewText($parent_post_content, 300);
+                $parent_preview = $this->previewText($parent_post_content, 100);
                 $subject = "New Reply: " . $thread_title;
-                $content = "A new message was posted in:\n" . $full_course_name . "\n\nThread Title: " . $thread_title . "\n Post (preview):\n" . $parent_preview . "\n\nNew Reply:\n\n" . $post_content;
+                $content = "A new message was posted in:\n" . $full_course_name . "\n\nThread Title: " . $thread_title . "\n Post:\n" . $parent_preview . "\n\nNew Reply:\n\n" . $post_content;
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'post_id' => $post_id, 'thread_id' => $thread_id];
                 $this->core->getNotificationFactory()->onNewPost($event);
 
@@ -623,14 +623,14 @@ class ForumController extends AbstractController {
 
     /**
      * Returns the full text if short, otherwise a preview capped at $limit characters.
-     * Adds "..." when truncated.
+     * Adds "...(truncated)" when truncated.
      */
     private function previewText(string $text, int $limit = 300): string {
         $text = str_replace("\r", "", $text);
         if (mb_strlen($text, 'UTF-8') <= $limit) {
             return $text;
         }
-        return mb_substr($text, 0, $limit, 'UTF-8') . "...";
+        return mb_substr($text, 0, $limit, 'UTF-8') . "...(truncated)";
     }
 
     #[Route("/courses/{_semester}/{_course}/forum/posts/single", methods: ["POST"])]


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12276 
Previously, the email notification sent out included just a portion of the original post and the entirety of the reply post. This was changed at some point to include the entire original post. This might not be a problem for shorter original posts, but for longer ones it would result in a long email.

### What is the New Behavior?
Now, if the original post content long it gets truncated by a helper function. If it is shorter than this preset value, the entire post gets included in the email.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Make sure a testing user has email notifications for replies to their threads/ participating threads.
2. Create a thread as this user with a very long post body
3. Log in as another user and reply to this thread.
4. Use 'systemctl start nullsmtpd' to check emails generated on this branch to verify the preview is truncated.

Additional information about email use here:  https://submitty.org/developer/development_instructions/vagrant_email_configuration

### Automated Testing & Documentation


### Other information
This is not a breaking change.
