### PR TITLE
[Bugfix:System] Added Spacing for Mobile Sidebar Btns

### DIFF
--- a/site/vue/src/components/sidebar/Button.vue
+++ b/site/vue/src/components/sidebar/Button.vue
@@ -68,7 +68,7 @@ function getButtonId(button: Button): string | undefined {
               v-if="button.icon"
               :class="[button.prefix, button.icon]"
             />
-            <span class="icon-title title-spacer">{{ button.title }}</span>
+            <span class="icon-title">{{ button.title }}</span>
           </span>
           <span
             v-if="button.badge && button.badge > 0"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The mobile sidebar has no spacing between badges and titles
<img width="226" height="450" alt="image" src="https://github.com/user-attachments/assets/e82b1123-0de2-475b-a7d8-8093493dbc36" />

### What is the New Behavior?
Added 12px of spacing between badges and titles
<img width="226" height="450" alt="image" src="https://github.com/user-attachments/assets/ef494cdf-b319-4754-b6b8-8bc1c611465e" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
Observer no spacing on main sidebar, and spacing on topic branch sidebar
If there is any other improvements that could be made to the mobile sidebar in this PR, please let me know!

### Automated Testing & Documentation
N / A

### Other information
This is not a breaking change.
