### PR TITLE
[Bugfix:Autograding] Fix Regrade Team Classification Check

### DIFF
--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -203,6 +203,11 @@ def main():
                     datastore = json.load(build_configuration)
                     required_capabilities = datastore.get('required_capabilities', 'default')
                     max_grading_time = datastore.get('max_possible_grading_time', -1)
+                    is_team_assignment = datastore.get('team_assignment', False)
+                    if not isinstance(is_team_assignment, bool):
+                        raise SystemExit(
+                            "ERROR: build config field 'team_assignment' must be a boolean for gradeable '{}'".format(my_gradeable)
+                        )
 
                 #get the current time
                 queue_time = dateutils.write_submitty_date()
@@ -213,15 +218,14 @@ def main():
                     raise SystemExit("ERROR: path reconstruction failed")
                 # add them to the queue
 
-                # FIXME: This will be incorrect if the username includes an underscore
-                if '_' not in my_who:
-                    my_user = my_who
-                    my_team = ""
-                    my_is_team = False
-                else:
+                if is_team_assignment:
                     my_user = ""
                     my_team = my_who
                     my_is_team = True
+                else:
+                    my_user = my_who
+                    my_team = ""
+                    my_is_team = False
 
                 # Note: If the initial checkout failed, or if
                 # autograding failed to create a results subdirectory

--- a/bin/regrade.py
+++ b/bin/regrade.py
@@ -204,10 +204,6 @@ def main():
                     required_capabilities = datastore.get('required_capabilities', 'default')
                     max_grading_time = datastore.get('max_possible_grading_time', -1)
                     is_team_assignment = datastore.get('team_assignment', False)
-                    if not isinstance(is_team_assignment, bool):
-                        raise SystemExit(
-                            "ERROR: build config field 'team_assignment' must be a boolean for gradeable '{}'".format(my_gradeable)
-                        )
 
                 #get the current time
                 queue_time = dateutils.write_submitty_date()


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12423  

### What is the New Behavior?
Instead of relying on checking underscore as a method to distinguish team vs user submissions, use the team_assignment boolean as the absolute source of truth. 
 
### What steps should a reviewer take to reproduce or test the bug or new feature?
Create individual and team gradeables, which has two instances each where who has an underscore in it. ie(jane_doe) - this would be 4 total gradeables 
run regrade.py on each of these gradeables. 
check the jsons in the to be graded queue, and verify that the regrader has correctly identified each gradable's team/individual status

### Automated Testing & Documentation
No automated testing or documentation fixed 

### Other information
N/A