### PR TITLE
[Bugfix:Autograding] Decode router messages

### DIFF
--- a/.setup/pip/system_requirements.txt
+++ b/.setup/pip/system_requirements.txt
@@ -30,6 +30,7 @@ jsonschema==4.26.0
 jsonref==1.1.0
 docker==7.1.0
 urllib3==2.6.3
+chardet==5.2.0
 
 # Python libraries for QR bulk upload
 pyzbar==0.1.9

--- a/grading/python/submitty_router.py
+++ b/grading/python/submitty_router.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import threading 
 import time
 import html
+import chardet
 
 class submitty_router():
   '''
@@ -75,7 +76,17 @@ class submitty_router():
   # All messages will be passed through this function for optional decoding 
   # to string
   def sequence_diagram_message_preprocess(self, message):
-    return message
+    ret = message
+    try:
+
+        encoding_prediction = chardet.detect(message)
+
+        if encoding_prediction['confidence'] >0.8:
+
+          ret = message.decode(encoding_prediction['encoding'])
+    except Exception:
+        pass
+    return ret
 
   def write_sequence_file(self, obj, status, message_type):
     append_write = 'a' if os.path.exists(self.sequence_diagram_file) else 'w'

--- a/grading/python/submitty_router.py
+++ b/grading/python/submitty_router.py
@@ -76,17 +76,17 @@ class submitty_router():
   # All messages will be passed through this function for optional decoding 
   # to string
   def sequence_diagram_message_preprocess(self, message):
-    ret = message
-    try:
+    if isinstance(message, bytes):
+        try:
+            encoding_prediction = chardet.detect(message)
+            encoding = encoding_prediction.get("encoding")
+            confidence = encoding_prediction.get("confidence", 0)
 
-        encoding_prediction = chardet.detect(message)
-
-        if encoding_prediction['confidence'] >0.8:
-
-          ret = message.decode(encoding_prediction['encoding'])
-    except Exception:
-        pass
-    return ret
+            if encoding and confidence > 0.8:
+                return message.decode(encoding)
+        except Exception:
+            pass
+    return message
 
   def write_sequence_file(self, obj, status, message_type):
     append_write = 'a' if os.path.exists(self.sequence_diagram_file) else 'w'

--- a/grading/python/submitty_router.py
+++ b/grading/python/submitty_router.py
@@ -76,16 +76,16 @@ class submitty_router():
   # All messages will be passed through this function for optional decoding 
   # to string
   def sequence_diagram_message_preprocess(self, message):
-    if isinstance(message, bytes):
-        try:
-            encoding_prediction = chardet.detect(message)
-            encoding = encoding_prediction.get("encoding")
-            confidence = encoding_prediction.get("confidence", 0)
+    if not isinstance(message, bytes):
+        return message
 
-            if encoding and confidence > 0.8:
-                return message.decode(encoding)
-        except Exception:
-            pass
+    try:
+        encoding_prediction = chardet.detect(message)
+        if encoding_prediction and encoding_prediction.get('confidence', 0) > 0.8:
+            return message.decode(encoding_prediction.get('encoding') or 'utf-8')
+    except Exception:
+        pass
+
     return message
 
   def write_sequence_file(self, obj, status, message_type):

--- a/site/app/templates/autograding/AutoChecks.twig
+++ b/site/app/templates/autograding/AutoChecks.twig
@@ -118,23 +118,36 @@
                     {{ element.src|raw }}
                 </div>
             {% elseif element.type == "sequence_diagram" %}
-              <div class="mermaid" id="div_{{ index }}_{{ check_index }}">
-                sequenceDiagram
-                {{ element.src |escape }}
-              </div>
-              <script>
-                // Unfortunately, mermaid takes in manual css changes as a string by default.
-                var config = {
-                  "startOnLoad":false,
-                  "theme" : "default",
-                  "themeCSS":".messageText{fill: #333;stroke: none;font-size: 12px;}.actor{stroke:var(--standard-light-blue);fill:var(--standard-pale-blue)}text.actor{overflow-wrap:break-word}.actor-line{stroke:var(--standard-medium-dark-gray)}.positive-end{content:'\f00c';font-family:'Font Awesome 5 Free'}.negative-end{content:'\f12a';font-family:'Font Awesome 5 Free'}.labelText{overflow-wrap:break-word}.note{stroke:var(--standard-light-yellow);fill:var(--standard-pale-yellow)}.noteText{overflow-wrap:break-word}",
-                  "useMaxWidth" : false
-                };
-                mermaid.initialize(config);
-                $( document ).ready(function() {
-                    mermaid.init( { "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");
-                });
-              </script>
+  <div class="mermaid" id="div_{{ index }}_{{ check_index }}">
+    sequenceDiagram
+    {{ element.src | escape }}
+  </div>
+  <script>
+    (function() {
+        
+        var config = {
+            "startOnLoad": false,
+            "theme" : "default",
+            "themeCSS": ".messageText{fill: #333;stroke: none;font-size: 12px;}.actor{stroke:var(--standard-light-blue);fill:var(--standard-pale-blue)}text.actor{overflow-wrap:break-word}.actor-line{stroke:var(--standard-medium-dark-gray)}.positive-end{content:'\\f00c';font-family:'Font Awesome 5 Free'}.negative-end{content:'\\f12a';font-family:'Font Awesome 5 Free'}.labelText{overflow-wrap:break-word}.note{stroke:var(--standard-light-yellow);fill:var(--standard-pale-yellow)}.noteText{overflow-wrap:break-word}",
+            "useMaxWidth" : false
+        };
+        
+        $(document).ready(function() {
+          
+            if (typeof mermaid !== 'undefined') {
+                try {
+                    mermaid.initialize(config);
+                    mermaid.init({ "useMaxWidth" : false }, "#div_{{ index }}_{{ check_index }}");
+                } catch (err) {
+                    console.error("Mermaid failed to initialize for #div_{{ index }}_{{ check_index }}", err);
+                }
+            } else {
+               
+                console.warn("Mermaid library not loaded, skipping initialization to prevent page crash.");
+            }
+        });
+    })();
+  </script>
             {% elseif element.type == "notebook" %}
                 <iframe src="{{ element.src }}" width="100%" height="1200px" style="border: 0"></iframe>
             {% endif %}


### PR DESCRIPTION
Closes #5445

This PR updates the autograding router to automatically decode sequence diagram message byte strings before rendering.

Previously, the router displayed raw byte strings (for example, b'Hello') in sequence diagrams.

This change uses the chardet library to detect the message encoding and decode it when the confidence level is above 0.8. Decoding is only attempted when the message is of type bytes.

If decoding fails or confidence is low, the original message is returned to prevent runtime errors.

The chardet dependency has been added to requirements.txt to support this change.