### PR TITLE
[Documentation:Developer] Use GitHub security reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,8 @@ Testing should be limited only to Submitty and its various components, contained
 
 ## How to report a security vulnerability?
 
-If you believe you’ve found a security vulnerability in one of our products or platforms please send it to us 
-by emailing [submitty-admin@googlegroups.com](mailto:submitty-admin@googlegroups.com). 
+If you believe you’ve found a security vulnerability in one of our products or platforms, please
+report it through GitHub [here](https://github.com/Submitty/Submitty/security/advisories/new).
 
 Please include the following details with your report:
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
We previously have used a google group to receive security reports.

### What is the New Behavior?
I enabled allowing anyone to report security reports through GitHub and am documenting for people to use that. This gives some nicer dev experience when working with security fixes.
