### PR TITLE
[Testing:System] Remove old field from notebook example

### DIFF
--- a/more_autograding_examples/notebook_expected_string/config/config.json
+++ b/more_autograding_examples/notebook_expected_string/config/config.json
@@ -4,8 +4,7 @@
     "container_options": {
         "container_image": "submitty/autograding-default:latest"
     },
-
-    "hide_submitted_files" : true,
+  
 //    "hide_version_and_test_details" : true,
 
     "assignment_message" : "# Welcome To My Favorite Notebook Gradeable\n  \


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Lingering change from https://github.com/Submitty/Submitty/pull/7804

See warning/error in https://github.com/Submitty/Submitty/actions/runs/21500146068/job/61944467809#step:5:12258

### What is the New Behavior?
hide_submitted_files, an invalid config value, is now removed from the notebook_expected_string config example.
