### PR TITLE
[Bugfix:Forum] Enable discussion forum by default

### DIFF
--- a/site/config/course_template.json
+++ b/site/config/course_template.json
@@ -15,7 +15,7 @@
         "vcs_base_url": "",
         "vcs_type": "git",
         "private_repository": "",
-        "forum_enabled": false,
+        "forum_enabled": true,
         "forum_create_thread_message": "",
         "grade_inquiry_message": "Warning: Frivolous grade inquiries may lead to grade deductions or lost late days",
         "seating_only_for_instructor": false,


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12335 

### What is the New Behavior?
Previously, the discussion forum would not be created by default when a course is made. Now, the discussion forum is created by default.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Test old behavior:
1. Create new course
2. Observe that discussion forum is disabled
3. Enable Discussion forum in course settings
4. Observe that discussion forum is now enabled
5. Try making a forum post to test functionality

Test new behavior:
1. Create new course
2. Observe that discussion forum is enabled
3. Try making a forum post to test functionality

### Automated Testing & Documentation
This feature is not yet tested.

### Other information
This is not a breaking change, and does not need migration.
