### PR TITLE
Clarify file upload limit message to reduce student confusion

### DIFF
--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -467,7 +467,7 @@
             {% if viewing_inactive_version %}
                 <h3 style="color: #666666;">Switch to most recent version to upload files</h3>
             {% else %}
-                <p>Maximum allowed number of files to be uploaded is {{ max_file_uploads }}.</p>
+                <p>Maximum <strong>{{ max_file_uploads }} files</strong> allowed per submission. <em>This limit applies only to the number of files in a single submission and does not affect the number of submission attempts.</em></p>
             {% endif %}
         </div>
     </div>

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -266,7 +266,7 @@
                     {% if viewing_inactive_version %}
                         <h3 style="color: #666666;">Switch to most recent version to upload files</h3>
                     {% else %}
-                        <p>Maximum allowed number of files to be uploaded is {{ max_file_uploads }}.</p>
+                        <p>Maximum <strong>{{ max_file_uploads }} files</strong> allowed per submission. <em>This limit applies only to the number of files in a single submission and does not affect the number of submission attempts.</em></p>
                     {% endif %}
                 </div>
             {% endfor %}


### PR DESCRIPTION
### Why is this change important?

The previous message about the file upload limit could be slightly confusing for students.
It might make users think that the limit applies to the total number of submissions.

This change clarifies that the limit only applies to the number of files that can be uploaded **per submission attempt**, not the number of attempts.

### What is the new behavior?

The message on the submission page now clearly states that the limit applies only to the number of files in a single submission. This helps avoid misunderstanding for students when uploading their work.

### How can reviewers test this?

1. Open any gradeable submission page.
2. Locate the file upload area.
3. Check the message showing the file upload limit.

The updated text should clearly explain that the limit applies **per submission**, not to the total number of submissions.

### Additional notes

This is a small UI text clarification intended to improve usability and reduce confusion for students.
