### PR TITLE
[Bugfix:System] Preserve files on install clean

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -137,6 +137,22 @@ if [ ${VAGRANT} == 1 ]; then
     chmod 740 ${SUBMITTY_INSTALL_DIR}/site/phpunit.xml
 fi
 
+# Restore installation-specific files that were backed up during "install clean"
+# (e.g. institution logo in site/public/img, config/footer_links.json). See issue #9511.
+CLEAN_BACKUP_DIR="${SUBMITTY_CONFIG_DIR:?}/.install_clean_backup"
+if [ -d "${CLEAN_BACKUP_DIR}" ]; then
+    if [ -d "${CLEAN_BACKUP_DIR}/img" ]; then
+        mkdir -p "${SUBMITTY_INSTALL_DIR}/site/public/img"
+        cp -a "${CLEAN_BACKUP_DIR}/img/." "${SUBMITTY_INSTALL_DIR}/site/public/img/"
+        chown -R ${PHP_USER}:${PHP_GROUP} "${SUBMITTY_INSTALL_DIR}/site/public/img"
+    fi
+    if [ -f "${CLEAN_BACKUP_DIR}/footer_links.json" ]; then
+        cp -a "${CLEAN_BACKUP_DIR}/footer_links.json" "${SUBMITTY_INSTALL_DIR}/config/footer_links.json"
+        chown root:root "${SUBMITTY_INSTALL_DIR}/config/footer_links.json"
+    fi
+    rm -rf "${CLEAN_BACKUP_DIR}"
+fi
+
 # check for either of the dependency folders, and if they do not exist, pretend like
 # their respective json file was edited. Composer needs the folder to exist to even
 # run, but it could be someone just deleted the folders to try and fix some

--- a/.setup/install_submitty/setup_directories.sh
+++ b/.setup/install_submitty/setup_directories.sh
@@ -47,6 +47,18 @@ if [[ "$#" -ge 1 && "$1" == "clean" ]] ; then
 
     echo -e "\nDeleting submitty installation directories, ${SUBMITTY_INSTALL_DIR:?}, for a clean installation\n"
 
+    # Backup installation-specific files that would otherwise be lost on clean.
+    # These are restored by install_site.sh after the site is rsync'd (see issue #9511).
+    CLEAN_BACKUP_DIR="${SUBMITTY_CONFIG_DIR:?}/.install_clean_backup"
+    rm -rf "${CLEAN_BACKUP_DIR}"
+    mkdir -p "${CLEAN_BACKUP_DIR}"
+    if [ -d "${SUBMITTY_INSTALL_DIR:?}/site/public/img" ]; then
+        cp -a "${SUBMITTY_INSTALL_DIR:?}/site/public/img" "${CLEAN_BACKUP_DIR}/img"
+    fi
+    if [ -f "${SUBMITTY_INSTALL_DIR:?}/config/footer_links.json" ]; then
+        cp -a "${SUBMITTY_INSTALL_DIR:?}/config/footer_links.json" "${CLEAN_BACKUP_DIR}/footer_links.json"
+    fi
+
     if [[ "$#" -ge 1 && $1 == "quick" ]] ; then
         # pop this argument from the list of arguments...
         shift


### PR DESCRIPTION
Fixes #9511

Running `INSTALL_SUBMITTY.sh clean` was deleting the institution logo image under `site/public/img/` (used on the SAML login screen) and the optional `config/footer_links.json`, with no way to restore them. This change backs up those installation-specific files before the clean step and restores them after the site is reinstalled, so system administrators do not lose these customizations when performing a clean install.

**What changed:** The clean path in `setup_directories.sh` now saves `site/public/img` and `config/footer_links.json` into a temporary backup under the config directory (which is not removed during clean). After the site is copied back, `install_site.sh` restores these from the backup and then removes the backup directory.