### PR TITLE
[Bugfix:Notebook] Fix codebox scroll in grader view

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -89,9 +89,6 @@
                     data-recent_submission="{{ cell.recent_submission }}"
                     data-version_submission="{{ cell.version_submission }}"
                     onkeyup="handle_input_keypress();"
-                    {% if viewing_inactive_version or is_grader_view %}
-                        style="pointer-events:none;"
-                    {% endif %}
                 >
                 </div>
                 {% if not is_grader_view %}
@@ -110,6 +107,10 @@
                         theme = "dark";
                     }
                     config_{{ num_codeboxes }}.theme = (theme == null || theme === "light") ? "eclipse" : "monokai";
+
+                    {% if viewing_inactive_version or is_grader_view %}
+                      config_{{ num_codeboxes }}.readOnly = 'nocursor';
+                    {% endif %}
 
                     {% if cell.programming_language is defined and cell.programming_language != '' %}
                       config_{{ num_codeboxes }}.lineNumbers = true;


### PR DESCRIPTION
## Summary
Fix graders being unable to scroll through long codebox answers in notebook gradeables.

## Context / Motivation
Fixes #11096. When a grader views a notebook submission with a long codebox answer, the content overflows but cannot be scrolled. The grader cannot see the full student response.

## Changes Made
- Removed `pointer-events: none` from the codebox container `<div>` in `Notebook.twig`
- Added CodeMirror `readOnly: 'nocursor'` config option for grader/inactive-version views

## Root Cause
The codebox `<div>` had `style="pointer-events:none;"` applied in grader view to prevent editing. However, `pointer-events: none` disables **all** mouse interaction on the element, including scroll events. This meant graders literally could not scroll the CodeMirror editor.

## Solution
CodeMirror's built-in `readOnly: 'nocursor'` option prevents all editing and cursor placement while keeping the scroll-pane fully functional. This is the standard way to make a CodeMirror instance read-only.

## Testing
- Verified that the `readOnly: 'nocursor'` config is only applied when `viewing_inactive_version` or `is_grader_view` is true (same condition as the removed `pointer-events: none`)
- CodeMirror docs confirm `readOnly: 'nocursor'` prevents editing and focus while allowing scroll interaction

---

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*