### PR TITLE
Improve submission limit warning message for clarity

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -973,7 +973,7 @@ function handleSubmission(gradeable_status, remaining_late_days_for_gradeable, c
     let message = '';
     // check versions used
     if (versions_used >= versions_allowed) {
-        message = `You have already made ${versions_used} submissions.  You are allowed ${versions_allowed} submissions before a small point penalty will be applied. Are you sure you want to continue?`;
+        message = `You have already used ${versions_used} of the allowed ${versions_allowed} submissions. Submitting again may result in a small point penalty. Do you want to continue?`;
         if (!confirm(message)) {
             $('#submit').prop('disabled', false);
             return;


### PR DESCRIPTION
### Why is this Change Important & Necessary?

The current warning message shown when a student exceeds the allowed number of submissions can be confusing. It says:

"You have already made X submissions. You are allowed Y submissions..."

This wording does not clearly indicate that the limit has already been exceeded.

This change improves the message wording to make the situation clearer for the user.

---

### What is the New Behavior?

Previous message:
"You have already made X submissions. You are allowed Y submissions before a small point penalty will be applied."

New message:
"You have already used X of the allowed Y submissions. Submitting again may result in a small point penalty."

This makes the message clearer when the number of submissions exceeds the allowed limit.

---

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Open a gradeable submission page.
2. Submit files repeatedly until the number of submissions exceeds the allowed limit.
3. Attempt another submission.
4. Observe the updated confirmation warning message.

---

### Automated Testing & Documentation

No automated tests were required since this change only modifies a user-facing message.

---

### Other information

- This is not a breaking change.
- No migrations are required.
- No security impact.