### PR TITLE
[Refactor:System] Add job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   ansible-lint:
     name: Ansible Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Run ansible-lint
@@ -41,6 +42,7 @@ jobs:
   css-lint:
     name: CSS Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -66,6 +68,7 @@ jobs:
   js-lint:
     name: JavaScript Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -91,6 +94,7 @@ jobs:
   js-unit:
     name: JavaScript Unit
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -119,6 +123,7 @@ jobs:
   twig-lint:
     name: Twig Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -146,6 +151,7 @@ jobs:
   php-lint:
     name: PHP Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -182,6 +188,7 @@ jobs:
   php-unit:
     name: PHP Unit
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: site
@@ -218,6 +225,7 @@ jobs:
   python-lint:
     name: Python Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -240,6 +248,7 @@ jobs:
   python-unit:
     name: Python Unit
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -325,6 +334,7 @@ jobs:
   yaml-lint:
     name: YAML Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: install yamllint
@@ -336,6 +346,7 @@ jobs:
   shellcheck:
     name: Shell Lint
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: install ShellCheck
@@ -347,6 +358,7 @@ jobs:
   colors-css:
     name: colors.css Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
 
     steps:
       - name: Checkout main branch
@@ -391,6 +403,7 @@ jobs:
   db-check:
     name: DB Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     env:
       PGPASSWORD: submitty_dbuser
       MAIN_INSTALL_PATH: ${{ github.WORKSPACE }}/main
@@ -645,6 +658,7 @@ jobs:
   Cypress-System:
     name: Cypress (System)
     runs-on: ubuntu-22.04
+    timeout-minutes: 40
     services:
       postgres:
         image: postgres
@@ -825,6 +839,7 @@ jobs:
 
   Cypress:
     runs-on: ubuntu-22.04
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -906,6 +921,7 @@ jobs:
   Integration:
     name: Integration
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     # Postgres should not be needed for the integration tests.
     # But unfortunately Configure test suite seems to use it at the moment, and
     # Configure test suite seems to be necessary for the Integration tests
@@ -935,6 +951,7 @@ jobs:
   ansible-ci:
     name: Ansible Install
     runs-on: ubuntu-22.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
       - name: Setup SSH


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12494

The 17 CI jobs in [ci.yml](cci:7://file:///c:/Users/BIT/Desktop/Submitty/.github/workflows/ci.yml:0:0-0:0) do not have explicit `timeout-minutes` configuration. They rely on GitHub Actions' default timeout of **6 hours**, which means hung jobs (e.g., during dependency installation, Cypress E2E tests, or Ansible provisioning) can silently waste significant CI minutes before failing.

This is especially risky for heavy jobs like `Cypress-System` (runs multiple auth suites), `Cypress` (7-container matrix), `Integration`, and `ansible-ci` all of which involve full system setup, Postgres services, and browser-based testing.

### What is the New Behavior?

Added `timeout-minutes` to all 17 jobs in [.github/workflows/ci.yml](cci:7://file:///c:/Users/BIT/Desktop/Submitty/.github/workflows/ci.yml:0:0-0:0). Timeout values are set slightly above expected execution times to account for normal variance while preventing excessive resource usage during a hang:

| Job | Type | Timeout |
|-----|------|---------|
| `ansible-lint` | Lint | 10 min |
| `css-lint` | Lint | 10 min |
| `js-lint` | Lint | 10 min |
| `js-unit` | Unit test | 10 min |
| `twig-lint` | Lint | 10 min |
| `php-lint` | Lint | 10 min |
| `php-unit` | Unit test | 10 min |
| `python-lint` | Lint | 15 min |
| `python-unit` | Unit test | 15 min |
| `yaml-lint` | Lint | 5 min |
| `shellcheck` | Lint | 5 min |
| `colors-css` | Check | 5 min |
| `db-check` | DB migration | 20 min |
| `Cypress-System` | E2E test | 40 min |
| `Cypress` | E2E test (matrix) | 40 min |
| `Integration` | Integration test | 30 min |
| `ansible-ci` | Full install | 40 min |

A hung job will now fail in **5–40 minutes** (depending on job type) instead of **6 hours**.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Review the diff each job has exactly one `timeout-minutes` line added after `runs-on`
2. Verify all CI jobs pass on this PR (no behavior change under normal conditions)
3. Timeout values can be validated against typical job durations visible in the Actions tab

### Automated Testing & Documentation

This change is fully validated by the existing CI test suite. If any timeout is too aggressive, the affected job will fail and the value can be adjusted. No new tests or documentation updates are needed.

### Other information

- **Not a breaking change** only adds guardrails, does not alter any test behavior
- **No migrations needed**
- **No security concerns**
- If a job legitimately needs more time in the future, the timeout value can simply be increased
- This follows [GitHub's security hardening recommendations](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
