### PR TITLE
[Bugfix:System] Fix opencv migration dep

### DIFF
--- a/migration/migrator/migrations/system/20220710211447_switch_opencv_headless.py
+++ b/migration/migrator/migrations/system/20220710211447_switch_opencv_headless.py
@@ -1,13 +1,11 @@
 """Migration for the Submitty system."""
-import pkg_resources
 import subprocess
 import sys
+from importlib.util import find_spec
 
 def up(config):
-    #get existing installed packages and check if opencv-python is there
-    #https://stackoverflow.com/questions/44210656/how-to-check-if-a-module-is-installed-in-python-and-if-not-install-it-within-t    
-    installed = {pkg.key for pkg in pkg_resources.working_set}
-    if 'opencv-python' in installed:
+    opencv_python_pkg = find_spec('opencv-python')
+    if opencv_python_pkg is not None:
         print("Uninstalling opencv-python")
         try:
             subprocess.check_call("python3 -m pip uninstall opencv-python --yes --no-input", shell=True, stderr=subprocess.STDOUT)


### PR DESCRIPTION
### Why is this Change Important & Necessary?
CI is failing https://github.com/Submitty/Submitty/actions/runs/21803157121/job/62902011782

An old migration has a non stdlib import. That functionality can easily be replaced with stdlib python functionality.

### What is the New Behavior?
CI passes.

### Other information
It seems that non stdlib library is not present on the latest runners. We could consider installing it but it doesn't make sense given we only need it for a single migration. Editing old migrations is usually not best practice to do but no point keeping a dependency around for just that.
