### PR TITLE
[UI/UX:Various] Add standardized message banner CSS foundation

### DIFF
--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -1,5 +1,5 @@
 {% if rainbow_grade_active is defined and not rainbow_grade_active %}
-    <div class="content warning-banner" data-testid="rainbow-grades-not-active-banner">
+    <div class="submitty-banner submitty-banner-warning" data-testid="rainbow-grades-not-active-banner">
         <p>Rainbow Grades are not available to students.</p>
         <p>You can choose to toggle it on within the <a href="{{ config_url }}">course settings.</a></p>
     </div>

--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -2,12 +2,8 @@
 
 {% if messages|length > 0 %}
 {# WRAP THE LATE DAY INFORMATION IN A DIV #}
-<div class="content"
-    {% if error %}
-        style="background-color: var(--standard-light-red);"
-    {% endif %}
->
-    <h4>
+<div class="submitty-banner {% if error %}submitty-banner-danger{% else %}submitty-banner-warning{% endif %}">
+    <h4 class="submitty-banner-title">
         {% for message in messages %}
             {% if message.type == 'extension' %}
                 You have a {{ message.info.extensions }} day deadline extension for this assignment.

--- a/site/composer.json
+++ b/site/composer.json
@@ -44,7 +44,7 @@
     "php-mock/php-mock-phpunit": "2.15.0",
     "phpstan/phpstan": "2.1.38",
     "phpstan/phpstan-deprecation-rules": "2.0.3",
-    "phpstan/phpstan-doctrine": "2.0.12",
+    "phpstan/phpstan-doctrine": "2.0.17",
     "phpstan/phpstan-strict-rules": "2.0.8",
     "phpunit/phpunit": "10.5.62",
     "submitty/php-codesniffer": "3.0.1",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63978b05dc0468928dd9eebd6a9dc738",
+    "content-hash": "fcae34ccc1bf38ffedea1fd1b300fbe9",
     "packages": [
         {
             "name": "brick/math",
@@ -6346,21 +6346,21 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.12",
+            "version": "2.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "d20ee0373d22735271f1eb4d631856b5f847d399"
+                "reference": "734ef36c2709b51943f04aacadddb76f239562d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/d20ee0373d22735271f1eb4d631856b5f847d399",
-                "reference": "d20ee0373d22735271f1eb4d631856b5f847d399",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/734ef36c2709b51943f04aacadddb76f239562d3",
+                "reference": "734ef36c2709b51943f04aacadddb76f239562d3",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.13"
+                "phpstan/phpstan": "^2.1.34"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
@@ -6411,11 +6411,14 @@
                 "MIT"
             ],
             "description": "Doctrine extensions for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.12"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.17"
             },
-            "time": "2025-12-01T11:34:02+00:00"
+            "time": "2026-02-18T10:21:23+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -112,6 +112,19 @@
     --standard-light-blue: #99ccff;
     --standard-light-seafoam: #a4dad5;
 
+    --banner-info-bg: var(--alert-background-blue);
+    --banner-info-border: var(--alert-border-blue);
+    --banner-info-text: var(--alert-info-blue);
+    --banner-warning-bg: var(--alert-background-warning-yellow);
+    --banner-warning-border: var(--alert-border-yellow);
+    --banner-warning-text: var(--alert-warning-yellow);
+    --banner-success-bg: var(--alert-background-success-green);
+    --banner-success-border: var(--alert-border-success-green);
+    --banner-success-text: var(--alert-success-green);
+    --banner-danger-bg: var(--alert-background-danger-red);
+    --banner-danger-border: var(--alert-border-danger-red);
+    --banner-danger-text: var(--alert-danger-red);
+
     /* the look of the webpage itself */
     --background-blue: #f6fbfe;
     --main-body-white: #ffffff;
@@ -122,8 +135,10 @@
     --focus-dropdown: #f5f5f5;
 
     /* text and fonts */
-    --text-black: #000000; /* use only on white/background-blue */
-    --text-white: #ffffff; /* use on all colors */
+    --text-black: #000000;
+    /* use only on white/background-blue */
+    --text-white: #ffffff;
+    /* use on all colors */
     --btn-text-white: #ffffff;
     --btn-text-black: #000000;
     --btn-default-text: #2e2e2e;
@@ -131,7 +146,8 @@
     /* discussion forum */
     --deleted-and-unviewed-thread: #acc0d7;
     --deleted-discussion-post-grey: #dcdcdc;
-    --important-post: #ffd700; /* is also for star color */
+    --important-post: #ffd700;
+    /* is also for star color */
     --attachment-box-color: #f5f5f5;
     --file-upload-table-hover: #d1d1d1;
     --upduck-yellow: #f5bd41;
@@ -199,16 +215,14 @@
     --category-color-20: #c0c246;
 
     /* rainbow */
-    --rainbow-gradient: linear-gradient(
-        135deg,
-        rgb(255 0 0 / 30%),
-        rgb(255 255 0 / 30%),
-        rgb(0 255 0 / 30%),
-        rgb(0 255 155 / 30%),
-        rgb(0 0 255 / 30%),
-        rgb(255 0 255 / 30%),
-        rgb(255 0 0 / 30%)
-    );
+    --rainbow-gradient: linear-gradient(135deg,
+            rgb(255 0 0 / 30%),
+            rgb(255 255 0 / 30%),
+            rgb(0 255 0 / 30%),
+            rgb(0 255 155 / 30%),
+            rgb(0 0 255 / 30%),
+            rgb(255 0 255 / 30%),
+            rgb(255 0 0 / 30%));
 
     /* poll histogram colors */
     --histogram-default: var(--standard-vibrant-dark-blue);
@@ -255,6 +269,19 @@
     --diff-background-expected: #122816;
     --diff-char-background-actual: #f26b6c;
     --diff-char-background-expected: #47c73b;
+
+    --banner-info-bg: #687379;
+    --banner-info-border: #2b5e68;
+    --banner-info-text: #9dd0de;
+    --banner-warning-bg: #805b02;
+    --banner-warning-border: #996d02;
+    --banner-warning-text: #f2e3b5;
+    --banner-success-bg: #1e4d2e;
+    --banner-success-border: #2a6640;
+    --banner-success-text: #8acc9a;
+    --banner-danger-bg: #5a1a1a;
+    --banner-danger-border: #7a2020;
+    --banner-danger-text: #f4a0a0;
 }
 
 [data-theme="dark"] {
@@ -292,6 +319,19 @@
     --standard-light-green: #427742;
     --standard-pastel-blue: #2f6580;
 
+    --banner-info-bg: #687379;
+    --banner-info-border: #2b5e68;
+    --banner-info-text: #9dd0de;
+    --banner-warning-bg: #805b02;
+    --banner-warning-border: #996d02;
+    --banner-warning-text: #f2e3b5;
+    --banner-success-bg: #1e4d2e;
+    --banner-success-border: #2a6640;
+    --banner-success-text: #8acc9a;
+    --banner-danger-bg: #5a1a1a;
+    --banner-danger-border: #7a2020;
+    --banner-danger-text: #f4a0a0;
+
     /* the look of the webpage itself */
     --background-blue: #202225;
     --main-body-white: #ffffff;
@@ -302,8 +342,10 @@
     --focus-dropdown: #f5f5f5;
 
     /* text and fonts */
-    --text-black: #ffffff; /* use only on white/background-blue */
-    --text-white: #000000; /* use on all colors */
+    --text-black: #ffffff;
+    /* use only on white/background-blue */
+    --text-white: #000000;
+    /* use on all colors */
     --btn-text-white: #ffffff;
     --btn-text-black: #000000;
     --btn-default-text: #ffffff;

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -14,7 +14,7 @@ a,
 a:visited,
 a:link,
 a.fa:hover,
-a > i.fa:hover {
+a>i.fa:hover {
     color: var(--external-link-blue);
 }
 
@@ -22,7 +22,7 @@ a,
 a:visited,
 a:link,
 a.fas:hover,
-a > i.fas:hover {
+a>i.fas:hover {
     color: var(--external-link-blue);
 }
 
@@ -30,7 +30,7 @@ a,
 a:visited,
 a:link,
 a.far:hover,
-a > i.far:hover {
+a>i.far:hover {
     color: var(--external-link-blue);
 }
 
@@ -49,9 +49,9 @@ a.btn-danger,
 a.fa.btn-success,
 a.btn-primary,
 a.btn-danger,
-a.btn-success > i.fa,
-a.btn-primary > i.fa,
-a.btn-danger > i.fa {
+a.btn-success>i.fa,
+a.btn-primary>i.fa,
+a.btn-danger>i.fa {
     color: var(--btn-text-white);
 }
 
@@ -61,9 +61,9 @@ a.btn-danger,
 a.fas.btn-success,
 a.btn-primary,
 a.btn-danger,
-a.btn-success > i.fas,
-a.btn-primary > i.fas,
-a.btn-danger > i.fas {
+a.btn-success>i.fas,
+a.btn-primary>i.fas,
+a.btn-danger>i.fas {
     color: var(--btn-text-white);
 }
 
@@ -73,31 +73,32 @@ a.btn-danger,
 a.far.btn-success,
 a.btn-primary,
 a.btn-danger,
-a.btn-success > i.far,
-a.btn-primary > i.far,
-a.btn-danger > i.far {
+a.btn-success>i.far,
+a.btn-primary>i.far,
+a.btn-danger>i.far {
     color: var(--btn-text-white);
 }
+
 /* stylelint-enable no-duplicate-selectors */
 
 a.btn-default,
 a.fa.btn-default,
 a.fa,
-a > i.fa {
+a>i.fa {
     color: var(--btn-default-text);
 }
 
 a.btn-default,
 a.fas.btn-default,
 a.fas,
-a > i.fas {
+a>i.fas {
     color: var(--btn-default-text);
 }
 
 a.btn-default,
 a.far.btn-default,
 a.far,
-a > i.far {
+a>i.far {
     color: var(--btn-default-text);
 }
 
@@ -232,8 +233,8 @@ input[type="checkbox"]:checked::before {
 
 .fa-question-circle.disabled,
 .fa-question-circle[disabled],
-.disabled > .fa-question-circle,
-[disabled] > .fa-question-circle {
+.disabled>.fa-question-circle,
+[disabled]>.fa-question-circle {
     /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
     font-family: "Font Awesome 5 Free";
     color: var(--standard-light-gray);
@@ -321,16 +322,16 @@ table tr.table-header {
     border-radius: 4px;
 }
 
-.table-striped > tbody > tr:nth-child(even) {
+.table-striped>tbody>tr:nth-child(even) {
     background: var(--standard-hover-light-gray);
 }
 
-.table-striped > tbody > tr:nth-child(odd) {
+.table-striped>tbody>tr:nth-child(odd) {
     background: var(--default-white);
 }
 
-.table > thead > tr,
-.table > tfoot > tr {
+.table>thead>tr,
+.table>tfoot>tr {
     background: var(--standard-hover-light-gray);
 }
 
@@ -340,7 +341,7 @@ tr.info th {
     background-color: var(--alert-border-blue);
 }
 
-td > a.active-sort {
+td>a.active-sort {
     text-decoration: underline;
     font-weight: bold;
 }
@@ -352,13 +353,13 @@ td > a.active-sort {
     visibility: hidden;
 }
 
-.floating-thead > td,
-.floating-header > td {
+.floating-thead>td,
+.floating-header>td {
     display: table-cell;
     text-align: center;
 }
 
-.tr-vertically-centered > td {
+.tr-vertically-centered>td {
     vertical-align: middle;
 }
 
@@ -370,12 +371,12 @@ td > a.active-sort {
     border: none;
 }
 
-.table-text-left > tbody > tr > td:nth-child(3),
-.table-text-left > tbody > tr > td:nth-child(4),
-.table-text-left > tbody > tr > td:nth-child(5),
-.table-text-left > thead > tr > th:nth-child(3),
-.table-text-left > thead > tr > th:nth-child(4),
-.table-text-left > thead > tr > th:nth-child(5) {
+.table-text-left>tbody>tr>td:nth-child(3),
+.table-text-left>tbody>tr>td:nth-child(4),
+.table-text-left>tbody>tr>td:nth-child(5),
+.table-text-left>thead>tr>th:nth-child(3),
+.table-text-left>thead>tr>th:nth-child(4),
+.table-text-left>thead>tr>th:nth-child(5) {
     text-align: left;
 }
 
@@ -488,7 +489,8 @@ td > a.active-sort {
 
 .clear {
     clear: both;
-    border-bottom: 1px solid var(--standard-light-gray); /* same color, saw no need to make 2 vars */
+    border-bottom: 1px solid var(--standard-light-gray);
+    /* same color, saw no need to make 2 vars */
     padding-top: 20px;
 }
 
@@ -537,20 +539,20 @@ td > a.active-sort {
     font-style: italic;
 }
 
-.option-input > textarea,
-.option-input > input[type="text"] {
+.option-input>textarea,
+.option-input>input[type="text"] {
     width: 95%;
     resize: none;
 }
 
-.option-small-input > textarea,
-.option-small-input > input[type="text"] {
+.option-small-input>textarea,
+.option-small-input>input[type="text"] {
     width: 99%;
     padding-right: 1px;
     padding-left: 1px;
 }
 
-.option-small-output > input[type="text"] {
+.option-small-output>input[type="text"] {
     width: 99%;
     padding-right: 1px;
     padding-left: 1px;
@@ -687,15 +689,15 @@ td > a.active-sort {
     margin-left: 0;
 }
 
-.box-title > h4 {
+.box-title>h4 {
     margin-left: 90px;
 }
 
-.box-title > h4 > code {
+.box-title>h4>code {
     overflow-wrap: break-word;
 }
 
-.box-title-total > h4 {
+.box-title-total>h4 {
     margin-left: 20px;
     margin-top: 8px;
     margin-bottom: 8px;
@@ -710,13 +712,13 @@ td > a.active-sort {
     margin-bottom: 25px;
 }
 
-.box > h4 {
+.box>h4 {
     margin-bottom: 10px;
     margin-left: 10px;
     margin-top: 10px;
 }
 
-.box > h4 > code {
+.box>h4>code {
     overflow-wrap: break-word;
     padding-left: 50px;
 }
@@ -729,12 +731,12 @@ td > a.active-sort {
     flex-wrap: wrap;
 }
 
-.box-block > h4 {
+.box-block>h4 {
     margin-bottom: 10px;
 }
 
-.box-block > code,
-.box-block > pre {
+.box-block>code,
+.box-block>pre {
     padding: 10px;
     background-color: var(--standard-pale-gray);
     border: 1px solid var(--standard-light-gray);
@@ -753,7 +755,7 @@ td > a.active-sort {
     margin-right: 2px;
 }
 
-.diff-element > h4 {
+.diff-element>h4 {
     white-space: nowrap;
 }
 
@@ -803,6 +805,67 @@ td > a.active-sort {
 .dark-green-background {
     background-color: var(--good-green);
     color: var(--btn-text-black);
+}
+
+.submitty-banner {
+    padding: 15px;
+    margin: 10px 0;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    font-weight: 400;
+    text-align: left;
+}
+
+.submitty-banner-title {
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.submitty-banner p {
+    margin-bottom: 0.5rem;
+}
+
+.submitty-banner p:last-child {
+    margin-bottom: 0;
+}
+
+.submitty-banner ul,
+.submitty-banner ol {
+    margin-left: 1.5rem;
+}
+
+.submitty-banner a,
+.submitty-banner a:visited {
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+.submitty-banner a:hover {
+    opacity: 0.8;
+}
+
+.submitty-banner-info {
+    background-color: var(--banner-info-bg);
+    color: var(--banner-info-text);
+    border-color: var(--banner-info-border);
+}
+
+.submitty-banner-warning {
+    background-color: var(--banner-warning-bg);
+    color: var(--banner-warning-text);
+    border-color: var(--banner-warning-border);
+}
+
+.submitty-banner-success {
+    background-color: var(--banner-success-bg);
+    color: var(--banner-success-text);
+    border-color: var(--banner-success-border);
+}
+
+.submitty-banner-danger {
+    background-color: var(--banner-danger-bg);
+    color: var(--banner-danger-text);
+    border-color: var(--banner-danger-border);
 }
 
 .dark-yellow-background {
@@ -949,8 +1012,8 @@ tbody.collapse.in {
 
 .btn-primary:active,
 .btn-primary.active,
-.show > .dropdown-toggle.btn-primary,
-.open > .dropdown-toggle.btn-primary {
+.show>.dropdown-toggle.btn-primary,
+.open>.dropdown-toggle.btn-primary {
     color: var(--default-white);
     background-color: var(--hover-actionable-blue);
     border-color: var(--hover-border-actionable-blue);
@@ -958,16 +1021,16 @@ tbody.collapse.in {
 
 .btn-primary:active:hover,
 .btn-primary.active:hover,
-.show > .dropdown-toggle.btn-primary:hover,
-.open > .dropdown-toggle.btn-primary:hover,
+.show>.dropdown-toggle.btn-primary:hover,
+.open>.dropdown-toggle.btn-primary:hover,
 .btn-primary:active:focus,
 .btn-primary.active:focus,
-.show > .dropdown-toggle.btn-primary:focus,
-.open > .dropdown-toggle.btn-primary:focus,
+.show>.dropdown-toggle.btn-primary:focus,
+.open>.dropdown-toggle.btn-primary:focus,
 .btn-primary:active.focus,
 .btn-primary.active.focus,
-.show > .dropdown-toggle.btn-primary.focus,
-.open > .dropdown-toggle.btn-primary.focus {
+.show>.dropdown-toggle.btn-primary.focus,
+.open>.dropdown-toggle.btn-primary.focus {
     color: var(--default-white);
     background-color: var(--hover-border-actionable-blue);
     border-color: var(--hover-dark-border-actionable-blue);
@@ -976,8 +1039,8 @@ tbody.collapse.in {
 /* stylelint-disable-next-line no-duplicate-selectors */
 .btn-primary:active,
 .btn-primary.active,
-.show > .dropdown-toggle.btn-primary,
-.open > .dropdown-toggle.btn-primary {
+.show>.dropdown-toggle.btn-primary,
+.open>.dropdown-toggle.btn-primary {
     background-image: none;
 }
 
@@ -999,7 +1062,7 @@ fieldset[disabled] .btn-primary.focus {
     background-color: var(--default-white);
 }
 
-.panel-heading > .dropdown .dropdown-toggle {
+.panel-heading>.dropdown .dropdown-toggle {
     color: inherit;
 }
 
@@ -1275,7 +1338,7 @@ body.no-scroll {
     padding-right: initial;
 }
 
-.popup-form > div > input[type="text"] {
+.popup-form>div>input[type="text"] {
     width: 95%;
 }
 
@@ -1356,7 +1419,7 @@ body.no-scroll {
     border-radius: 4px;
 }
 
-.meter > span {
+.meter>span {
     display: block;
     height: 100%;
     background-color: var(--good-green);
@@ -1425,7 +1488,8 @@ end of styles used in the admin gradeable page
 .grading-example-circle {
     width: 15px;
     height: 15px;
-    border-radius: 50%; /* Makes the element a circle */
+    border-radius: 50%;
+    /* Makes the element a circle */
     display: inline-block;
 }
 
@@ -1440,27 +1504,28 @@ end of styles used in the admin gradeable page
 /* color for limited access graders who were verifed */
 .grader-verified {
     /* yellow       green   */
-    background: linear-gradient(
-        to right,
-        var(--standard-vibrant-yellow) 50%,
-        var(--standard-vibrant-green) 50%
-    );
+    background: linear-gradient(to right,
+            var(--standard-vibrant-yellow) 50%,
+            var(--standard-vibrant-green) 50%);
 }
 
 /* color for student/peer grading */
 .grader-4 {
-    background-color: var(--standard-plum-purple); /* purple */
+    background-color: var(--standard-plum-purple);
+    /* purple */
 }
 
 /* color for a limited access grader */
 .grader-3 {
-    background-color: var(--important-post); /* yellow */
+    background-color: var(--important-post);
+    /* yellow */
 }
 
 /* color for an instructor or full access grader */
 .grader-2,
 .grader-1 {
-    background-color: var(--standard-vibrant-green); /* green */
+    background-color: var(--standard-vibrant-green);
+    /* green */
 }
 
 .hide-highlights {
@@ -1469,7 +1534,8 @@ end of styles used in the admin gradeable page
 
 /* color for double graded */
 .grader-double {
-    background-color: var(--standard-vibrant-dark-blue); /* dark blue */
+    background-color: var(--standard-vibrant-dark-blue);
+    /* dark blue */
 }
 
 .grader-grade-inquiry {
@@ -1571,7 +1637,7 @@ end of styles used in the admin gradeable page
     border: 1px solid var(--text-black);
 }
 
-.wrapper-layout-header > th {
+.wrapper-layout-header>th {
     padding: 4px;
     border: 1px solid var(--text-black);
 }
@@ -1610,7 +1676,7 @@ end of styles used in the admin gradeable page
     padding: 0.75rem;
 }
 
-#details-legend > li {
+#details-legend>li {
     list-style: none;
     font-size: 0.75em;
 }
@@ -1699,7 +1765,7 @@ end of styles used in the admin gradeable page
 }
 
 .black-btn,
-.black-btn > i {
+.black-btn>i {
     /* stylelint-disable-next-line declaration-no-important */
     color: var(--text-black) !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -1708,8 +1774,8 @@ end of styles used in the admin gradeable page
 }
 
 .black-btn:hover,
-.black-btn:hover > i,
-.black-btn > i:hover {
+.black-btn:hover>i,
+.black-btn>i:hover {
     /* stylelint-disable-next-line declaration-no-important */
     color: #405e90 !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -1717,8 +1783,8 @@ end of styles used in the admin gradeable page
 }
 
 .black-btn:active,
-.black-btn:active > i,
-.black-btn > i:active {
+.black-btn:active>i,
+.black-btn>i:active {
     /* stylelint-disable-next-line declaration-no-important */
     color: var(--external-link-active) !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -1737,7 +1803,7 @@ end of styles used in the admin gradeable page
     flex-direction: column;
 }
 
-.flex-col-space > * {
+.flex-col-space>* {
     margin: 10px 0;
 }
 
@@ -1799,7 +1865,7 @@ end of styles used in the admin gradeable page
     width: 100%;
 }
 
-.btn-wrapper > .btn {
+.btn-wrapper>.btn {
     flex: 1 0 90%;
     margin: 5px 0 0 5px;
 }
@@ -1825,7 +1891,7 @@ header {
     flex-wrap: wrap;
 }
 
-header > * {
+header>* {
     margin-bottom: 20px;
 }
 
@@ -1893,7 +1959,7 @@ header > * {
         width: max-content;
     }
 
-    .btn-wrapper > .btn {
+    .btn-wrapper>.btn {
         flex: 1 0 auto;
     }
 
@@ -1936,18 +2002,21 @@ header > * {
     height: 120px;
     align-content: center;
     animation: spin 2s linear infinite;
-    position: fixed; /* Sit on top of the page content */
-    background-color: var(
-        --black-moderately-transparent
-    ); /* Black background with opacity */
-    z-index: 999; /* Specify a stack order in case you're using a different order for other elements */
-    cursor: pointer; /* Add a pointer on hover */
+    position: fixed;
+    /* Sit on top of the page content */
+    background-color: var(--black-moderately-transparent);
+    /* Black background with opacity */
+    z-index: 999;
+    /* Specify a stack order in case you're using a different order for other elements */
+    cursor: pointer;
+    /* Add a pointer on hover */
 }
 
 @keyframes spin {
     0% {
         transform: rotate(0deg);
     }
+
     100% {
         transform: rotate(360deg);
     }
@@ -1977,11 +2046,9 @@ header > * {
 }
 
 .custom-file-input:active::before {
-    background: linear-gradient(
-        to bottom,
-        var(--standard-light-gray),
-        var(--standard-pale-gray)
-    );
+    background: linear-gradient(to bottom,
+            var(--standard-light-gray),
+            var(--standard-pale-gray));
 }
 
 .mermaid-element {
@@ -2068,15 +2135,15 @@ Start of slider switch
     transition: 0.4s;
 }
 
-input:checked + .slider {
+input:checked+.slider {
     background-color: var(--good-green);
 }
 
-input:checked + .slider::before {
+input:checked+.slider::before {
     transform: translateX(1.3em);
 }
 
-input:checked + .slider::after {
+input:checked+.slider::after {
     left: 1.75em;
 }
 


### PR DESCRIPTION
Adds a foundation for standardized message banners across Submitty, as requested in #12431.

**Changes:**
- `colors.css`: Added semantic color variables for info/warning/success/danger banners in both light and dark mode.
- `server.css`: Added reusable `.submitty-banner` and variant modifier classes (`.submitty-banner-info`, `.submitty-banner-warning`, `.submitty-banner-success`, `.submitty-banner-danger`).
- `LateDayMessage.twig`, `RainbowGrades.twig`: Migrated as pilot pages to verify the new styles.

Part of #12431. Further migration of existing banners (Office Hours Queue, etc.) will follow in a separate PR.

