### PR TITLE
[Bugfix:Developer] Filter unit test in submitty_test 

### DIFF
--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -27,7 +27,7 @@ run_css_style() {
 
 run_php_unit() {
     COMPOSER_ALLOW_SUPERUSER=1 composer install
-    sudo -u submitty_php php vendor/bin/phpunit "${@:2}" 2>/dev/null
+    sudo -u submitty_php php vendor/bin/phpunit "${@:2}"
 }
 
 if [ -z "$1" ] || [ "$1" == "help" ]; then
@@ -35,7 +35,7 @@ if [ -z "$1" ] || [ "$1" == "help" ]; then
           phpstan : php static analysis [option: --memory-limit 4G, --generate-baseline ...]
           phpcs   : php CodeSniffer
           php-lint: phpcs & phpstan
-          php-unit: run php unit tests [option: --filter testFunctionName, testFile]
+          php-unit: run php unit tests [option: --filter testFunctionName, --debug, testFile ...]
           js-lint : eslint
           css-lint: css-stylelint
           "


### PR DESCRIPTION
### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
According to our documentation, https://submitty.org/developer/testing/php_unit_tests, there is a filter option that could be passed to php-unit. For people debugging single unit tests, this command is very helpful. However, in our submitty_test file, we do not allow passing in command line arguments to unit tests. Like other commands in submitty_test, we should allow it to take in arguments to help the developer

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Allow `submitty_test php-unit` to take in commands, mimicking other functions

### What steps should a reviewer take to reproduce or test the bug or new feature?
`submitty_test php-unit --filter testRunQuery` Runs `testRunQuery` from `SqlToolboxControllerTester.php`

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->
N/A

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
