### PR TITLE
[Bug Fix:InstructorUI] Fixed calendar date dropdown UI

### DIFF
--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -34,7 +34,7 @@
     text-align: center;
     font-size: 20px;
     font-weight: 600;
-    width: 65px;
+    width: 90px;
     height: 50px;
     background: 1px solid var(--standard-light-gray);
     padding: 0;

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -34,7 +34,7 @@
     text-align: center;
     font-size: 20px;
     font-weight: 600;
-    width: 90px;
+    width: auto;
     height: 50px;
     background: 1px solid var(--standard-light-gray);
     padding: 0;

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -17,6 +17,7 @@
     flex-direction: column;
     align-items: center;
     margin-top: 5px;
+    gap: 6px;
 }
 
 .cal-month-title {
@@ -82,11 +83,13 @@ a.cal-btn:focus {
 }
 
 #prev-month-switch {
-    text-align: right;
+    text-align: left;
+    padding-left: 1vw;
 }
 
 #next-month-switch {
-    text-align: left;
+    text-align: right;
+    padding-right: 1vw;
 }
 
 #calendar-item-type-edit {
@@ -355,3 +358,4 @@ div.legend-color {
         display: none;
     }
 }
+

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -2,6 +2,7 @@
 .table-calendar {
     text-align: left;
     border: 1px solid var(--default-black);
+    table-layout: fixed;
 }
 
 /* the title at the top of the calendar table, showing month, year */
@@ -24,8 +25,8 @@
     font-weight: 600;
     width: auto;
     height: 50px;
-    background: 1px solid var(--standard-light-gray);
-    padding: 0;
+    border: 1px solid var(--standard-light-gray);
+    padding: 10px;
     font-family: "Source Sans Pro", sans-serif;
     color: var(--text-black);
 }
@@ -36,7 +37,7 @@
     font-weight: 600;
     width: auto;
     height: 50px;
-    background: 1px solid var(--standard-light-gray);
+    border: 1px solid var(--standard-light-gray);
     padding: 0;
     font-family: "Source Sans Pro", sans-serif;
     color: var(--text-black);
@@ -103,40 +104,14 @@ a.cal-btn:focus {
 }
 
 /* the row of Monday, Tuesday, ... */
-.cal-week-title-row {
-    margin-bottom: 20px;
-}
-
-.cal-week-title {
-    padding-left: 3px;
-}
-
-.cal-week-title-sun {
-    width: 12%;
-}
-
-.cal-week-title-mon {
-    width: 15%;
-}
-
-.cal-week-title-tue {
-    width: 15%;
-}
-
-.cal-week-title-wed {
-    width: 16%;
-}
-
-.cal-week-title-thu {
-    width: 15%;
-}
-
-.cal-week-title-fri {
-    width: 15%;
-}
-
+.cal-week-title-sun,
+.cal-week-title-mon,
+.cal-week-title-tue,
+.cal-week-title-wed,
+.cal-week-title-thu,
+.cal-week-title-fri,
 .cal-week-title-sat {
-    width: 12%;
+    width: 14.2857%;
 }
 
 /* the day number in each cell */

--- a/site/public/css/calendar.css
+++ b/site/public/css/calendar.css
@@ -26,7 +26,7 @@
     width: auto;
     height: 50px;
     border: 1px solid var(--standard-light-gray);
-    padding: 10px;
+    padding: 0;
     font-family: "Source Sans Pro", sans-serif;
     color: var(--text-black);
 }


### PR DESCRIPTION
Fixes #12519

### Why is this Change Important & Necessary?
Fixes #12519

-Updates the UI so that the entire date is visible to the user in the calendar tab

### What is the New Behavior?
Before: 
<img width="384" height="163" alt="Screenshot 2026-03-02 at 9 10 51 PM" src="https://github.com/user-attachments/assets/b9fba738-de65-4da2-bb93-72fdb7b4130c" />
After:
<img width="399" height="98" alt="Screenshot 2026-03-02 at 10 15 33 PM" src="https://github.com/user-attachments/assets/5b7b9dcb-dcf0-45bc-8350-08229e54f983" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open up the web app in Safari
2. Log in as any user
3. Navigate to the calendar tab and make sure the entire date can be seen

### Automated Testing & Documentation
Change is minor

### Other information
NA