### PR TITLE
[Refactor:Autograding] Optimize item pool lookup

### DIFF
--- a/autograder/autograder/grade_item.py
+++ b/autograder/autograder/grade_item.py
@@ -11,10 +11,11 @@ from . execution_environments import jailed_sandbox
 
 
 def get_item_from_item_pool(complete_config_obj, item_name):
-    for item in complete_config_obj['item_pool']:
-        if item['item_name'] == item_name:
-            return item
-    return None
+    if '_item_pool_lookup' not in complete_config_obj:
+        complete_config_obj['_item_pool_lookup'] = {
+            item['item_name']: item for item in complete_config_obj['item_pool']
+        }
+    return complete_config_obj['_item_pool_lookup'].get(item_name)
 
 
 def get_testcases(


### PR DESCRIPTION
### Why is this Change Important & Necessary?

`get_item_from_item_pool` does a linear scan O(n) on every call and is used inside a loop in `get_testcases()`, making it O(N × M). This replaces it with a cached O(1) dict lookup.

### What is the New Behaviour?

A dictionary keyed by `item_name` is built on first call and cached on the config object. All subsequent lookups are O(1). Return values are unchanged — `None` for missing items.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Run the autograder test suite
2. Verify correct item is returned for valid names, `None` for invalid names.
3. Work done on #12531 

### Automated Testing & Documentation
No docs update needed, internal optimisation only.

### Other information

- Not a breaking change
- No migrations
- No security concerns
