### PR TITLE
[Bugfix:System] Fix Sign Up form clearing fields on error

### DIFF
--- a/site/app/templates/CreateNewAccount.twig
+++ b/site/app/templates/CreateNewAccount.twig
@@ -1,6 +1,10 @@
 {% set user_id_reqs = requirements["user_id_requirements"] %}
 {% set name_reqs = requirements["user_id_requirements"]["name_requirements"] %}
 {% set email_reqs = requirements["user_id_requirements"]["email_requirements"] %}
+<script>
+    var acceptedEmails = {{ requirements["accepted_emails"] | json_encode | raw }};
+    var userIdRequirements = {{ user_id_reqs | json_encode | raw }};
+</script>
 <div class="content shadow" id="login-box">
     <div id="login-guest">
         <h1> Sign Up <a target=_blank href="https://submitty.org/student/self_account_creation">
@@ -78,6 +82,10 @@
             Confirm Password
             <input type="password" name="confirm_password" data-testid="confirm-password" required id="confirm-password-input" onblur="checkPasswordsMatch()" />
         </div>
-        <input type="submit" name="signup" value="Sign Up" class="btn signup-btn btn-primary" data-testid="sign-up-button" />
+        <input type="submit" name="signup" value="Sign Up" class="btn signup-btn btn-primary" data-testid="sign-up-button" onclick="
+            if (!validateSignupForm(acceptedEmails, userIdRequirements)) {
+                event.preventDefault();
+            }
+        " />
     </form>
 </div>

--- a/site/public/js/authentication.js
+++ b/site/public/js/authentication.js
@@ -1,4 +1,4 @@
-/* exported showRequirements, checkPasswordsMatch  */
+/* exported showRequirements, checkPasswordsMatch, validateSignupForm  */
 /* global displayErrorMessage */
 function showRequirements(id_string) {
     $(`#${id_string}-helper`).toggle();
@@ -9,4 +9,24 @@ function checkPasswordsMatch() {
         $('#confirm-password-input').val('');
         displayErrorMessage('Passwords do not match');
     }
+}
+
+function validateSignupForm(acceptedEmails, userIdRequirements) {
+    const email = $('input[name="email"]').val().trim();
+    const userId = $('input[name="user_id"]').val().trim();
+
+    // Validate email extension
+    const emailParts = email.split('@');
+    if (emailParts.length < 2 || !acceptedEmails.includes(emailParts[emailParts.length - 1])) {
+        displayErrorMessage('This email is not accepted.');
+        return false;
+    }
+
+    // Validate user ID length
+    if (userId.length < userIdRequirements.min_length || userId.length > userIdRequirements.max_length) {
+        displayErrorMessage('This user id does not meet the requirements.');
+        return false;
+    }
+
+    return true;
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #12490 

When email or user ID validation fails on the Sign Up form, the server-side redirect clears all fields, forcing users to re-enter everything. This is frustrating, especially when only one field is invalid.

### What is the New Behavior?

Added client-side validation for email and user ID fields on the Sign Up form. Invalid inputs are now caught before the form submits, so the page stays put and all fields are preserved. Error messages match the existing server-side messages.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Go to `localhost:1511/authentication/create_account`
2. Fill in all fields
3. Use an email with an unaccepted domain (e.g., `test@invalid.com`) → error toast appears, fields are preserved
4. Use a user ID shorter than the minimum length → error toast appears, fields are preserved
5. Verify that valid submissions still work normally

### Automated Testing & Documentation


### Other information


