### PR TITLE
Update ThreadPostForm.twig

### DIFF
--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -185,6 +185,7 @@
             <input type="checkbox" class="thread-anon-checkbox" data-testid="thread-anon-checkbox" {% if anon_edit_post_id is defined and anon_edit_post_id %} id="{{ anon_edit_post_id }}"{% endif %} aria-label="Anonymous (to class)?" name="Anon" value="Anon" data-ays-ignore="true"/>
             <label>Anonymous (to class) </label>
         {% endif %}
+
         {% if show_announcement is defined and show_announcement and core.getUser().accessFullGrading() %}
             {% set announcement_text = email_enabled ? "Notify students (w/email)" : "Notify students" %}
             <input type="checkbox" class="pinThread-checkbox" name="pinThread" id="pinThread" value="pinThread" data-ays-ignore="true"/>
@@ -192,6 +193,20 @@
             <input type="checkbox" id="Announcement" class="thread-announcement-checkbox" name="Announcement" value="Announcement" data-ays-ignore="true"/>
             <label class="inline-block" for="Announcement">{{ announcement_text }}</label>
         {% endif %}
+
+  {% if show_reply_announcement is defined and show_reply_announcement and core.getUser().accessFullGrading() %}
+            {% set announcement_text = email_enabled ? "Notify students (w/email)" : "Notify students" %}
+            <input type="checkbox"
+                   id="replyAnnouncement"
+                   name="replyAnnouncement"
+                   value="replyAnnouncement"
+                   data-ays-ignore="true"/>
+            <label class="inline-block" for="replyAnnouncement">
+                 {{ announcement_text }} (reply announcement)
+            </label>
+        {% endif %}
+
+
         {% if show_expiration is defined and show_expiration and core.getUser().accessFullGrading() %}
             <div id="pin-expiration-date">
               <label class="inline-block" for="expirationDate" style="margin-left: 15px;">{{ "Expiration Date" }}</label>


### PR DESCRIPTION
Fixes #12333

## What does this PR do?
Adds a checkbox option in the forum reply form that allows  teaching staff to send a reply on a pinned thread as an  announcement to all students via email/notification.

## Changes made
- Added new checkbox in ThreadPostForm.twig that appears  only for instructors/TAs when replying to a pinned thread

## Why?
Currently if an instructor replies to a pinned announcement  thread, students don't get notified. This fix allows them  to force send that reply as an announcement.