### PR TITLE
   [Bugfix:InstructorUI] Fix histogram bucket double-count

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/StatusBase.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusBase.twig
@@ -42,23 +42,24 @@
             }
         }
         var maxMin = tracking-increment;
-        var ct = 0;
+        // Assign each score to exactly one bucket (last bucket first) so total count stays correct.
         for(i = 0;i<xValue.length;i++){
-           ct++;
-           for(var [key,value] of betterBuckets){
-                if(key===maxMin){
-                    if(xValue[i]>=key&&xValue[i]<=max){
-                       betterBuckets.set(key,value+1);
-                   }
-                }
-               else{
-                    if(xValue[i]>=key && xValue[i]<(key+increment)){
-                        betterBuckets.set(key,value+1);
+            let score = xValue[i];
+            let assigned = false;
+            if(score >= maxMin && score <= max){
+                betterBuckets.set(maxMin, betterBuckets.get(maxMin) + 1);
+                assigned = true;
+            }
+            if(!assigned){
+                for(const [key,value] of betterBuckets){
+                    if(key !== maxMin && score >= key && score < (key + increment)){
+                        betterBuckets.set(key, value + 1);
+                        break;
                     }
                 }
-           }
+            }
         }
-        for(var[key,value]of betterBuckets){
+        for(const [key,value] of betterBuckets){
             if(value>modeCount){
                 modeCount=value;
                 mode = key+" to <"+(key+increment);

--- a/site/tests/unit/histogram_buckets.test.js
+++ b/site/tests/unit/histogram_buckets.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit test for histogram bucket aggregation (Issue #12410).
+ * Verifies that sum of bucket counts equals total students for any bucket size.
+ * Run: node site/tests/unit/histogram_buckets.test.js
+ */
+
+function fillBuckets(range, increment, betterBuckets, xValue, yValue, xBuckets, max, min) {
+    let loop = Math.ceil(range / increment);
+    if (increment === 1) {
+        loop += 1;
+    }
+    let tracking = min;
+    for (let i = 0; i < loop; i++) {
+        betterBuckets.set(tracking, 0);
+        tracking = +parseFloat(tracking + increment).toPrecision(4);
+        if (i === (loop - 1)) {
+            if (increment === 1) {
+                xBuckets.push(String(max));
+            } else {
+                xBuckets.push(+parseFloat(tracking - increment).toPrecision(4) + ' to <=' + max);
+            }
+        } else {
+            xBuckets.push(+parseFloat(tracking - increment).toPrecision(4) + ' to <' + tracking);
+        }
+    }
+    const maxMin = tracking - increment;
+    for (let i = 0; i < xValue.length; i++) {
+        const score = xValue[i];
+        let assigned = false;
+        if (score >= maxMin && score <= max) {
+            betterBuckets.set(maxMin, betterBuckets.get(maxMin) + 1);
+            assigned = true;
+        }
+        if (!assigned) {
+            for (const [key, value] of betterBuckets) {
+                if (key !== maxMin && score >= key && score < (key + increment)) {
+                    betterBuckets.set(key, value + 1);
+                    break;
+                }
+            }
+        }
+    }
+    for (const [key, value] of betterBuckets) {
+        yValue.push(value);
+    }
+}
+
+function runTest(name, xValue, min, max, bucketSizesToTest) {
+    const range = max - min;
+    let passed = 0;
+    let failed = 0;
+    for (const increment of bucketSizesToTest) {
+        const betterBuckets = new Map();
+        const yValue = [];
+        const xBuckets = [];
+        fillBuckets(range, increment, betterBuckets, xValue, yValue, xBuckets, max, min);
+        const sum = yValue.reduce((a, b) => a + b, 0);
+        const expected = xValue.length;
+        if (sum === expected) {
+            passed++;
+        } else {
+            failed++;
+            console.error(`  FAIL bucket size ${increment}: sum=${sum}, expected=${expected}`);
+        }
+    }
+    if (failed > 0) {
+        console.error(`FAIL ${name}: ${failed}/${bucketSizesToTest.length} bucket sizes wrong`);
+        return false;
+    }
+    console.log(`OK ${name}: total count correct for all ${bucketSizesToTest.length} bucket sizes`);
+    return true;
+}
+
+function main() {
+    console.log('Testing histogram bucket aggregation (fix for #12410)...\n');
+
+    let allPass = true;
+
+    // Test 1: Simple range, various bucket sizes (issue scenario)
+    const scores1 = [10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100];
+    const min1 = 10;
+    const max1 = 100;
+    const range1 = max1 - min1;
+    const defaultBucketSize = Math.floor(range1 / 10) || range1 / 10;
+    allPass &= runTest(
+        'Manual/Autograding-style (scores 10-100)',
+        scores1,
+        min1,
+        max1,
+        [1, 5, 10, defaultBucketSize, 15, 20, 25, 30, 50]
+    );
+
+    // Test 2: Smaller range, bucket larger than default
+    const scores2 = [0, 5, 10, 15, 20, 25, 30];
+    allPass &= runTest(
+        'Small range',
+        scores2,
+        0,
+        30,
+        [1, 3, 5, 10, 15]
+    );
+
+    // Test 3: Single value - in the app, min===max is handled in the template (no fillBuckets call).
+    // So we only test when range > 0.
+
+    // Test 3: Many scores, boundary-heavy (scores at bucket boundaries)
+    const scores4 = [];
+    for (let i = 0; i <= 100; i += 5) {
+        scores4.push(i);
+    }
+    allPass &= runTest(
+        'Scores on boundaries (0,5,...,100)',
+        scores4,
+        0,
+        100,
+        [10, 15, 20, 25, 33]
+    );
+
+    // Test 4: Float-like scores (toPrecision can create boundaries)
+    const scores5 = [10.1, 20.2, 30.3, 40.4, 50.5, 60.6, 70.7, 80.8, 90.9, 100];
+    allPass &= runTest(
+        'Decimal scores',
+        scores5,
+        10.1,
+        100,
+        [10, 15, 20, 25]
+    );
+
+    console.log('');
+    if (allPass) {
+        console.log('All tests passed. Histogram bucket total is correct for all tested cases.');
+        process.exit(0);
+    } else {
+        console.error('Some tests failed.');
+        process.exit(1);
+    }
+}
+
+main();


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12410

On the Statistics & Charts page, changing the histogram bucket size for Manual Grading,
Autograding, or Overall caused the total student count displayed to be incorrect. Scores
at bucket boundaries were double-counted (or dropped) because the loop never broke after
assigning a score to a bucket, allowing floating-point boundary overlap to match the same
score to more than one bucket.

### What is the New Behavior?
Each score is now assigned to exactly one bucket. The last bucket is checked first; all
other buckets use a `break` after a match. The sum of all bucket counts now always equals
the total number of students, regardless of the chosen bucket size.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Set up a course with several student submissions that have scores near bucket boundaries.
2. Open the Statistics & Charts page and change the histogram bucket size for Manual
   Grading or Autograding.
3. Before the fix: observe that the displayed total student count differs from the actual
   number of students.
4. After the fix: confirm the displayed total always equals the actual student count for
   every bucket size.

### Automated Testing & Documentation
A standalone Node.js unit test was added at:
  `site/tests/unit/histogram_buckets.test.js`

It verifies that the sum of bucket counts equals the student count across multiple bucket
sizes and datasets (boundary scores, decimal scores, small ranges).

Run with:
  node site/tests/unit/histogram_buckets.test.js

No documentation update required; this is an internal bug fix with no user-facing
behavior change beyond correct totals.

### Other information
- Not a breaking change.
- No migrations required.
- No security concerns.
