### PR TITLE
[Bugfix:RainbowGrades] Guard null bucket access in customizations

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -138,7 +138,11 @@ class RainbowCustomization extends AbstractModel {
                 $bucket = $json_bucket->type;
 
                 // Filter out removed gradeables or updated gradeable buckets
-                $this->customization_data[$bucket] = array_values(array_filter($this->customization_data[$bucket], function ($g) use ($gradeable_buckets, $json_bucket) {
+                $existing_bucket_data = $this->customization_data[$bucket] ?? [];
+                if (!is_array($existing_bucket_data)) {
+                    $existing_bucket_data = [];
+                }
+                $this->customization_data[$bucket] = array_values(array_filter($existing_bucket_data, function ($g) use ($gradeable_buckets, $json_bucket) {
                     $removed = !isset($gradeable_buckets[$g['id']]);
                     $swapped = !$removed && $gradeable_buckets[$g['id']] !== $json_bucket->type;
                     return !$removed && !$swapped;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12544.

Old courses can contain `null` bucket entries in stored rainbow customization data. The current code passes that `null` directly to `array_filter`, which throws a fatal `TypeError` and crashes the customization page.

### What is the New Behavior?
When reading an existing customization bucket, the code now normalizes missing or non-array bucket data to an empty array before filtering removed/swapped gradeables. This prevents the crash while preserving existing filtering logic for valid array inputs.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Use a course where rainbow customization JSON includes a bucket key with `null` value (or temporarily inject one).
2. Open the rainbow grades customization page.
3. Before this fix: page crashes with `array_filter(): Argument #1 ($array) must be of type array, null given`.
4. After this fix: page loads successfully and bucket cleanup proceeds.

### Automated Testing & Documentation
- Could not run PHP lint/test commands in this runner because `php` is not installed (`php: command not found`).
- Change is scoped to a defensive type guard around existing logic; no behavior change for valid array inputs.
- No documentation changes required.

### Other information
- Not a breaking change.
- No migrations.
- No additional security concerns.