### PR TITLE
[Bugfix:Autograding] Fix team detection in regrade

### DIFF
--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -213,15 +213,23 @@ def main():
                     raise SystemExit("ERROR: path reconstruction failed")
                 # add them to the queue
 
-                # FIXME: This will be incorrect if the username includes an underscore
-                if '_' not in my_who:
-                    my_user = my_who
-                    my_team = ""
-                    my_is_team = False
-                else:
+                # Determine whether the submission belongs to a user or a
+                # team by inspecting user_assignment_settings.json.  Team
+                # directories contain a "team_history" key written when the
+                # team is created, whereas individual user directories do not.
+                who_dir = os.path.join(data_dir, my_semester, my_course, "submissions", my_gradeable, my_who)
+                settings_path = os.path.join(who_dir, "user_assignment_settings.json")
+                my_is_team = False
+                if os.path.isfile(settings_path):
+                    with open(settings_path, 'r') as sf:
+                        my_is_team = "team_history" in json.load(sf)
+
+                if my_is_team:
                     my_user = ""
                     my_team = my_who
-                    my_is_team = True
+                else:
+                    my_user = my_who
+                    my_team = ""
 
                 # Note: If the initial checkout failed, or if
                 # autograding failed to create a results subdirectory


### PR DESCRIPTION
## Description

Fixes #12423

The `regrade.py` script uses an underscore-based heuristic to distinguish user submissions from team submissions:

```python
# FIXME: This will be incorrect if the username includes an underscore
if '_' not in my_who:
    my_user = my_who
```

This incorrectly classifies usernames containing underscores (e.g., `jane_doe`) as team submissions.

### Root cause

The original code checked for `_` in the directory name because team IDs are formatted as `NNNNN_<user_id>`. However, usernames can also contain underscores, making this heuristic unreliable.

### Fix

Replace the underscore check with a reliable filesystem-based detection. When a team is created, the PHP `TeamController` writes a `user_assignment_settings.json` file in the team's submission directory containing a `"team_history"` key. Individual user directories never contain this key.

The fix reads this settings file and checks for the presence of `"team_history"` to determine whether the submitter is a team or user. If the file is missing (e.g., corrupt state), it defaults to treating the submitter as a user, which is the safer fallback.

**Note:** The issue suggested using `team_assignment` from the build configuration (`datastore`), but the build config (`config/build/build_<gradeable>.json`) does not contain this field — it only has autograding-related settings like `required_capabilities` and `max_possible_grading_time`. The `team_assignment` boolean is stored in the database (`electronic_gradeable.eg_team_assignment`), which `regrade.py` does not have access to. The `user_assignment_settings.json` approach provides a reliable filesystem-based alternative.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Code review verified the logic against the existing `TeamController.php` which writes `team_history` to settings files (line 68)
- Code review verified `is_active_version()` already reads `user_assignment_settings.json` from the same directory, confirming the file exists for both teams and users
- Verified team ID format (`NNNNN_<user_id>`) in `DatabaseQueries.php:3655` to confirm usernames with underscores can collide with team IDs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. All code was reviewed, tested, and verified by a human before submission.*