### PR TITLE
[Bugfix:Developer] Change Image for Vagrant Jobs

### DIFF
--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -73,11 +73,11 @@ jobs:
           job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
-      # - name: Send zulip message on failure
-      #   if: failure()
-      #   run: |
-      #     curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
-      #       --data-urlencode 'type=stream' \
-      #       --data-urlencode 'to=Submitty Developer Studio' \
-      #       --data-urlencode 'topic=Vagrant Up Failures' \
-      #       --data-urlencode 'content=The Package Vagrant VM Github Action has failed, this means the VM is not saved, and requires attention. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'
+      - name: Send zulip message on failure
+        if: failure()
+        run: |
+          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
+            --data-urlencode 'type=stream' \
+            --data-urlencode 'to=Submitty Developer Studio' \
+            --data-urlencode 'topic=Vagrant Up Failures' \
+            --data-urlencode 'content=The Package Vagrant VM Github Action has failed, this means the VM is not saved, and requires attention. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -37,7 +37,7 @@ jobs:
           jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
           job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
-      # - name: Send zulip message on failure
-      #   if: failure()
-      #   run: |
-      #    curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' --data-urlencode 'topic=Vagrant Up Failures' --data-urlencode 'content=The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'
+      - name: Send zulip message on failure
+        if: failure()
+        run: |
+         curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' --data-urlencode 'topic=Vagrant Up Failures' --data-urlencode 'content=The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Related to #12163 
Github has retired the macos-13 intel images, and has macos-15-intel images that is a temporary solution until x86 infrastructure is no longer supported by github actions.

### What is the New Behavior?
The jobs that were using the macos-13 image are now using the macos-15-intel image.

### What steps should a reviewer take to reproduce or test the bug or new feature?
See that the jobs run now [Vagrant Up](https://github.com/Submitty/Submitty/actions/runs/20114839319) and [Save Vagrant Box](https://github.com/Submitty/Submitty/actions/runs/20114848279/job/57721655877)

### Other information
It would be good to change from using x86 based boxes to arm boxes (especially now that they (might) support virtualbox), as they will have longer term support. 