### PR TITLE
[UI/UX] Fix sticky column freeze and overlap on Bulk Late Days table (#12534)

### DIFF
--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -32,18 +32,14 @@ tr > td:nth-child(3) {
     left: 5.25rem;
 }
 
+
 tr > th:nth-child(4),
 tr > td:nth-child(4) {
     position: sticky;
     left: 10.75rem;
+    border-right: 1px solid var(--standard-medium-gray);  
 }
 
-tr > th:nth-child(5),
-tr > td:nth-child(5) {
-    position: sticky;
-    left: 16.75rem;
-    border-right: 1px solid var(--standard-medium-gray);
-}
 
 .highlighted-row td:nth-child(n + 1):nth-child(-n + 5) {
     /* stylelint-disable-next-line declaration-no-important */


### PR DESCRIPTION
Fixes #12534.

The Bulk Late Days table had position sticky incorrectly applied to 5 columns instead of 4. The 5th column (first gradeable) was being frozen unintentionally and the border-right separator was on the wrong column.

## What Changed
- Removed position sticky from nth-child(5) so the first gradeable column now scrolls normally
- Moved border-right separator to nth-child(4) which is the correct last frozen column
- Only the intended 4 columns remain frozen: User ID, Given Name, Family Name and Initial

## How to Test
1. Login as instructor
2. Go to sample course and open Bulk Late Days
3. Horizontally scroll the table
4. Confirm first 4 columns stay frozen with no overlap
5. Confirm gradeable columns scroll normally

## Notes
- No breaking changes
- No migrations required
- CSS only fix in site/public/css/simple-grading.css