### PR TITLE
[Bugfix:InstructorUI] Fix sticky cols on Bulk Late Days table

### DIFF
--- a/site/app/templates/admin/late_day_cache/LateDayCacheTablePlugin.twig
+++ b/site/app/templates/admin/late_day_cache/LateDayCacheTablePlugin.twig
@@ -1,84 +1,56 @@
-{# This is a data table #}
-<table id="late-day-table" class="mobile-table">
-    <caption />
-    {# Table header #}
-    <thead>
-        <tr>
-            <th>
-                User ID
-            </th>
-            <th>
-                Given Name
-            </th>
-            <th>
-                Family Name
-            </th>
-            <th>
-                Initial
-            </th>
-
-            {% for title in late_day_cache_header %}
-                <th>
-                    {% if title.timestamp is defined %}
-
-                        {{ title|date('m/d/Y') }}
-                    {% else %}
-                        {{ title }}
-                    {% endif %}
-                </th>
-            {% endfor %}
-
-            <th>
-                Remaining
-            </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        {% set index = 0 %}
-        {% for student in students %}
-            <tr id="row-{{ index }}" USER_ID="{{ student.getId() }}" data-row="{{ index }}">
-                <td data-before-content="Student ID">
-                    {{ student.getId() }}
-                </td>
-                <td data-before-content="Name">
-                    {{ student.getDisplayedGivenName() }}
-                </td>
-                 <td data-before-content="Family Name">
-                    {{ student.getDisplayedFamilyName() }}
-                </td>
-                <td initial_ld_id="Initial Late Days">
-                    {{ initial_late_days }}
-                </td>
-
-                {% set user_cache = late_day_cache[student.getId()] ?? null %}   
-
-                {# Late day change for updates and gradeables #}
+<div class="table-scroll">
+    <table id="late-day-table" class="mobile-table">
+        <caption>Bulk Late Days Usage</caption>
+        <thead>
+            <tr>
+                <th class="sticky-col sticky-col-1">User ID</th>
+                <th class="sticky-col sticky-col-2">Given Name</th>
+                <th class="sticky-col sticky-col-3">Family Name</th>
+                <th class="sticky-col sticky-col-4">Initial</th>
                 {% for title in late_day_cache_header %}
-                    {% set title = title.timestamp is defined ? title|date('Y-m-d') : title %}
-
-                    <td id="{{ title }}" USER_ID-content="{{ student.getId() }}">
-                        {% if user_cache is defined and user_cache[title] is defined %}
-                            {% set curr_cache = user_cache[title] %}
-                            {{ ((curr_cache.late_days_change > 0) ? '+' : '') ~ curr_cache.late_days_change }}
+                    <th>
+                        {% if title.timestamp is defined %}
+                            {{ title|date('m/d/Y') }}
+                        {% else %}
+                            {{ title }}
                         {% endif %}
-                    </td>                    
+                    </th>
                 {% endfor %}
-
-                {% set last_title = last_late_day_events[student.getId()] ?? null %}
-                {% set last_title = last_title.timestamp is defined ? last_title|date('Y-m-d') : last_title %}
-                
-                {% if last_title is null %}
-                    {# If there are no late day events yet #}
-                    <td ld_id="Late Days Remaining"> {{ initial_late_days }} </td>
-                {% elseif user_cache[last_title] is defined %}
-                    {# If we have cache data for the last event, we have cache data for all events #}
-                    <td ld_id="Late Days Remaining"> {{ user_cache[last_title].late_days_remaining }} </td>
-                {% else %}
-                    {# Else put cache is incomplete, leave value blank #}
-                    <td ld_id="Late Days Remaining"> </td>
-                {% endif %}
+                <th>Remaining</th>
             </tr>
-        {% endfor %}
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            {% for student in students %}
+                <tr id="row-{{ loop.index0 }}" data-user-id="{{ student.getId() }}" data-row="{{ loop.index0 }}">
+                    <td class="sticky-col sticky-col-1" data-before-content="Student ID">{{ student.getId() }}</td>
+                    <td class="sticky-col sticky-col-2" data-before-content="Name">{{ student.getDisplayedGivenName() }}</td>
+                    <td class="sticky-col sticky-col-3" data-before-content="Family Name">{{ student.getDisplayedFamilyName() }}</td>
+                    <td class="sticky-col sticky-col-4" data-before-content="Initial" data-initial-late-days="{{ initial_late_days }}">{{ initial_late_days }}</td>
+
+                    {% set user_cache = late_day_cache[student.getId()] ?? null %}
+
+                    {% for title in late_day_cache_header %}
+                        {% set formatted_title = title.timestamp is defined ? title|date('Y-m-d') : title %}
+                        <td id="{{ formatted_title }}" data-user-id-content="{{ student.getId() }}">
+                            {% if user_cache is not null and user_cache[formatted_title] is defined %}
+                                {% set curr_cache = user_cache[formatted_title] %}
+                                {{ ((curr_cache.late_days_change > 0) ? '+' : '') ~ curr_cache.late_days_change }}
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+
+                    {% set last_title = last_late_day_events[student.getId()] ?? null %}
+                    {% set formatted_last_title = last_title is not null and last_title.timestamp is defined ? last_title|date('Y-m-d') : last_title %}
+
+                    {% if formatted_last_title is null %}
+                        <td data-late-days-remaining="{{ initial_late_days }}">{{ initial_late_days }}</td>
+                    {% elseif user_cache is not null and user_cache[formatted_last_title] is defined %}
+                        <td data-late-days-remaining="{{ user_cache[formatted_last_title].late_days_remaining }}">{{ user_cache[formatted_last_title].late_days_remaining }}</td>
+                    {% else %}
+                        <td data-late-days-remaining=""></td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -185,7 +185,7 @@
             {% if vcs_host_type == constant('app\\models\\gradeable\\GradeableUtils::VCS_TYPE_PUBLIC_GITHUB') %}
             Note: This should be a <em>public repository</em>, visible to everyone.
             {% else %}
-            Note: If this is not a <em>public repository</em>, please ensure that you have granted read access to INCOMPLETE! FIXME! SPECIAL USER.
+            Note: If this is not a <em>public repository</em>, please ensure that you have granted read access to your instructor or the submitty service account.
             {% endif %}
 
         {% endif %}

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -2,16 +2,20 @@
     /* stylelint-disable-next-line color-named */
     background-color: red;
 }
+
 #empty-table {
     margin: 10px auto;
     padding: 1.6em 1em;
     text-align: center;
     border-radius: 8px;
 }
+
 .mobile-table {
-    width: 100%;
+    min-width: 100%;
+    width: auto;
     text-align: center;
 }
+
 .mobile-table caption {
     padding: 0.5em;
     font-weight: bold;
@@ -19,15 +23,24 @@
     width: 100%;
     display: block;
 }
-.mobile-table th, .mobile-table td {
+
+.mobile-table th {
     padding: 5px;
-    box-sizing: border-box;
 }
+
+.mobile-table th,
+.mobile-table td {
+    box-sizing: border-box;
+    min-width: 80px;
+}
+
+
 .section-break {
     border-top: 1px solid var(--standard-hover-light-gray);
     font-weight: normal;
     padding: 0.5em;
 }
+
 @media (max-width: 830px) {
     table.mobile-table,
     .mobile-table thead,
@@ -38,10 +51,14 @@
         display: block;
         border: none;
     }
+
     .mobile-table tr {
         margin-top: 1em;
+        /* stylelint-disable-next-line declaration-no-important */
         background: none !important;
     }
+
+    /* Hide table headers */
     .mobile-table thead tr {
         position: absolute;
         width: 1px;
@@ -52,6 +69,7 @@
         clip-path: inset(50%);
         border: 0;
     }
+
     .mobile-table td {
         display: flex;
         justify-content: space-between;
@@ -59,76 +77,103 @@
         padding: 2px 8px;
         margin: 2px 0;
     }
+
     .mobile-table tr:nth-child(even) td {
         background: var(--standard-hover-light-gray);
     }
+
     .mobile-table tr:nth-child(odd) td {
         background: var(--standard-light-gray);
     }
+
     .mobile-table td::before {
         padding-right: 1em;
         font-weight: bold;
     }
-    .sticky-col {
-        position: static;
-        left: auto;
-        z-index: auto;
-        background: none;
-    }
 }
+
 @media (min-width: 831px) {
     .mobile-table {
         border: 1px solid var(--standard-hover-light-gray);
     }
+
     .mobile-table caption {
         display: table-caption;
     }
+
     .section-break {
         padding: 0;
     }
+
     .mobile-table td::before {
         content: none !important;
     }
+
     .mobile-table td:first-child,
     .mobile-table th:first-child {
         padding-left: 15px;
     }
+
     .mobile-table td:last-child,
     .mobile-table th:last-child {
         padding-right: 15px;
     }
 }
+
 .peer-table-data {
     width: 50px;
 }
+
 .peer-table-header {
     width: 80px;
 }
+
 .peer-table-title-data {
     text-align: left;
 }
+
 .table-scroll {
     overflow-x: auto;
     width: 100%;
 }
+
 .sticky-col {
     position: sticky;
     background: var(--default-white);
     box-sizing: border-box;
 }
-.sticky-col-1 { width: 120px; left: 0px;   z-index: 10; }
-.sticky-col-2 { width: 120px; left: 120px; z-index: 9;  }
-.sticky-col-3 { width: 120px; left: 240px; z-index: 8;  }
-.sticky-col-4 { width: 100px; left: 360px; z-index: 7;  }
+
+:root {
+    --col1-width: 120px;
+    --col2-width: 120px;
+    --col3-width: 120px;
+    --col4-width: 70px;
+}
+
+.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 10; }
+.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 9;  }
+.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 8;  }
+.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 7;  }
+
 #late-day-table thead th {
     position: sticky;
     top: 0;
     background: var(--default-white);
     z-index: 20;
+    width: var(--col2-width);
+    min-width: 80px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 #late-day-table thead th.sticky-col {
     z-index: 30;
 }
+#late-day-table thead th.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 35; }
+#late-day-table thead th.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 34; }
+#late-day-table thead th.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 33; }
+#late-day-table thead th.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 32; }
+
 #late-day-table tbody tr {
     background: var(--default-white);
 }
@@ -141,3 +186,8 @@
 #late-day-table tbody tr:nth-child(odd) .sticky-col {
     background: var(--default-white);
 }
+
+#late-day-table tbody td.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); white-space: nowrap; left: 0; z-index: 25; }
+#late-day-table tbody td.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 24; }
+#late-day-table tbody td.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 23; }
+#late-day-table tbody td.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 22; }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -1,21 +1,17 @@
 .flagged-row {
-    /* stylelint-disable-next-line color-named */
     background-color: red;
 }
-
 #empty-table {
     margin: 10px auto;
     padding: 1.6em 1em;
     text-align: center;
     border-radius: 8px;
 }
-
 .mobile-table {
     min-width: 100%;
     width: auto;
     text-align: center;
 }
-
 .mobile-table caption {
     padding: 0.5em;
     font-weight: bold;
@@ -23,24 +19,19 @@
     width: 100%;
     display: block;
 }
-
 .mobile-table th {
     padding: 5px;
 }
-
 .mobile-table th,
 .mobile-table td {
     box-sizing: border-box;
     min-width: 80px;
 }
-
-
 .section-break {
     border-top: 1px solid var(--standard-hover-light-gray);
     font-weight: normal;
     padding: 0.5em;
 }
-
 @media (max-width: 830px) {
     table.mobile-table,
     .mobile-table thead,
@@ -51,14 +42,10 @@
         display: block;
         border: none;
     }
-
     .mobile-table tr {
         margin-top: 1em;
-        /* stylelint-disable-next-line declaration-no-important */
         background: none !important;
     }
-
-    /* Hide table headers */
     .mobile-table thead tr {
         position: absolute;
         width: 1px;
@@ -69,7 +56,6 @@
         clip-path: inset(50%);
         border: 0;
     }
-
     .mobile-table td {
         display: flex;
         justify-content: space-between;
@@ -77,79 +63,63 @@
         padding: 2px 8px;
         margin: 2px 0;
     }
-
     .mobile-table tr:nth-child(even) td {
         background: var(--standard-hover-light-gray);
     }
-
     .mobile-table tr:nth-child(odd) td {
         background: var(--standard-light-gray);
     }
-
     .mobile-table td::before {
         padding-right: 1em;
         font-weight: bold;
     }
 }
-
 @media (min-width: 831px) {
     .mobile-table {
         border: 1px solid var(--standard-hover-light-gray);
     }
-
     .mobile-table caption {
         display: table-caption;
     }
-
     .section-break {
         padding: 0;
     }
-
     .mobile-table td::before {
         content: none !important;
     }
-
     .mobile-table td:first-child,
     .mobile-table th:first-child {
         padding-left: 15px;
     }
-
     .mobile-table td:last-child,
     .mobile-table th:last-child {
         padding-right: 15px;
     }
 }
-
 .peer-table-data {
     width: 50px;
 }
-
 .peer-table-header {
     width: 80px;
 }
-
 .peer-table-title-data {
     text-align: left;
 }
-
 .table-scroll {
     overflow-x: auto;
     width: 100%;
 }
-
 .sticky-col {
     position: sticky;
     background: var(--default-white);
     box-sizing: border-box;
 }
-
 :root {
     --col1-width: 120px;
     --col2-width: 120px;
     --col3-width: 120px;
     --col4-width: 70px;
 }
-
 .sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 10; }
 .sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 9;  }
 .sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 8;  }
@@ -173,7 +143,6 @@
 #late-day-table thead th.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 34; }
 #late-day-table thead th.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 33; }
 #late-day-table thead th.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 32; }
-
 #late-day-table tbody tr {
     background: var(--default-white);
 }
@@ -186,7 +155,6 @@
 #late-day-table tbody tr:nth-child(odd) .sticky-col {
     background: var(--default-white);
 }
-
 #late-day-table tbody td.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); white-space: nowrap; left: 0; z-index: 25; }
 #late-day-table tbody td.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 24; }
 #late-day-table tbody td.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 23; }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -2,19 +2,16 @@
     /* stylelint-disable-next-line color-named */
     background-color: red;
 }
-
 #empty-table {
     margin: 10px auto;
     padding: 1.6em 1em;
     text-align: center;
     border-radius: 8px;
 }
-
 .mobile-table {
     width: 100%;
     text-align: center;
 }
-
 .mobile-table caption {
     padding: 0.5em;
     font-weight: bold;
@@ -22,17 +19,15 @@
     width: 100%;
     display: block;
 }
-
-.mobile-table th {
+.mobile-table th, .mobile-table td {
     padding: 5px;
+    box-sizing: border-box;
 }
-
 .section-break {
     border-top: 1px solid var(--standard-hover-light-gray);
     font-weight: normal;
     padding: 0.5em;
 }
-
 @media (max-width: 830px) {
     table.mobile-table,
     .mobile-table thead,
@@ -43,14 +38,10 @@
         display: block;
         border: none;
     }
-
     .mobile-table tr {
         margin-top: 1em;
-        /* stylelint-disable-next-line declaration-no-important */
         background: none !important;
     }
-
-    /* Hide table headers */
     .mobile-table thead tr {
         position: absolute;
         width: 1px;
@@ -61,7 +52,6 @@
         clip-path: inset(50%);
         border: 0;
     }
-
     .mobile-table td {
         display: flex;
         justify-content: space-between;
@@ -69,58 +59,85 @@
         padding: 2px 8px;
         margin: 2px 0;
     }
-
     .mobile-table tr:nth-child(even) td {
         background: var(--standard-hover-light-gray);
     }
-
     .mobile-table tr:nth-child(odd) td {
         background: var(--standard-light-gray);
     }
-
     .mobile-table td::before {
         padding-right: 1em;
         font-weight: bold;
     }
+    .sticky-col {
+        position: static;
+        left: auto;
+        z-index: auto;
+        background: none;
+    }
 }
-
 @media (min-width: 831px) {
     .mobile-table {
         border: 1px solid var(--standard-hover-light-gray);
     }
-
     .mobile-table caption {
         display: table-caption;
     }
-
     .section-break {
         padding: 0;
     }
-
     .mobile-table td::before {
-        /* stylelint-disable-next-line declaration-no-important */
         content: none !important;
     }
-
     .mobile-table td:first-child,
     .mobile-table th:first-child {
         padding-left: 15px;
     }
-
     .mobile-table td:last-child,
     .mobile-table th:last-child {
         padding-right: 15px;
     }
 }
-
 .peer-table-data {
     width: 50px;
 }
-
 .peer-table-header {
     width: 80px;
 }
-
 .peer-table-title-data {
     text-align: left;
+}
+.table-scroll {
+    overflow-x: auto;
+    width: 100%;
+}
+.sticky-col {
+    position: sticky;
+    background: var(--default-white);
+    box-sizing: border-box;
+}
+.sticky-col-1 { width: 120px; left: 0px;   z-index: 10; }
+.sticky-col-2 { width: 120px; left: 120px; z-index: 9;  }
+.sticky-col-3 { width: 120px; left: 240px; z-index: 8;  }
+.sticky-col-4 { width: 100px; left: 360px; z-index: 7;  }
+#late-day-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--default-white);
+    z-index: 20;
+}
+#late-day-table thead th.sticky-col {
+    z-index: 30;
+}
+#late-day-table tbody tr {
+    background: var(--default-white);
+}
+#late-day-table tbody tr:nth-child(even) {
+    background: var(--standard-light-gray);
+}
+#late-day-table tbody tr:nth-child(even) .sticky-col {
+    background: var(--standard-light-gray);
+}
+#late-day-table tbody tr:nth-child(odd) .sticky-col {
+    background: var(--default-white);
 }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -1,17 +1,21 @@
 .flagged-row {
+    /* stylelint-disable-next-line color-named */
     background-color: red;
 }
+
 #empty-table {
     margin: 10px auto;
     padding: 1.6em 1em;
     text-align: center;
     border-radius: 8px;
 }
+
 .mobile-table {
     min-width: 100%;
     width: auto;
     text-align: center;
 }
+
 .mobile-table caption {
     padding: 0.5em;
     font-weight: bold;
@@ -19,19 +23,23 @@
     width: 100%;
     display: block;
 }
+
 .mobile-table th {
     padding: 5px;
 }
+
 .mobile-table th,
 .mobile-table td {
     box-sizing: border-box;
     min-width: 80px;
 }
+
 .section-break {
     border-top: 1px solid var(--standard-hover-light-gray);
     font-weight: normal;
     padding: 0.5em;
 }
+
 @media (max-width: 830px) {
     table.mobile-table,
     .mobile-table thead,
@@ -42,10 +50,14 @@
         display: block;
         border: none;
     }
+
     .mobile-table tr {
         margin-top: 1em;
+        /* stylelint-disable-next-line declaration-no-important */
         background: none !important;
     }
+
+    /* Hide table headers */
     .mobile-table thead tr {
         position: absolute;
         width: 1px;
@@ -56,6 +68,7 @@
         clip-path: inset(50%);
         border: 0;
     }
+
     .mobile-table td {
         display: flex;
         justify-content: space-between;
@@ -63,63 +76,80 @@
         padding: 2px 8px;
         margin: 2px 0;
     }
+
     .mobile-table tr:nth-child(even) td {
         background: var(--standard-hover-light-gray);
     }
+
     .mobile-table tr:nth-child(odd) td {
         background: var(--standard-light-gray);
     }
+
     .mobile-table td::before {
         padding-right: 1em;
         font-weight: bold;
     }
 }
+
 @media (min-width: 831px) {
     .mobile-table {
         border: 1px solid var(--standard-hover-light-gray);
     }
+
     .mobile-table caption {
         display: table-caption;
     }
+
     .section-break {
         padding: 0;
     }
+
     .mobile-table td::before {
+        /* stylelint-disable-next-line declaration-no-important */
         content: none !important;
     }
+
     .mobile-table td:first-child,
     .mobile-table th:first-child {
         padding-left: 15px;
     }
+
     .mobile-table td:last-child,
     .mobile-table th:last-child {
         padding-right: 15px;
     }
 }
+
 .peer-table-data {
     width: 50px;
 }
+
 .peer-table-header {
     width: 80px;
 }
+
 .peer-table-title-data {
     text-align: left;
 }
+
 .table-scroll {
     overflow-x: auto;
     width: 100%;
 }
+
 .sticky-col {
     position: sticky;
     background: var(--default-white);
     box-sizing: border-box;
 }
+
 :root {
     --col1-width: 120px;
     --col2-width: 120px;
     --col3-width: 120px;
     --col4-width: 70px;
 }
+
 .sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 10; }
 .sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 9;  }
 .sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 8;  }
@@ -143,6 +173,7 @@
 #late-day-table thead th.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 34; }
 #late-day-table thead th.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 33; }
 #late-day-table thead th.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 32; }
+
 #late-day-table tbody tr {
     background: var(--default-white);
 }
@@ -155,6 +186,7 @@
 #late-day-table tbody tr:nth-child(odd) .sticky-col {
     background: var(--default-white);
 }
+
 #late-day-table tbody td.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); white-space: nowrap; left: 0; z-index: 25; }
 #late-day-table tbody td.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 24; }
 #late-day-table tbody td.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 23; }

--- a/site/public/css/table.css
+++ b/site/public/css/table.css
@@ -150,10 +150,30 @@
     --col4-width: 70px;
 }
 
-.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 10; }
-.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 9;  }
-.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 8;  }
-.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 7;  }
+.sticky-col-1 {
+    width: var(--col1-width);
+    min-width: var(--col1-width);
+    left: 0;
+    z-index: 10;
+}
+.sticky-col-2 {
+    width: var(--col2-width);
+    min-width: var(--col2-width);
+    left: var(--col1-width);
+    z-index: 9;
+}
+.sticky-col-3 {
+    width: var(--col3-width);
+    min-width: var(--col3-width);
+    left: calc(var(--col1-width) + var(--col2-width));
+    z-index: 8;
+}
+.sticky-col-4 {
+    width: var(--col4-width);
+    min-width: var(--col4-width);
+    left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width));
+    z-index: 7;
+}
 
 #late-day-table thead th {
     position: sticky;
@@ -169,10 +189,30 @@
 #late-day-table thead th.sticky-col {
     z-index: 30;
 }
-#late-day-table thead th.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); left: 0;   z-index: 35; }
-#late-day-table thead th.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 34; }
-#late-day-table thead th.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 33; }
-#late-day-table thead th.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 32; }
+#late-day-table thead th.sticky-col-1 {
+    width: var(--col1-width);
+    min-width: var(--col1-width);
+    left: 0;
+    z-index: 35;
+}
+#late-day-table thead th.sticky-col-2 {
+    width: var(--col2-width);
+    min-width: var(--col2-width);
+    left: var(--col1-width);
+    z-index: 34;
+}
+#late-day-table thead th.sticky-col-3 {
+    width: var(--col3-width);
+    min-width: var(--col3-width);
+    left: calc(var(--col1-width) + var(--col2-width));
+    z-index: 33;
+}
+#late-day-table thead th.sticky-col-4 {
+    width: var(--col4-width);
+    min-width: var(--col4-width);
+    left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width));
+    z-index: 32;
+}
 
 #late-day-table tbody tr {
     background: var(--default-white);
@@ -187,7 +227,28 @@
     background: var(--default-white);
 }
 
-#late-day-table tbody td.sticky-col-1 { width: var(--col1-width); min-width: var(--col1-width); white-space: nowrap; left: 0; z-index: 25; }
-#late-day-table tbody td.sticky-col-2 { width: var(--col2-width); min-width: var(--col2-width); left: var(--col1-width); z-index: 24; }
-#late-day-table tbody td.sticky-col-3 { width: var(--col3-width); min-width: var(--col3-width); left: calc(var(--col1-width) + var(--col2-width)); z-index: 23; }
-#late-day-table tbody td.sticky-col-4 { width: var(--col4-width); min-width: var(--col4-width); left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width)); z-index: 22; }
+#late-day-table tbody td.sticky-col-1 {
+    width: var(--col1-width);
+    min-width: var(--col1-width);
+    white-space: nowrap;
+    left: 0;
+    z-index: 25;
+}
+#late-day-table tbody td.sticky-col-2 {
+    width: var(--col2-width);
+    min-width: var(--col2-width);
+    left: var(--col1-width);
+    z-index: 24;
+}
+#late-day-table tbody td.sticky-col-3 {
+    width: var(--col3-width);
+    min-width: var(--col3-width);
+    left: calc(var(--col1-width) + var(--col2-width));
+    z-index: 23;
+}
+#late-day-table tbody td.sticky-col-4 {
+    width: var(--col4-width);
+    min-width: var(--col4-width);
+    left: calc(var(--col1-width) + var(--col2-width) + var(--col3-width));
+    z-index: 22;
+}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The first 4 columns (User ID, Given Name, Family Name, Initial) were not staying fixed when scrolling the table left and right. They were moving around and overlapping each other, making the table hard to read.

### What is the New Behavior?
The first 4 columns now stay fixed on the left side when you scroll the table horizontally.

**After screenshot:**
<img width="1900" height="905" alt="image" src="https://github.com/user-attachments/assets/c428972e-b433-4206-a598-f04006b4fdd4" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Go to the Bulk Late Days page
2. Scroll the table to the right
3. Check that the first 4 columns stay fixed and visible
4. Check that no columns overlap each other

### Automated Testing & Documentation
No tests needed. This is a CSS only fix.

### Other information
No breaking changes. Added CSS to make the first 4 columns sticky with correct widths and positions.