### PR TITLE
[Bugfix:Forum] Fix OP badge on anonymous toggle

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -101,9 +101,9 @@
 
         <span class="last-edit" data-testid="last-edit">
             {% if post_user_info.is_OP == true and first == false %}
-			    <strong class="post_user_id" data-testid="post-user-id" title="Original Poster">{{ visible_username }} <span style="color: var(--standard-medium-vibrant-blue);"><strong>OP</strong></span></strong>
+			    <strong class="post_user_id" data-testid="post-user-id" title="Original Poster"><span class="author-name">{{ visible_username }}</span> <span style="color: var(--standard-medium-vibrant-blue);"><strong>OP</strong></span></strong>
             {% else %}
-                <strong class="post_user_id" data-testid="post-user-id">{{ visible_username }}</strong>
+                <strong class="post_user_id" data-testid="post-user-id"><span class="author-name">{{ visible_username }}</span></strong>
             {% endif %}
             {% if post_user_info.pronouns and post_user_info.display_pronouns and visible_username !="Anonymous" %}
                 <strong class="post_user_pronouns" data-testid="post-user-pronouns">({{post_user_info.pronouns}})</strong>

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1024,17 +1024,21 @@ function openUrl(url) {
 }
 
 function changeName(element, user, visible_username, anon) {
-    const new_element = element.getElementsByTagName('strong')[0];
+    const new_element = element.getElementsByClassName('author-name')[0];
+    if (!new_element) {
+        return;
+    }
+
     // eslint-disable-next-line eqeqeq
     anon = anon == 'true';
     icon = element.getElementsByClassName('fas fa-eye')[0];
     if (icon === undefined) {
         icon = element.getElementsByClassName('fas fa-eye-slash')[0];
         if (anon) {
-            new_element.style.color = 'black';
+            new_element.style.removeProperty('color');
             new_element.style.fontStyle = 'normal';
         }
-        new_element.textContent = visible_username;
+        new_element.childNodes[0].nodeValue = visible_username;
         icon.className = 'fas fa-eye';
         icon.title = 'Show full user information';
     }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #11755

This change is necessary because toggling the anonymity of a student in the Instructor Discussion Forum (using the "eye" icon) causes the Original Poster (OP) badge to disappear from the DOM. Additionally, toggling back to "Anonymous" hardcodes the text color to black when the site is set to Dark Mode. 

### What is the New Behavior?
- The Original Poster (OP) badge is preserved and accurately displayed when revealing or hiding a student's real name.
- Toggling back to "Anonymous" on Dark Mode correctly inherits the default white text color instead of switching to pure black.
- [site/app/templates/forum/CreatePost.twig] now wraps `visible_username` inside a targeted `.author-name` span so JavaScript does not overwrite sibling elements (like the OP badge).
- [site/public/js/server.js] [changeName()] function now cleanly targets `.author-name` and removes the `color` property instead of overriding it, keeping CSS inheritance intact for dark mode.

Before:-
<img width="1153" height="560" alt="image" src="https://github.com/user-attachments/assets/220ccfd9-a3f2-4823-ab76-b3af40616c6c" />

After:-
<img width="1909" height="900" alt="image" src="https://github.com/user-attachments/assets/1746147a-cdf6-403c-942b-11b5cc05a876" />
<img width="1909" height="900" alt="image" src="https://github.com/user-attachments/assets/54de9bb4-4b8f-496a-ad73-41b9bd6fd780" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open up the Submitty instance as an instructor.
2. Ensure you have the site set to Dark Mode.
3. Locate an anonymous post/thread on the Discussion Forum where the anonymous user is the Original Poster.
4. Click the 'eye' icon to deanonymize the student.
5. Verify the "OP" badge remains visible next to the student's real name.
6. Click the 'eye' icon again to return the status to "Anonymous".
7. Verify that the word "Anonymous" returns to the standard white color, instead of changing to black text.

### Automated Testing & Documentation
N/A - This is a CSS and DOM structure change that requires manual UI verification in the browser to confirm dark/light mode behavior.

### Other information
This is not a breaking change.
No migrations are required.
No security concerns.