### PR TITLE
Add Cypress test to ensure legal names are not displayed in UI

### DIFF
--- a/site/cypress/e2e/Cypress-UI/name_privacy.spec.js
+++ b/site/cypress/e2e/Cypress-UI/name_privacy.spec.js
@@ -12,9 +12,14 @@ describe('Legal name privacy test', () => {
     cy.document().then((doc) => {
       const html = doc.documentElement.innerHTML;
 
+      // Ensure legal names never appear in UI
       expect(html).to.not.contain(legalFirst);
       expect(html).to.not.contain(legalLast);
     });
+
+    // Also check visible name fields
+    cy.get('body').should('not.contain', legalFirst);
+    cy.get('body').should('not.contain', legalLast);
 
   });
 


### PR DESCRIPTION
### What change does this PR introduce?

This PR adds a Cypress E2E test to ensure that legal names are not displayed in the UI when preferred names exist.

The test verifies that legal names never appear in rendered HTML pages.

### Why is this change important?

Previously, there were bugs where legal names appeared in some UI pages.
This test helps prevent regressions by ensuring that legal names are never displayed.

Fixes #8435
