### PR TITLE
Fix #12432: Condense buttons on Autograding Testcases page for improved layout and responsiveness

### DIFF
--- a/site/app/templates/admin/UploadConfigForm.twig
+++ b/site/app/templates/admin/UploadConfigForm.twig
@@ -61,11 +61,13 @@
         {% if file.files is defined %}
             <li>
                 {% if indent == 1 %}
-                    <a class="fas fa-pencil-alt key_to_click" tabindex="0" onclick="openRenamePopup('{{ file.path }}')"></a>
-                    <a class="fas fa-download key_to_click" tabindex="0" onclick="downloadConfig('{{ file.path }}')"></a>
-                    {% if file.path not in inuse_config %}
-                        <a class="fas fa-trash key_to_click" tabindex="0" onclick="openDeletePopup('{{ file.path }}')"></a>
-                    {% endif %}
+                    <div class="config-actions-group">
+                        <a class="fas fa-pencil-alt key_to_click config-action-button" tabindex="0" onclick="openRenamePopup('{{ file.path }}')" title="Rename"></a>
+                        <a class="fas fa-download key_to_click config-action-button" tabindex="0" onclick="downloadConfig('{{ file.path }}')" title="Download"></a>
+                        {% if file.path not in inuse_config %}
+                            <a class="fas fa-trash key_to_click config-action-button" tabindex="0" onclick="openDeletePopup('{{ file.path }}')" title="Delete"></a>
+                        {% endif %}
+                    </div>
                 {% endif %}
                 <span id='{{ id }}-span' class='fa icon-folder-closed'></span><a class="key_to_click" tabindex="0" onclick='openDiv("{{ id }}");'>{{ seen_root ? name : file.path }}</a>
                 <ul id='{{ id }}' style='margin-left: {{ margin_left }}px; list-style-type: none; display: none'>

--- a/site/public/css/autograding-config-upload.css
+++ b/site/public/css/autograding-config-upload.css
@@ -15,7 +15,11 @@
 }
 
 .upload-buttons-padding {
-    padding-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding-top: 16px;
+    align-items: center;
 }
 
 .upload-button {
@@ -43,4 +47,30 @@
     opacity: 0.5;
     pointer-events: none;
     cursor: not-allowed;
+}
+
+.config-actions-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-right: 12px;
+}
+
+.config-action-button {
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+    color: var(--always-default-blue);
+    text-decoration: none;
+}
+
+.config-action-button:hover {
+    background-color: rgb(0 0 0 / 5%);
+    color: var(--always-default-blue);
+}
+
+.config-action-button:focus {
+    outline: 2px solid var(--always-default-blue);
+    outline-offset: 2px;
 }


### PR DESCRIPTION
### Why is this change important?

Fixes #12432

This PR improves the layout and usability of the Autograding Testcases page by reducing visual clutter and making action buttons more compact and responsive. The changes enhance spacing consistency, accessibility, and overall user experience, especially on smaller screens.

### What is the new behavior?

* Action buttons (edit, download, delete) are grouped using flexbox for better alignment
* Reduced top padding (24px → 16px) to create a more compact layout
* Added consistent spacing between buttons (8px gap)
* Enabled responsive wrapping of buttons using `flex-wrap`
* Improved hover and focus states for better visual feedback
* Updated button classes for cleaner styling control
* Added `title` attributes to improve accessibility

### How to test the changes

1. Navigate to the Autograding Testcases page.
2. Verify that action buttons are grouped and aligned properly.
3. Resize the browser window to confirm responsive wrapping behavior.
4. Check hover and focus states on all action buttons.
5. Ensure all existing button actions (edit, download, delete) work as expected.

### Automated testing & documentation

* UI-only change; no backend logic modified.
* Existing functionality remains unaffected.
* No documentation updates required.

### Other information

* Not a breaking change
* No database migrations required
* No security concerns introduced
