### PR TITLE
[Bugfix:SubminiPolls] Fix Safari layout

### DIFF
--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -26,13 +26,13 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="Edit">Edit</th>
+                    <th scope="col" aria-label="Delete">Delete</th>
+                    <th scope="col" aria-label="Poll Name">Poll Name</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="View Poll">View Poll</th>
                 </tr>
             </thead>
             <tbody>
@@ -46,7 +46,7 @@
                         <td>
                                 <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}","{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
                         </td>
-                        <td style="text-align: left">
+                        <td style="text-align: left; min-width: 200px;">
                             {{ poll.getName() }}
                         </td>
                         <td>
@@ -91,12 +91,12 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="Edit">Edit</th>
+                    <th scope="col" aria-label="Delete">Delete</th>
+                    <th scope="col" aria-label="Poll Name">Poll Name</th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Responses</th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="View Poll">View Poll</th>
                 </tr>
             </thead>
             <tbody>
@@ -110,7 +110,7 @@
                         <td>
                                 <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
                         </td>
-                        <td style="text-align: left;">
+                        <td style="text-align: left; min-width: 200px;">
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() | date("Y-m-d") }} </td>
@@ -154,14 +154,14 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="Edit">Edit</th>
+                    <th scope="col" aria-label="Deletel">Delete</th>
+                    <th scope="col" aria-label="Poll Name">Poll Name</th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>
                     <th scope="col">Accepting Answers</th>
                     <th scope="col">Responses</th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="View Poll">View Poll</th>
                 </tr>
             </thead>
             <tbody>
@@ -175,7 +175,7 @@
                         <td>
                                 <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
                         </td>
-                        <td style="text-align: left">
+                        <td style="text-align: left; min-width: 200px;">
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() | date("Y-m-d") }} </td>
@@ -221,12 +221,12 @@
             <col style="width: 15%">
             <thead>
                 <tr>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="Edit">Edit</th>
+                    <th scope="col" aria-label="Delete">Delete</th>
+                    <th scope="col" aria-label="Poll Name">Poll Name</th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Responses</th>
-                    <th scope="col" aria-label="Empty Cell"></th>
+                    <th scope="col" aria-label="View Poll">View Poll</th>
                 </tr>
             </thead>
             <tbody>
@@ -240,7 +240,7 @@
                         <td>
                             <a class="fas fa-trash black-btn" tabindex="0" href='javascript:newDeletePollForm("{{ poll.getId() }}", "{{ poll.getName() }}", "{{ base_url }}");' title="delete poll {{ poll.getName() }}" aria-label="delete poll {{ poll.getId() }}"></a>
                         </td>
-                        <td style="text-align: left">
+                        <td style="text-align: left; min-width: 200px;">
                             {{ poll.getName() }}
                         </td>
                         <td> {{ poll.getReleaseDate() | date("Y-m-d") }} </td>

--- a/site/app/templates/polls/AllPollsPageInstructor.twig
+++ b/site/app/templates/polls/AllPollsPageInstructor.twig
@@ -155,7 +155,7 @@
             <thead>
                 <tr>
                     <th scope="col" aria-label="Edit">Edit</th>
-                    <th scope="col" aria-label="Deletel">Delete</th>
+                    <th scope="col" aria-label="Delete">Delete</th>
                     <th scope="col" aria-label="Poll Name">Poll Name</th>
                     <th scope="col">Date Released</th>
                     <th scope="col">Visible</th>


### PR DESCRIPTION
Why is this Change Important & Necessary?
Fixes #10899. The Polls index page exhibited "wonky" layout issues specifically on Mac Safari. Table headers were misaligned with their data columns, and the table was prone to horizontal squashing. This PR provides the minimal set of changes required to stabilize the rendering.

What is the New Behavior?
Header Alignment: Replaced empty <th> tags with explicit visible labels ("Edit", "Delete", "Poll Name", "View Poll"). This allows the Safari rendering engine to calculate column widths accurately, ensuring headers align with checkboxes and data.

Layout Stability: Implemented min-width: 200px on the Poll Name <td> across Today, Tomorrow, Old, and Future poll tables to prevent column collapse.

Clean Diff: Removed all unrelated formatting and file changes to focus strictly on the fix as requested.

What steps should a reviewer take to reproduce or test the bug or new feature?
Open Submitty in Mac Safari.

Navigate to the Polls index page.

Verify that the "Visible", "Accepting Answers", and "Responses" headers align vertically with their respective data columns.

Verify that resizing the browser does not squash the action icons.

Automated Testing & Documentation
Manual visual verification was performed on Safari and Brave browsers to ensure cross-browser stability.

No new automated tests or documentation updates are required for this CSS/UI fix.

Other information
This is not a breaking change.

Does not include migrations or security concerns.