### PR TITLE
[Bugfix:Notifications] Completed Semester => Term Refactor

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5417,12 +5417,12 @@ AND gc_id IN (
     /**
      * Get 10 most recent Notification objects in a course
      * @param string $user_id
-     * @param string $semester
+     * @param string $term
      * @param string $course_name
      * @param object $course_db
      * @return array<int, Notification>
      */
-    public function getRecentUserNotifications($user_id, $semester, $course_name, $course_db) {
+    public function getRecentUserNotifications($user_id, $term, $course_name, $course_db) {
         $query = "
             SELECT id, component, metadata, content,
                 (CASE WHEN seen_at IS NULL THEN false ELSE true END) AS seen,
@@ -5447,7 +5447,7 @@ AND gc_id IN (
                     'seen' => $row['seen'],
                     'elapsed_time' => $row['elapsed_time'],
                     'created_at' => $row['created_at'],
-                    'semester' => $semester,
+                    'term' => $term,
                     'course' => $course_name,
                 ]
             );

--- a/site/app/models/Notification.php
+++ b/site/app/models/Notification.php
@@ -19,7 +19,7 @@ use app\libraries\DateUtils;
  * @method void     setNotifySource($content)
  * @method void     setNotifyTarget($content)
  * @method void     setType($t)
- * @method void setSemester(string $semester)
+ * @method void setTerm(string $term)
  * @method void setCourse(string $course)
 
  *
@@ -37,8 +37,6 @@ use app\libraries\DateUtils;
  * @method string   getNotifyMetadata()
  * @method bool     getNotifyNotToSource()
  * @method string   getType()
- * @method string|null getSemester()
- * @method string|null getCourse()
  */
 class Notification extends AbstractModel implements \JsonSerializable {
     /** @prop
@@ -69,8 +67,8 @@ class Notification extends AbstractModel implements \JsonSerializable {
     protected $notify_not_to_source;
 
     /** @prop
-     * @var string|null Semester for this notification */
-    protected ?string $semester = null;
+     * @var string|null Term for this notification */
+    protected ?string $term = null;
 
     /** @prop
      * @var string|null Course for this notification */
@@ -125,8 +123,8 @@ class Notification extends AbstractModel implements \JsonSerializable {
         $instance->setCreatedAt($details['created_at']);
         $instance->setNotifyMetadata($details['metadata']);
         $instance->setNotifyContent($details['content']);
-        if (isset($details['semester'])) {
-            $instance->setSemester($details['semester']);
+        if (isset($details['term'])) {
+            $instance->setTerm($details['term']);
         }
 
         if (isset($details['course'])) {
@@ -207,7 +205,7 @@ class Notification extends AbstractModel implements \JsonSerializable {
      * elapsed_time: float,
      * created_at: string,
      * notify_time: string,
-     * semester: string|null,
+     * term: string|null,
      * course: string|null,
      * url: string
      * }
@@ -216,11 +214,11 @@ class Notification extends AbstractModel implements \JsonSerializable {
         $base_url = '';
 
         if ($this->getNotifyMetadata() !== null) {
-            $semester = $this->semester;
+            $term = $this->term;
             $course = $this->course;
 
-            if (($semester !== null && $semester !== '') && ($course !== null && $course !== '')) {
-                $base_url = $this->core->buildUrl(['courses', $semester, $course, 'notifications', $this->getId()]);
+            if (($term !== null && $term !== '') && ($course !== null && $course !== '')) {
+                $base_url = $this->core->buildUrl(['courses', $term, $course, 'notifications', $this->getId()]);
             }
             else {
                 $base_url = $this->core->buildCourseUrl(['notifications', $this->getId()]);
@@ -241,7 +239,7 @@ class Notification extends AbstractModel implements \JsonSerializable {
             'elapsed_time' => $this->getElapsedTime(),
             'created_at' => $this->getCreatedAt(),
             'notify_time' => $this->getNotifyTime(),
-            'semester' => $this->semester,
+            'term' => $this->term,
             'course' => $this->course,
             'url' => $url
         ];


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In #12233, I made an effort to refactor the notifications system to use `term` instead of `semester`, to maintain consistency with the rest of the site. Unfortunately, I missed several files, resulting in each notification having an `undefined` term. As a result, `markAllSeen()`, which uses `term` to find the notifications to clear, was unable to update the page dynamically.

### What is the New Behavior?
Convertedall instances of `semester` to `term` within the notification system.

### What steps should a reviewer take to reproduce or test the bug or new feature?
**On main:**
Observe that `markAllSeen` works upon reload, but does not update the page dynamically. If you want to take it a step further, you can do `console.log(n.term)` inside of the function, and observe that it is always `undefined`.

**On my branch:**
Observer that `markAllSeen`, and all other functionality of the notifications UI is dynamic. `n.term` is now `s26`.

### Automated Testing & Documentation
There is currently no complete E2E testing of the notification system (#11908). With the new user interface now complete, this will be my next priority.

### Other information
This is not a breaking change.
