### PR TITLE
[Feature: Forum] Improve Live Chat Anonymous Naming

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@ Christopher Reed, 2021-current
 William Allen, 2021-current  
 
 
+
 ## Developers  
 
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,4 @@
-## Admins / Project Managers  
-
+## Admins / Project Managers
 [Barbara Cutler](http://www.cs.rpi.edu/~cutler/) 2014-current  
 [Matthew Peveler](http://mpeveler.com/) 2014-current  
 Christopher Reed, 2021-current  

--- a/migration/migrator/data/course_tables.sql
+++ b/migration/migrator/data/course_tables.sql
@@ -776,6 +776,40 @@ ALTER SEQUENCE public.chatroom_messages_id_seq OWNED BY public.chatroom_messages
 
 
 --
+-- Name: chatroom_participants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chatroom_participants (
+    id integer NOT NULL,
+    chatroom_id integer NOT NULL,
+    user_id character varying NOT NULL,
+    anon_salt character varying(64) NOT NULL,
+    session_snapshot character varying(32) DEFAULT NULL::character varying,
+    anon_name character varying(64) DEFAULT NULL::character varying
+);
+
+
+--
+-- Name: chatroom_participants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.chatroom_participants_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: chatroom_participants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.chatroom_participants_id_seq OWNED BY public.chatroom_participants.id;
+
+
+--
 -- Name: chatrooms; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2126,6 +2160,13 @@ ALTER TABLE ONLY public.chatroom_messages ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
+-- Name: chatroom_participants id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chatroom_participants ALTER COLUMN id SET DEFAULT nextval('public.chatroom_participants_id_seq'::regclass);
+
+
+--
 -- Name: chatrooms id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2355,6 +2396,14 @@ ALTER TABLE ONLY public.categories_list
 
 ALTER TABLE ONLY public.chatroom_messages
     ADD CONSTRAINT chatroom_messages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chatroom_participants chatroom_participants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chatroom_participants
+    ADD CONSTRAINT chatroom_participants_pkey PRIMARY KEY (id);
 
 
 --
@@ -2814,6 +2863,14 @@ ALTER TABLE ONLY public.course_materials_sections
 
 
 --
+-- Name: chatroom_participants unique_participant; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chatroom_participants
+    ADD CONSTRAINT unique_participant UNIQUE (chatroom_id, user_id);
+
+
+--
 -- Name: student_favorites user_and_thread_unique; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3040,6 +3097,22 @@ ALTER TABLE ONLY public.chatroom_messages
 
 
 --
+-- Name: chatroom_participants chatroom_participants_chatroom_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chatroom_participants
+    ADD CONSTRAINT chatroom_participants_chatroom_id_fkey FOREIGN KEY (chatroom_id) REFERENCES public.chatrooms(id) ON DELETE CASCADE;
+
+
+--
+-- Name: chatroom_participants chatroom_participants_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chatroom_participants
+    ADD CONSTRAINT chatroom_participants_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+
+--
 -- Name: chatrooms chatrooms_host_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3128,19 +3201,19 @@ ALTER TABLE ONLY public.electronic_gradeable_version
 
 
 --
--- Name: course_materials_sections fk_course_material_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.course_materials_sections
-    ADD CONSTRAINT fk_course_material_id FOREIGN KEY (course_material_id) REFERENCES public.course_materials(id) ON DELETE CASCADE;
-
-
---
 -- Name: course_materials_access fk_course_material_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.course_materials_access
     ADD CONSTRAINT fk_course_material_id FOREIGN KEY (course_material_id) REFERENCES public.course_materials(id);
+
+
+--
+-- Name: course_materials_sections fk_course_material_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.course_materials_sections
+    ADD CONSTRAINT fk_course_material_id FOREIGN KEY (course_material_id) REFERENCES public.course_materials(id) ON DELETE CASCADE;
 
 
 --
@@ -3850,4 +3923,6 @@ ALTER TABLE ONLY public.viewed_responses
 --
 -- PostgreSQL database dump complete
 --
+
+\unrestrict 3cdKqak14NZ2Ot8MJdJeLfM7AabzHzuCwb5RZ0dOzY4rlof5rWd1RNC0hrmZhL3
 

--- a/migration/migrator/migrations/course/20260306120000_chatroom_participants.py
+++ b/migration/migrator/migrations/course/20260306120000_chatroom_participants.py
@@ -1,0 +1,52 @@
+"""Migration for a given Submitty course database."""
+
+
+def up(config, database, semester, course):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute(
+        """
+
+        CREATE TABLE IF NOT EXISTS chatroom_participants (
+            id SERIAL PRIMARY KEY,
+            chatroom_id integer NOT NULL REFERENCES chatrooms(id) ON DELETE CASCADE,
+            user_id character varying NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+            anon_salt character varying(64) NOT NULL,
+            session_snapshot character varying(32) DEFAULT NULL,
+            anon_name character varying(64) DEFAULT NULL,
+            CONSTRAINT unique_participant UNIQUE (chatroom_id, user_id)
+        );
+        """
+    )
+
+
+def down(config, database, semester, course):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    :param semester: Semester of the course being migrated
+    :type semester: str
+    :param course: Code of course being migrated
+    :type course: str
+    """
+    database.execute(
+        """
+        DROP TABLE IF EXISTS chatroom_participants;
+        ALTER TABLE chatrooms DROP COLUMN IF EXISTS allow_read_only_after_end;
+        """
+    )
+

--- a/site/app/controllers/ChatroomController.php
+++ b/site/app/controllers/ChatroomController.php
@@ -121,7 +121,6 @@ class ChatroomController extends AbstractController {
         $user = $this->core->getUser();
         $title = $_POST['title'] ?? '';
         $description = $_POST['description'] ?? '';
-        $allow_read_only_after_end = isset($_POST['allow_read_only_after_end']);
 
         $userEntity = $em->getRepository(UserEntity::class)->find($user->getId());
 
@@ -135,7 +134,6 @@ class ChatroomController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
         $chatroom = new Chatroom($userEntity, $title, $description);
-        $chatroom->setAllowReadOnlyAfterEnd($allow_read_only_after_end);
         if (!isset($_POST['allow-anon'])) {
             $chatroom->setAllowAnon(false);
         }
@@ -168,11 +166,7 @@ class ChatroomController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
 
-        if (
-            !$chatroom->isActive()
-            && !$chatroom->allowReadOnlyAfterEnd()
-            && !$this->core->getUser()->accessAdmin()
-        ) {
+        if (!$chatroom->isActive() && !$this->core->getUser()->accessAdmin()) {
             $this->core->addErrorMessage("Chatroom not enabled");
             return new RedirectResponse(
                 $this->core->buildCourseUrl(['chat'])
@@ -219,9 +213,6 @@ class ChatroomController extends AbstractController {
             $this->core->addErrorMessage("Chatroom not found");
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
-        $chatroom->setAllowReadOnlyAfterEnd(
-            isset($_POST['allow_read_only_after_end'])
-        );
         $title = $_POST['title'] ?? '';
         $description = $_POST['description'] ?? '';
         if (trim($title) === '') {
@@ -263,14 +254,9 @@ class ChatroomController extends AbstractController {
             $msg_array['type'] = 'chat_close';
             // indiv_msg_array sends to kick people out of closing chatrooms, msg_array sends to remove/add the chatroom to the chat list
             $indiv_msg_array = [];
-            $msg_array['allow_read_only_after_end'] = $chatroom->allowReadOnlyAfterEnd();
-
-            if (!$chatroom->allowReadOnlyAfterEnd()) {
-                $indiv_msg_array = [];
-                $indiv_msg_array['type'] = 'chat_close';
-                $indiv_msg_array['chatroom_id'] = $chatroom->getId();
-                $this->sendSocketMessage($indiv_msg_array, true);
-            }
+            $indiv_msg_array['type'] = 'chat_close';
+            $indiv_msg_array['chatroom_id'] = $chatroom->getId();
+            $this->sendSocketMessage($indiv_msg_array, true);
         }
         $this->sendSocketMessage($msg_array);
         $chatroom->setSessionStartedAt($chatroom->isActive() ? null : new \DateTime("now"));
@@ -311,10 +297,6 @@ class ChatroomController extends AbstractController {
             return JsonResponse::getFailResponse("Chatroom not found");
         }
         if (!$chatroom->isActive() && !$user->accessAdmin()) {
-            if ($chatroom->allowReadOnlyAfterEnd()) {
-                return JsonResponse::getFailResponse("This chatroom is read-only.");
-            }
-
             return JsonResponse::getFailResponse("This chatroom is not enabled");
         }
         if (strcmp($_POST['content'], "") === 0) {

--- a/site/app/controllers/ChatroomController.php
+++ b/site/app/controllers/ChatroomController.php
@@ -6,6 +6,7 @@ use app\libraries\response\WebResponse;
 use app\libraries\response\JsonResponse;
 use app\libraries\response\RedirectResponse;
 use app\entities\chat\Chatroom;
+use app\entities\chat\ChatroomParticipant;
 use app\entities\chat\Message;
 use app\entities\UserEntity;
 use app\libraries\routers\AccessControl;
@@ -17,6 +18,30 @@ use WebSocket;
 
 #[Enabled(feature: "chat")]
 class ChatroomController extends AbstractController {
+    /**
+     * Retrieves the ChatroomParticipant record for the current user in the given chatroom,
+     * creating and persisting one (with a fresh random salt) if none exists yet.
+     */
+    private function getOrCreateParticipant(Chatroom $chatroom): ChatroomParticipant {
+        $em = $this->core->getCourseEntityManager();
+        $user = $this->core->getUser();
+
+        $participant = $em->getRepository(ChatroomParticipant::class)->findOneBy([
+            'chatroom' => $chatroom,
+            'user' => $user->getId(),
+        ]);
+
+        if ($participant === null) {
+            $userEntity = $em->getRepository(UserEntity::class)->find($user->getId());
+            $participant = new ChatroomParticipant($chatroom, $userEntity);
+            $em->persist($participant);
+            // Flush immediately so the salt is saved before name resolution.
+            $em->flush();
+        }
+
+        return $participant;
+    }
+
     /**
      * Send a message over WebSocket.
      *
@@ -96,6 +121,7 @@ class ChatroomController extends AbstractController {
         $user = $this->core->getUser();
         $title = $_POST['title'] ?? '';
         $description = $_POST['description'] ?? '';
+        $allow_read_only_after_end = isset($_POST['allow_read_only_after_end']);
 
         $userEntity = $em->getRepository(UserEntity::class)->find($user->getId());
 
@@ -109,6 +135,7 @@ class ChatroomController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
         $chatroom = new Chatroom($userEntity, $title, $description);
+        $chatroom->setAllowReadOnlyAfterEnd($allow_read_only_after_end);
         if (!isset($_POST['allow-anon'])) {
             $chatroom->setAllowAnon(false);
         }
@@ -141,7 +168,11 @@ class ChatroomController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
 
-        if (!$chatroom->isActive() && !$this->core->getUser()->accessAdmin()) {
+        if (
+            !$chatroom->isActive()
+            && !$chatroom->allowReadOnlyAfterEnd()
+            && !$this->core->getUser()->accessAdmin()
+        ) {
             $this->core->addErrorMessage("Chatroom not enabled");
             return new RedirectResponse(
                 $this->core->buildCourseUrl(['chat'])
@@ -188,6 +219,9 @@ class ChatroomController extends AbstractController {
             $this->core->addErrorMessage("Chatroom not found");
             return new RedirectResponse($this->core->buildCourseUrl(['chat']));
         }
+        $chatroom->setAllowReadOnlyAfterEnd(
+            isset($_POST['allow_read_only_after_end'])
+        );
         $title = $_POST['title'] ?? '';
         $description = $_POST['description'] ?? '';
         if (trim($title) === '') {
@@ -229,9 +263,14 @@ class ChatroomController extends AbstractController {
             $msg_array['type'] = 'chat_close';
             // indiv_msg_array sends to kick people out of closing chatrooms, msg_array sends to remove/add the chatroom to the chat list
             $indiv_msg_array = [];
-            $indiv_msg_array['type'] = 'chat_close';
-            $indiv_msg_array['chatroom_id'] = $chatroom->getId();
-            $this->sendSocketMessage($indiv_msg_array, true);
+            $msg_array['allow_read_only_after_end'] = $chatroom->allowReadOnlyAfterEnd();
+
+            if (!$chatroom->allowReadOnlyAfterEnd()) {
+                $indiv_msg_array = [];
+                $indiv_msg_array['type'] = 'chat_close';
+                $indiv_msg_array['chatroom_id'] = $chatroom->getId();
+                $this->sendSocketMessage($indiv_msg_array, true);
+            }
         }
         $this->sendSocketMessage($msg_array);
         $chatroom->setSessionStartedAt($chatroom->isActive() ? null : new \DateTime("now"));
@@ -272,6 +311,10 @@ class ChatroomController extends AbstractController {
             return JsonResponse::getFailResponse("Chatroom not found");
         }
         if (!$chatroom->isActive() && !$user->accessAdmin()) {
+            if ($chatroom->allowReadOnlyAfterEnd()) {
+                return JsonResponse::getFailResponse("This chatroom is read-only.");
+            }
+
             return JsonResponse::getFailResponse("This chatroom is not enabled");
         }
         if (strcmp($_POST['content'], "") === 0) {
@@ -283,7 +326,8 @@ class ChatroomController extends AbstractController {
         $msg_array['user_id'] = $isAnonymous ? 'null' : $user->getId();
         $display_name = '';
         if ($chatroom->isAllowAnon() && $isAnonymous) {
-            $display_name = $chatroom->calcAnonName($user->getId());
+            $participant = $this->getOrCreateParticipant($chatroom);
+            $display_name = $chatroom->resolveAnonName($participant);
         }
         else {
             if ($user->accessAdmin()) {
@@ -327,5 +371,28 @@ class ChatroomController extends AbstractController {
             $this->sendSocketMessage($msg_array, true);
         }
         return JsonResponse::getSuccessResponse("cleared chatroom $chatroom_id successfully");
+    }
+
+    #[AccessControl(role: "INSTRUCTOR")]
+    #[Route("/api/courses/{_semester}/{_course}/chat/{chatroom_id}/regenerateAnonNames", methods: ["POST"], requirements: ["chatroom_id" => "\d+"])]
+    #[Route("/courses/{_semester}/{_course}/chat/{chatroom_id}/regenerateAnonNames", methods: ["POST"], requirements: ["chatroom_id" => "\d+"])]
+    public function regenerateAnonNames(string $chatroom_id): JsonResponse {
+        $em = $this->core->getCourseEntityManager();
+        $chatroom = $em->getRepository(Chatroom::class)->find($chatroom_id);
+
+        if ($chatroom === null) {
+            return JsonResponse::getFailResponse("Chatroom not found");
+        }
+
+        $chatroom->regenerateAnonNames();
+        $em->flush();
+
+        $msg_array = [
+            'type'        => 'anon_names_regenerated',
+            'chatroom_id' => $chatroom->getId(),
+        ];
+        $this->sendSocketMessage($msg_array, true);
+
+        return JsonResponse::getSuccessResponse("Anonymous names regenerated");
     }
 }

--- a/site/app/entities/chat/Chatroom.php
+++ b/site/app/entities/chat/Chatroom.php
@@ -13,6 +13,24 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 #[ORM\Table(name: "chatrooms")]
 class Chatroom {
+    // 50 adjectives × 50 nouns = 2,500 base name combinations.
+    // Far exceeds typical class sizes, keeping numeric-suffix collisions rare.
+    private const ADJECTIVES = [
+        "Quick","Lazy","Cheerful","Pensive","Mysterious","Bright","Sly","Brave","Calm","Eager",
+        "Fierce","Gentle","Jolly","Kind","Lively","Nice","Proud","Quiet","Rapid","Swift",
+        "Bold","Clever","Daring","Earnest","Fancy","Graceful","Happy","Honest","Icy","Jumpy",
+        "Keen","Loving","Merry","Noble","Odd","Peppy","Quirky","Rowdy","Silly","Tidy",
+        "Unique","Vivid","Warm","Xenial","Youthful","Zany","Agile","Bouncy","Crafty","Dazzling",
+    ];
+
+    private const NOUNS = [
+        "Duck","Goose","Swan","Eagle","Parrot","Owl","Sparrow","Robin","Pigeon","Falcon",
+        "Hawk","Flamingo","Pelican","Seagull","Cardinal","Canary","Finch","Hummingbird","Crane","Heron",
+        "Ibis","Kingfisher","Lark","Magpie","Nightjar","Oriole","Penguin","Quail","Raven","Stork",
+        "Toucan","Vulture","Warbler","Xenops","Yellowthroat","Albatross","Bluebird","Cockatoo","Dove","Egret",
+        "Partridge","Puffin","Roadrunner","Sandpiper","Thrush","Wren","Macaw","Kestrel","Booby","Jay",
+    ];
+
     #[ORM\Id]
     #[ORM\Column(name: "id", type: Types::INTEGER)]
     #[ORM\GeneratedValue]
@@ -37,6 +55,9 @@ class Chatroom {
     #[ORM\Column(type: Types::BOOLEAN)]
     private bool $allow_anon;
 
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $allow_read_only_after_end = false;
+
     #[ORM\Column(type: Types::DATETIMETZ_MUTABLE, nullable: true)]
     private ?\DateTime $session_started_at = null;
 
@@ -46,14 +67,22 @@ class Chatroom {
     #[ORM\OneToMany(mappedBy: "chatroom", targetEntity: Message::class)]
     private Collection $messages;
 
+    /**
+     * @var Collection<ChatroomParticipant>
+     */
+    #[ORM\OneToMany(mappedBy: "chatroom", targetEntity: ChatroomParticipant::class, fetch: "EAGER")]
+    private Collection $participants;
+
     public function __construct(UserEntity $host, string $title, string $description) {
         $this->host = $host;
         $this->setTitle($title);
         $this->setDescription($description);
         $this->messages = new ArrayCollection();
+        $this->participants = new ArrayCollection();
         $this->is_active = false;
         $this->allow_anon = true;
         $this->is_deleted = false;
+        $this->allow_read_only_after_end = false;
     }
 
     public function getId(): int {
@@ -120,18 +149,8 @@ class Chatroom {
         return $this->is_deleted;
     }
 
-    public function calcAnonName(string $user_id): string {
-        $adjectives = ["Quick","Lazy","Cheerful","Pensive","Mysterious","Bright","Sly","Brave","Calm","Eager","Fierce","Gentle","Jolly","Kind","Lively","Nice","Proud","Quiet","Rapid","Swift"];
-        $nouns      = ["Duck","Goose","Swan","Eagle","Parrot","Owl","Sparrow","Robin","Pigeon","Falcon","Hawk","Flamingo","Pelican","Seagull","Cardinal","Canary","Finch","Hummingbird"];
-        $session_started_at = $this->getSessionStartedAt() !== null ? $this->getSessionStartedAt()->format('Y-m-d H:i:s') : 'unknown';
-        $seed_string = $user_id . '-' . $this->getId() . '-' . $this->getHostId() . '-' . $session_started_at;
-        $adj_hash = crc32($seed_string);
-        $noun_hash = crc32(strrev($seed_string));
-        $adj_index = abs($adj_hash) % count($adjectives);
-        $noun_index = abs($noun_hash) % count($nouns);
-        $adj  = $adjectives[$adj_index];
-        $noun = $nouns[$noun_index];
-        return "Anonymous {$adj} {$noun}";
+    public function getParticipants(): Collection {
+        return $this->participants;
     }
 
     public function getSessionStartedAt(): ?\DateTime {
@@ -140,5 +159,103 @@ class Chatroom {
 
     public function setSessionStartedAt(?\DateTime $session_started_at): void {
         $this->session_started_at = $session_started_at;
+    }
+
+    /**
+     * Bumps session_started_at to now and clears all stored anonymous names so
+     * they are re-derived on the next resolveAnonName() call.
+     * Can be triggered by the instructor via the "Regenerate Names" button.
+     */
+    public function regenerateAnonNames(): void {
+        $this->session_started_at = new \DateTime();
+        foreach ($this->participants as $participant) {
+            $participant->clearAnonName();
+        }
+    }
+
+    /**
+     * Derives a deterministic base anonymous name from the participant's stored
+     * cryptographically random salt via HMAC-SHA256.
+     * The salt is generated once at join time and never changes, so the mapping
+     * is stable across cookie clears and re-logins.
+     */
+    private function deriveBaseAnonName(ChatroomParticipant $participant): string {
+        $hmac = hash_hmac('sha256', $participant->getAnonSalt(), 'submitty-anon-name');
+        $adj_index  = hexdec(substr($hmac, 0, 8))  % count(self::ADJECTIVES);
+        $noun_index = hexdec(substr($hmac, 8, 8))  % count(self::NOUNS);
+        return 'Anonymous ' . self::ADJECTIVES[$adj_index] . ' ' . self::NOUNS[$noun_index];
+    }
+
+    /**
+     * Returns the set of anonymous names already assigned in the current session,
+     * excluding the given participant.
+     *
+     * @return string[]
+     */
+    private function getTakenNamesThisSession(ChatroomParticipant $excluding): array {
+        $snapshot = $this->session_started_at?->format('Y-m-d H:i:s') ?? 'unknown';
+        $taken = [];
+        foreach ($this->participants as $p) {
+            if ($p === $excluding) {
+                continue;
+            }
+            if ($p->getSessionSnapshot() === $snapshot && $p->getAnonName() !== null) {
+                $taken[] = $p->getAnonName();
+            }
+        }
+        return $taken;
+    }
+
+    /**
+     * Resolves and caches the anonymous name for a participant in this chatroom session.
+     *
+     * - If the participant already has a name recorded for the current session, returns it.
+     * - Otherwise, derives a base name from their permanent random salt, checks for
+     *   collisions among other participants in this session, and appends a numeric suffix
+     *   if necessary (e.g. "Anonymous Quick Duck 2").
+     * - The resolved name is stored on the participant entity so the caller must flush
+     *   the entity manager to persist it.
+     */
+    public function resolveAnonName(ChatroomParticipant $participant): string {
+        $snapshot = $this->session_started_at?->format('Y-m-d H:i:s') ?? 'unknown';
+
+        // Return cached name if it belongs to the current session.
+        if (
+            $participant->getAnonName() !== null
+            && $participant->getSessionSnapshot() === $snapshot
+        ) {
+            return $participant->getAnonName();
+        }
+
+        $baseName = $this->deriveBaseAnonName($participant);
+        $taken    = $this->getTakenNamesThisSession($participant);
+
+        if (!in_array($baseName, $taken, true)) {
+            $resolvedName = $baseName;
+        }
+        else {
+            $suffix = 2;
+            do {
+                $resolvedName = "{$baseName} {$suffix}";
+                $suffix++;
+            } while (in_array($resolvedName, $taken, true));
+        }
+
+        $participant->setAnonName($resolvedName);
+        $participant->setSessionSnapshot($snapshot);
+
+        return $resolvedName;
+    }
+
+    public function allowReadOnlyAfterEnd(): bool {
+        return $this->allow_read_only_after_end;
+    }
+
+    public function setAllowReadOnlyAfterEnd(bool $allow): void {
+        $this->allow_read_only_after_end = $allow;
+    }
+
+    public function isReadOnly(): bool {
+        return !$this->isActive() && $this->allowReadOnlyAfterEnd();
     }
 }

--- a/site/app/entities/chat/Chatroom.php
+++ b/site/app/entities/chat/Chatroom.php
@@ -55,9 +55,6 @@ class Chatroom {
     #[ORM\Column(type: Types::BOOLEAN)]
     private bool $allow_anon;
 
-    #[ORM\Column(type: Types::BOOLEAN)]
-    private bool $allow_read_only_after_end = false;
-
     #[ORM\Column(type: Types::DATETIMETZ_MUTABLE, nullable: true)]
     private ?\DateTime $session_started_at = null;
 
@@ -82,7 +79,6 @@ class Chatroom {
         $this->is_active = false;
         $this->allow_anon = true;
         $this->is_deleted = false;
-        $this->allow_read_only_after_end = false;
     }
 
     public function getId(): int {
@@ -247,15 +243,5 @@ class Chatroom {
         return $resolvedName;
     }
 
-    public function allowReadOnlyAfterEnd(): bool {
-        return $this->allow_read_only_after_end;
-    }
 
-    public function setAllowReadOnlyAfterEnd(bool $allow): void {
-        $this->allow_read_only_after_end = $allow;
-    }
-
-    public function isReadOnly(): bool {
-        return !$this->isActive() && $this->allowReadOnlyAfterEnd();
-    }
 }

--- a/site/app/entities/chat/ChatroomParticipant.php
+++ b/site/app/entities/chat/ChatroomParticipant.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\entities\chat;
+
+use app\entities\UserEntity;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: "chatroom_participants")]
+#[ORM\UniqueConstraint(name: "unique_participant", columns: ["chatroom_id", "user_id"])]
+class ChatroomParticipant {
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    private int $id;
+
+    #[ORM\ManyToOne(targetEntity: Chatroom::class, inversedBy: "participants")]
+    #[ORM\JoinColumn(name: "chatroom_id", referencedColumnName: "id", nullable: false)]
+    private Chatroom $chatroom;
+
+    #[ORM\ManyToOne(targetEntity: UserEntity::class)]
+    #[ORM\JoinColumn(name: "user_id", referencedColumnName: "user_id", nullable: false)]
+    private UserEntity $user;
+
+    /**
+     * Cryptographically random salt generated once per user per chatroom.
+     * Stored permanently — never changes regardless of cookie clearing or re-login,
+     * so the anonymous name base is always stable for a given user in a given room.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    private string $anon_salt;
+
+    /**
+     * Snapshot of the chatroom's session_started_at at the time this anon name was assigned.
+     * Used to detect when the session has been regenerated so the name should be re-derived.
+     */
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $session_snapshot = null;
+
+    /**
+     * The resolved anonymous name for the current session.
+     * Null means it hasn't been assigned yet this session.
+     */
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true)]
+    private ?string $anon_name = null;
+
+    public function __construct(Chatroom $chatroom, UserEntity $user) {
+        $this->chatroom = $chatroom;
+        $this->user = $user;
+        // 64 hex chars of cryptographically secure random data
+        $this->anon_salt = bin2hex(random_bytes(32));
+    }
+
+    public function getId(): int {
+        return $this->id;
+    }
+
+    public function getChatroom(): Chatroom {
+        return $this->chatroom;
+    }
+
+    public function getUser(): UserEntity {
+        return $this->user;
+    }
+
+    public function getAnonSalt(): string {
+        return $this->anon_salt;
+    }
+
+    public function getAnonName(): ?string {
+        return $this->anon_name;
+    }
+
+    public function setAnonName(?string $name): void {
+        $this->anon_name = $name;
+    }
+
+    public function getSessionSnapshot(): ?string {
+        return $this->session_snapshot;
+    }
+
+    public function setSessionSnapshot(?string $snapshot): void {
+        $this->session_snapshot = $snapshot;
+    }
+
+    public function clearAnonName(): void {
+        $this->anon_name = null;
+        $this->session_snapshot = null;
+    }
+}
+

--- a/site/app/templates/chat/Chatroom.twig
+++ b/site/app/templates/chat/Chatroom.twig
@@ -12,12 +12,10 @@
         </div>
         <div class="chatroom-content">
             <div class="messages-area"></div>
-            {% if not isReadOnly %}
-                <div class="input-container">
-                    <textarea name="content" class="message-input" placeholder="Enter your message here" maxlength=1500 data-testid="msg-input"></textarea>
-                    <button class="send-message-btn btn btn-primary" data-testid="send-btn">Send</button>
-                </div>
-            {% endif %}
+            <div class="input-container">
+                <textarea name="content" class="message-input" placeholder="Enter your message here" maxlength=1500 data-testid="msg-input"></textarea>
+                <button class="send-message-btn btn btn-primary" data-testid="send-btn">Send</button>
+            </div>
         </div>
     </div>
 </div>
@@ -28,7 +26,6 @@
         "userId": "{{ user_id }}",
         "displayName": "{{ user_display_name }}",
         "user_admin": "{{ user_admin }}",
-        "isAnonymous": "{{ anonymous }}",
-        "read_only": {{isReadOnly ? 'true' : 'false' }}
+        "isAnonymous": "{{ anonymous }}"
     }
 </script>

--- a/site/app/templates/chat/Chatroom.twig
+++ b/site/app/templates/chat/Chatroom.twig
@@ -3,14 +3,21 @@
     <div class="chatroom-container">
         <div class="chatroom-header">
             <span class="chatroom-title" data-testid="chat-title" title="{{ chatroom.getTitle() }}"> {{ chatroom.getTitle() | length > 40 ? chatroom.getTitle() | slice(0, 40) ~ '...' : chatroom.getTitle() }} </span>
+            {% if user_admin %}
+                <button class="btn btn-warning regenerate-anon-btn" data-testid="regenerate-anon-btn" title="Assign all anonymous users new names">
+                    <i class="fas fa-sync-alt"></i> Regenerate Names
+                </button>
+            {% endif %}
             <a href="{{ base_url }}" class="leave-room btn btn-danger" data-testid="leave-chat">Leave</a>
         </div>
         <div class="chatroom-content">
             <div class="messages-area"></div>
-            <div class="input-container">
-                <textarea name="content" class="message-input" placeholder="Enter your message here" maxlength=1500 data-testid="msg-input"></textarea>
-                <button class="send-message-btn btn btn-primary" data-testid="send-btn">Send</button>
-            </div>
+            {% if not isReadOnly %}
+                <div class="input-container">
+                    <textarea name="content" class="message-input" placeholder="Enter your message here" maxlength=1500 data-testid="msg-input"></textarea>
+                    <button class="send-message-btn btn btn-primary" data-testid="send-btn">Send</button>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>
@@ -21,6 +28,7 @@
         "userId": "{{ user_id }}",
         "displayName": "{{ user_display_name }}",
         "user_admin": "{{ user_admin }}",
-        "isAnonymous": "{{ anonymous }}"
+        "isAnonymous": "{{ anonymous }}",
+        "read_only": {{isReadOnly ? 'true' : 'false' }}
     }
 </script>

--- a/site/app/views/ChatroomView.php
+++ b/site/app/views/ChatroomView.php
@@ -5,6 +5,8 @@ namespace app\views;
 use app\libraries\Core;
 use app\libraries\Output;
 use app\entities\chat\Chatroom;
+use app\entities\chat\ChatroomParticipant;
+use app\entities\UserEntity;
 use app\libraries\FileUtils;
 
 class ChatroomView extends AbstractView {
@@ -47,12 +49,26 @@ class ChatroomView extends AbstractView {
      */
     public function showAllChatrooms(array $chatrooms): string {
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('twigjs', 'twig.min.js'));
+
+        $chatroom_rows = [];
+        foreach ($chatrooms as $chatroom) {
+            $chatroom_rows[] = [
+                'id' => $chatroom->getId(),
+                'title' => $chatroom->getTitle(),
+                'description' => $chatroom->getDescription(),
+                'hostName' => $chatroom->getHostName(),
+                'isAllowAnon' => $chatroom->isAllowAnon(),
+                'isActive' => $chatroom->isActive(),
+                'isReadOnly' => $chatroom->isReadOnly(),
+                'allowReadOnlyAfterEnd' => $chatroom->allowReadOnlyAfterEnd()
+            ];
+        }
         return $this->core->getOutput()->renderTwigTemplate("chat/AllChatroomsPage.twig", [
             'csrf_token' => $this->core->getCsrfToken(),
             'base_url' => $this->core->buildCourseUrl() . '/chat',
             'semester' => $this->core->getConfig()->getTerm(),
-            'chatrooms' => $chatrooms,
-            'user_admin' => $this->core->getUser()->accessAdmin()
+            'chatrooms' => $chatroom_rows,
+            'user_admin' => $this->core->getUser()->accessAdmin(),
         ]);
     }
 
@@ -60,9 +76,20 @@ class ChatroomView extends AbstractView {
         $this->core->getOutput()->addBreadcrumb("Chatroom");
         $user = $this->core->getUser();
         $display_name = $user->getDisplayFullName();
-        $roomId = $chatroom->getId();
         if ($anonymous) {
-            $display_name = $chatroom->calcAnonName($user->getId());
+            $em = $this->core->getCourseEntityManager();
+            $participant = $em->getRepository(ChatroomParticipant::class)->findOneBy([
+                'chatroom' => $chatroom,
+                'user'     => $user->getId(),
+            ]);
+            if ($participant === null) {
+                $userEntity  = $em->getRepository(UserEntity::class)->find($user->getId());
+                $participant = new ChatroomParticipant($chatroom, $userEntity);
+                $em->persist($participant);
+                $em->flush();
+            }
+            $display_name = $chatroom->resolveAnonName($participant);
+            $em->flush();
         }
         else {
             if (!$user->accessAdmin()) {
@@ -80,6 +107,7 @@ class ChatroomView extends AbstractView {
             'user_id' => $this->core->getUser()->getId(),
             'user_display_name' => $display_name,
             'anonymous' => $anonymous,
+            'isReadOnly' => $chatroom->isReadOnly()
         ]);
     }
 }

--- a/site/app/views/ChatroomView.php
+++ b/site/app/views/ChatroomView.php
@@ -50,24 +50,11 @@ class ChatroomView extends AbstractView {
     public function showAllChatrooms(array $chatrooms): string {
         $this->core->getOutput()->addVendorJs(FileUtils::joinPaths('twigjs', 'twig.min.js'));
 
-        $chatroom_rows = [];
-        foreach ($chatrooms as $chatroom) {
-            $chatroom_rows[] = [
-                'id' => $chatroom->getId(),
-                'title' => $chatroom->getTitle(),
-                'description' => $chatroom->getDescription(),
-                'hostName' => $chatroom->getHostName(),
-                'isAllowAnon' => $chatroom->isAllowAnon(),
-                'isActive' => $chatroom->isActive(),
-                'isReadOnly' => $chatroom->isReadOnly(),
-                'allowReadOnlyAfterEnd' => $chatroom->allowReadOnlyAfterEnd()
-            ];
-        }
         return $this->core->getOutput()->renderTwigTemplate("chat/AllChatroomsPage.twig", [
             'csrf_token' => $this->core->getCsrfToken(),
             'base_url' => $this->core->buildCourseUrl() . '/chat',
             'semester' => $this->core->getConfig()->getTerm(),
-            'chatrooms' => $chatroom_rows,
+            'chatrooms' => $chatrooms,
             'user_admin' => $this->core->getUser()->accessAdmin(),
         ]);
     }
@@ -106,8 +93,7 @@ class ChatroomView extends AbstractView {
             'user_admin' => $this->core->getUser()->accessAdmin(),
             'user_id' => $this->core->getUser()->getId(),
             'user_display_name' => $display_name,
-            'anonymous' => $anonymous,
-            'isReadOnly' => $chatroom->isReadOnly()
+            'anonymous' => $anonymous
         ]);
     }
 }

--- a/site/public/js/chatroom.js
+++ b/site/public/js/chatroom.js
@@ -21,16 +21,13 @@ function loadChatroomTemplate(chatroomId) {
     });
 }
 
-function renderChatroomRow(chatroomId, description, title, hostName, isAllowAnon, allowReadOnlyAfterEnd, isAdmin, isActive, base_url) {
-    const isReadOnly = !isActive && allowReadOnlyAfterEnd;
-
+function renderChatroomRow(chatroomId, description, title, hostName, isAllowAnon, isAdmin, isActive, base_url) {
     return Twig.twig({ ref: 'ChatroomRow' }).render({
         id: chatroomId,
         description: description,
         title: title,
         hostName: hostName,
         isAllowAnon: isAllowAnon,
-        isReadOnly: allowReadOnlyAfterEnd,
         isAdmin: isAdmin,
         isActive: isActive,
         baseUrl: base_url,
@@ -170,22 +167,8 @@ function initChatroomSocketClient(chatroomId) {
                 socketChatMessageHandler(msg);
                 break;
             case 'chat_close':
-                if (msg.allow_read_only_after_end) {
-                    const messageInput = document.querySelector('.message-input');
-                    const sendButton = document.querySelector('.send-message-btn');
-
-                    messageInput.disabled = true;
-                    messageInput.placeholder = 'This chat session has ended. Messages are read-only.';
-                    sendButton.disabled = true;
-                }
-                else {
-                    window.alert('Chatroom has been closed by the instructor.');
-                    window.location.href = buildCourseUrl(['chat']);
-                }
-                break;
-            case 'anon_names_regenerated':
-                // Reload the page so the current user gets their new anonymous name.
-                window.location.reload();
+                window.alert('Chatroom has been closed by the instructor.');
+                window.location.href = buildCourseUrl(['chat']);
                 break;
             case 'message_delete': {
                 const msgElement = document.getElementById(msg.message_id);
@@ -207,7 +190,6 @@ function initChatroomListSocketClient(user_admin, base_url) {
     window.socketClient = new WebSocketClient();
     window.socketClient.onmessage = (msg) => {
         const isActive = msg.type === 'chat_open';
-
         switch (msg.type) {
             case 'chat_open':
             case 'chat_close':
@@ -230,14 +212,13 @@ function newChatroomForm() {
     document.getElementById('chatroom-allow-anon').checked = true;
 }
 
-function editChatroomForm(chatroom_id, baseUrl, title, description, allow_anon, readOnly) {
+function editChatroomForm(chatroom_id, baseUrl, title, description, allow_anon) {
     const form = $('#edit-chatroom-form');
     form.css('display', 'block');
     document.getElementById('chatroom-edit-form').action = `${baseUrl}/${chatroom_id}/edit`;
     document.getElementById('chatroom-title-input').value = title;
     document.getElementById('chatroom-description-input').value = description;
     document.getElementById('chatroom-anon-allow').checked = allow_anon;
-    document.getElementById('edit-chatroom-read-only-allow').checked = readOnly;
 }
 
 function deleteChatroomForm(chatroom_id, chatroom_name, base_url) {
@@ -301,7 +282,7 @@ function handleChatStateChange(msg, user_admin, isActive, base_url) {
     }
 
     removeChatroomRow(msg.chatroom_id);
-    const rowHtml = renderChatroomRow(msg.chatroom_id, msg.description, msg.title, msg.host_name, msg.allow_anon, msg.allow_read_only_after_end, user_admin, isActive, base_url);
+    const rowHtml = renderChatroomRow(msg.chatroom_id, msg.description, msg.title, msg.host_name, msg.allow_anon, user_admin, isActive, base_url);
     // This should be safe because the Twig template escapes all passed variables.
     // eslint-disable-next-line no-unsanitized/method
     tableBody.insertAdjacentHTML('beforeend', rowHtml);
@@ -350,7 +331,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageDataElement = document.getElementById('page-data');
     if (pageDataElement) {
         const pageData = JSON.parse(pageDataElement.textContent);
-        const { chatroomId, userId, displayName, user_admin, isAnonymous, read_only } = pageData;
+        const { chatroomId, userId, displayName, user_admin, isAnonymous } = pageData;
 
         showJoinMessage(`You have successfully joined as ${displayName}.`);
 
@@ -369,34 +350,26 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-        if (!read_only) {
-            messageInput.addEventListener('keypress', (event) => {
-                if (event.keyCode === 13 && !event.shiftKey) {
-                    event.preventDefault();
-                    sendButton.click();
-                }
-            });
-        }
-        if (!read_only) {
-            sendButton.addEventListener('click', (event) => {
+        messageInput.addEventListener('keypress', (event) => {
+            if (event.keyCode === 13 && !event.shiftKey) {
                 event.preventDefault();
-                const messageContent = messageInput.value.trim();
-                if (messageContent === '') {
-                    alert('Please enter a message.');
-                    return;
-                }
+                sendButton.click();
+            }
+        });
+
+        sendButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            const messageContent = messageInput.value.trim();
+            if (messageContent === '') {
+                alert('Please enter a message.');
+                return;
+            }
 
                 const role = user_admin ? 'instructor' : 'student';
                 sendMessage(chatroomId, userId, displayName, role, messageContent, isAnonymous);
 
-                messageInput.value = '';
-            });
-        }
-        if (read_only) {
-            messageInput.disabled = true;
-            messageInput.placeholder = 'This chat session has ended. Messages are read-only.';
-            sendButton.disabled = true;
-        }
+            messageInput.value = '';
+        });
     }
     const chatroomsTable = document.getElementById('chatrooms-table');
     const allChatroomData = document.getElementById('all-chatroom-data');

--- a/site/public/js/chatroom.js
+++ b/site/public/js/chatroom.js
@@ -21,13 +21,16 @@ function loadChatroomTemplate(chatroomId) {
     });
 }
 
-function renderChatroomRow(chatroomId, description, title, hostName, isAllowAnon, isAdmin, isActive, base_url) {
+function renderChatroomRow(chatroomId, description, title, hostName, isAllowAnon, allowReadOnlyAfterEnd, isAdmin, isActive, base_url) {
+    const isReadOnly = !isActive && allowReadOnlyAfterEnd;
+
     return Twig.twig({ ref: 'ChatroomRow' }).render({
         id: chatroomId,
         description: description,
         title: title,
         hostName: hostName,
         isAllowAnon: isAllowAnon,
+        isReadOnly: allowReadOnlyAfterEnd,
         isAdmin: isAdmin,
         isActive: isActive,
         baseUrl: base_url,
@@ -132,6 +135,33 @@ function socketChatMessageHandler(msg) {
     appendMessage(msg.display_name, msg.role, msg.timestamp, msg.content, msg.message_id);
 }
 
+function regenerateAnonNames(chatroomId) {
+    $.ajax({
+        url: buildCourseUrl(['chat', chatroomId, 'regenerateAnonNames']),
+        type: 'POST',
+        data: { csrf_token: csrfToken },
+        success: function (response) {
+            try {
+                const msg = JSON.parse(response);
+                if (msg.status !== 'success') {
+                    displayErrorMessage(msg.message || 'Failed to regenerate anonymous names.');
+                }
+                else {
+                    displaySuccessMessage('Anonymous names have been regenerated. Users will receive new names on their next message.');
+                }
+            }
+            catch (err) {
+                console.error(err);
+                window.alert('Something went wrong. Please try again.');
+            }
+        },
+        error: function (err) {
+            console.error(err);
+            window.alert('Something went wrong. Please try again.');
+        },
+    });
+}
+
 function initChatroomSocketClient(chatroomId) {
     window.socketClient = new WebSocketClient();
     window.socketClient.onmessage = (msg) => {
@@ -140,8 +170,22 @@ function initChatroomSocketClient(chatroomId) {
                 socketChatMessageHandler(msg);
                 break;
             case 'chat_close':
-                window.alert('Chatroom has been closed by the instructor.');
-                window.location.href = buildCourseUrl(['chat']);
+                if (msg.allow_read_only_after_end) {
+                    const messageInput = document.querySelector('.message-input');
+                    const sendButton = document.querySelector('.send-message-btn');
+
+                    messageInput.disabled = true;
+                    messageInput.placeholder = 'This chat session has ended. Messages are read-only.';
+                    sendButton.disabled = true;
+                }
+                else {
+                    window.alert('Chatroom has been closed by the instructor.');
+                    window.location.href = buildCourseUrl(['chat']);
+                }
+                break;
+            case 'anon_names_regenerated':
+                // Reload the page so the current user gets their new anonymous name.
+                window.location.reload();
                 break;
             case 'message_delete': {
                 const msgElement = document.getElementById(msg.message_id);
@@ -163,6 +207,7 @@ function initChatroomListSocketClient(user_admin, base_url) {
     window.socketClient = new WebSocketClient();
     window.socketClient.onmessage = (msg) => {
         const isActive = msg.type === 'chat_open';
+
         switch (msg.type) {
             case 'chat_open':
             case 'chat_close':
@@ -185,13 +230,14 @@ function newChatroomForm() {
     document.getElementById('chatroom-allow-anon').checked = true;
 }
 
-function editChatroomForm(chatroom_id, baseUrl, title, description, allow_anon) {
+function editChatroomForm(chatroom_id, baseUrl, title, description, allow_anon, readOnly) {
     const form = $('#edit-chatroom-form');
     form.css('display', 'block');
     document.getElementById('chatroom-edit-form').action = `${baseUrl}/${chatroom_id}/edit`;
     document.getElementById('chatroom-title-input').value = title;
     document.getElementById('chatroom-description-input').value = description;
     document.getElementById('chatroom-anon-allow').checked = allow_anon;
+    document.getElementById('edit-chatroom-read-only-allow').checked = readOnly;
 }
 
 function deleteChatroomForm(chatroom_id, chatroom_name, base_url) {
@@ -255,7 +301,7 @@ function handleChatStateChange(msg, user_admin, isActive, base_url) {
     }
 
     removeChatroomRow(msg.chatroom_id);
-    const rowHtml = renderChatroomRow(msg.chatroom_id, msg.description, msg.title, msg.host_name, msg.allow_anon, user_admin, isActive, base_url);
+    const rowHtml = renderChatroomRow(msg.chatroom_id, msg.description, msg.title, msg.host_name, msg.allow_anon, msg.allow_read_only_after_end, user_admin, isActive, base_url);
     // This should be safe because the Twig template escapes all passed variables.
     // eslint-disable-next-line no-unsanitized/method
     tableBody.insertAdjacentHTML('beforeend', rowHtml);
@@ -304,7 +350,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pageDataElement = document.getElementById('page-data');
     if (pageDataElement) {
         const pageData = JSON.parse(pageDataElement.textContent);
-        const { chatroomId, userId, displayName, user_admin, isAnonymous } = pageData;
+        const { chatroomId, userId, displayName, user_admin, isAnonymous, read_only } = pageData;
 
         showJoinMessage(`You have successfully joined as ${displayName}.`);
 
@@ -314,27 +360,43 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const sendButton = document.querySelector('.send-message-btn');
         const messageInput = document.querySelector('.message-input');
+        const regenerateBtn = document.querySelector('.regenerate-anon-btn');
+        if (regenerateBtn) {
+            regenerateBtn.addEventListener('click', () => {
+                if (confirm('This will assign all anonymous users new names. Are you sure?')) {
+                    regenerateAnonNames(chatroomId);
+                }
+            });
+        }
 
-        messageInput.addEventListener('keypress', (event) => {
-            if (event.keyCode === 13 && !event.shiftKey) {
+        if (!read_only) {
+            messageInput.addEventListener('keypress', (event) => {
+                if (event.keyCode === 13 && !event.shiftKey) {
+                    event.preventDefault();
+                    sendButton.click();
+                }
+            });
+        }
+        if (!read_only) {
+            sendButton.addEventListener('click', (event) => {
                 event.preventDefault();
-                sendButton.click();
-            }
-        });
+                const messageContent = messageInput.value.trim();
+                if (messageContent === '') {
+                    alert('Please enter a message.');
+                    return;
+                }
 
-        sendButton.addEventListener('click', (event) => {
-            event.preventDefault();
-            const messageContent = messageInput.value.trim();
-            if (messageContent === '') {
-                alert('Please enter a message.');
-                return;
-            }
+                const role = user_admin ? 'instructor' : 'student';
+                sendMessage(chatroomId, userId, displayName, role, messageContent, isAnonymous);
 
-            const role = user_admin ? 'instructor' : 'student';
-            sendMessage(chatroomId, userId, displayName, role, messageContent, isAnonymous);
-
-            messageInput.value = '';
-        });
+                messageInput.value = '';
+            });
+        }
+        if (read_only) {
+            messageInput.disabled = true;
+            messageInput.placeholder = 'This chat session has ended. Messages are read-only.';
+            sendButton.disabled = true;
+        }
     }
     const chatroomsTable = document.getElementById('chatrooms-table');
     const allChatroomData = document.getElementById('all-chatroom-data');

--- a/site/tests/app/entities/chat/ChatroomTester.php
+++ b/site/tests/app/entities/chat/ChatroomTester.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace tests\app\entities\chat;
+
+use app\entities\chat\Chatroom;
+use app\entities\chat\ChatroomParticipant;
+use app\entities\UserEntity;
+use Doctrine\Common\Collections\ArrayCollection;
+use ReflectionClass;
+use ReflectionProperty;
+use tests\BaseUnitTest;
+
+/**
+ * Unit tests for anonymous-name logic in Chatroom / ChatroomParticipant.
+ *
+ * Because Chatroom and UserEntity are Doctrine ORM entities with no public
+ * constructor parameters for IDs, we use ReflectionClass / ReflectionProperty
+ * to inject values the same way the rest of the entity test suite does.
+ */
+class ChatroomTester extends BaseUnitTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates a minimal UserEntity with just the fields that Chatroom uses.
+     */
+    private function makeUser(string $userId, string $givenName = 'Test', string $familyName = 'User'): UserEntity {
+        $ref  = new ReflectionClass(UserEntity::class);
+        $user = $ref->newInstanceWithoutConstructor();
+
+        $this->setPrivate($user, 'user_id', $userId);
+        $this->setPrivate($user, 'user_givenname', $givenName);
+        $this->setPrivate($user, 'user_familyname', $familyName);
+        $this->setPrivate($user, 'user_preferred_givenname', null);
+        $this->setPrivate($user, 'user_preferred_familyname', null);
+
+        return $user;
+    }
+
+    /**
+     * Creates a Chatroom with a given numeric id (bypassing the DB generator).
+     */
+    private function makeChatroom(int $id, UserEntity $host): Chatroom {
+        $room = new Chatroom($host, 'Test Room', 'A test room');
+        $this->setPrivate($room, 'id', $id);
+        return $room;
+    }
+
+    /**
+     * Creates a ChatroomParticipant with a fixed salt so tests are deterministic.
+     */
+    private function makeParticipant(Chatroom $room, UserEntity $user, string $fixedSalt): ChatroomParticipant {
+        $participant = new ChatroomParticipant($room, $user);
+        $this->setPrivate($participant, 'anon_salt', $fixedSalt);
+        return $participant;
+    }
+
+    /**
+     * Sets an inaccessible (private/protected) property on an object.
+     */
+    private function setPrivate(object $obj, string $property, mixed $value): void {
+        $prop = new ReflectionProperty($obj, $property);
+        $prop->setAccessible(true);
+        $prop->setValue($obj, $value);
+    }
+
+    /**
+     * Adds a ChatroomParticipant directly into the Chatroom's participants
+     * ArrayCollection, simulating what Doctrine does when the relationship is
+     * managed by the ORM.
+     */
+    private function addParticipantToRoom(Chatroom $room, ChatroomParticipant $participant): void {
+        $prop = new ReflectionProperty($room, 'participants');
+        $prop->setAccessible(true);
+        /** @var ArrayCollection $collection */
+        $collection = $prop->getValue($room);
+        $collection->add($participant);
+    }
+
+    // -----------------------------------------------------------------------
+    // ChatroomParticipant – unit tests
+    // -----------------------------------------------------------------------
+
+    public function testParticipantSaltIsNonEmptyOnConstruction(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $user        = $this->makeUser('student1');
+        $participant = new ChatroomParticipant($room, $user);
+
+        $this->assertNotEmpty($participant->getAnonSalt());
+    }
+
+    public function testParticipantSaltIs64HexChars(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $participant = new ChatroomParticipant($room, $this->makeUser('s1'));
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $participant->getAnonSalt());
+    }
+
+    public function testParticipantAnonNameStartsNull(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $participant = new ChatroomParticipant($room, $this->makeUser('s1'));
+
+        $this->assertNull($participant->getAnonName());
+        $this->assertNull($participant->getSessionSnapshot());
+    }
+
+    public function testClearAnonNameResetsNameAndSnapshot(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $participant = new ChatroomParticipant($room, $this->makeUser('s1'));
+
+        $participant->setAnonName('Anonymous Quick Duck');
+        $participant->setSessionSnapshot('2024-01-01 10:00:00');
+        $participant->clearAnonName();
+
+        $this->assertNull($participant->getAnonName());
+        $this->assertNull($participant->getSessionSnapshot());
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – determinism
+    // -----------------------------------------------------------------------
+
+    public function testResolveAnonNameIsDeterministic(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+
+        $p1 = $this->makeParticipant($room, $this->makeUser('u1'), 'aaaa');
+        $p2 = $this->makeParticipant($room, $this->makeUser('u1'), 'aaaa');
+
+        $name1 = $room->resolveAnonName($p1);
+        $name2 = $room->resolveAnonName($p2);
+
+        $this->assertSame($name1, $name2, 'Same salt in the same session must always produce the same name');
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – output format
+    // -----------------------------------------------------------------------
+
+    public function testResolveAnonNameStartsWithAnonymous(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+        $p    = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('ab', 32));
+
+        $name = $room->resolveAnonName($p);
+
+        $this->assertStringStartsWith('Anonymous ', $name);
+    }
+
+    public function testResolveAnonNameIsNonEmpty(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+        $p    = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('cd', 32));
+
+        $this->assertNotEmpty($room->resolveAnonName($p));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – caching within a session
+    // -----------------------------------------------------------------------
+
+    public function testResolveAnonNameIsCachedForSameSession(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 09:00:00'));
+        $p    = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('ef', 32));
+
+        $name1 = $room->resolveAnonName($p);
+        // Second call must hit the cache; also the participant entity must have been mutated
+        $name2 = $room->resolveAnonName($p);
+
+        $this->assertSame($name1, $name2, 'Name must be stable within the same session');
+        $this->assertSame($name1, $p->getAnonName(), 'Participant entity should cache the resolved name');
+    }
+
+    public function testSnapshotIsStoredOnParticipantAfterResolution(): void {
+        $sessionTime = '2024-06-01 08:00:00';
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime($sessionTime));
+        $p           = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('12', 32));
+
+        $room->resolveAnonName($p);
+
+        $this->assertSame($sessionTime, $p->getSessionSnapshot());
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – new session clears the old name
+    // -----------------------------------------------------------------------
+
+    public function testNameChangesAfterSessionRegeneration(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 09:00:00'));
+        $p    = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('ab', 32));
+        $this->addParticipantToRoom($room, $p);
+
+        $snapshotBefore = '2024-01-01 09:00:00';
+        $room->resolveAnonName($p);
+        $this->assertSame($snapshotBefore, $p->getSessionSnapshot());
+
+        // Simulate the instructor clicking "Regenerate Names"
+        $room->regenerateAnonNames();
+
+        // After regeneration the participant's cached name is cleared.
+        $this->assertNull($p->getAnonName(), 'Cached name must be cleared by regenerateAnonNames');
+
+        // Re-resolving assigns a new snapshot (the bumped session time).
+        $nameAfter = $room->resolveAnonName($p);
+        $this->assertStringStartsWith('Anonymous ', $nameAfter);
+        $this->assertNotSame(
+            $snapshotBefore,
+            $p->getSessionSnapshot(),
+            'Session snapshot must reflect the new session_started_at after regeneration'
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – uniqueness / no duplicates
+    // -----------------------------------------------------------------------
+
+    public function testNoDuplicateNamesForDistinctSaltsInSameSession(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-06-01 08:00:00'));
+
+        $names = [];
+        for ($i = 0; $i < 20; $i++) {
+            // Each participant gets a unique, truly random salt (as in production)
+            $p = new ChatroomParticipant($room, $this->makeUser("user{$i}"));
+            $this->addParticipantToRoom($room, $p);
+            $names[] = $room->resolveAnonName($p);
+        }
+
+        $this->assertCount(
+            count($names),
+            array_unique($names),
+            'Each participant in the same chatroom session must receive a unique anonymous name'
+        );
+    }
+
+    public function testCollisionResolutionAppendsNumericSuffix(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+
+        // Both participants share the same salt → same base name → collision.
+        $sharedSalt = str_repeat('de', 32);
+        $p1 = $this->makeParticipant($room, $this->makeUser('u1'), $sharedSalt);
+        $p2 = $this->makeParticipant($room, $this->makeUser('u2'), $sharedSalt);
+        $this->addParticipantToRoom($room, $p1);
+        $this->addParticipantToRoom($room, $p2);
+
+        $name1 = $room->resolveAnonName($p1);
+        $name2 = $room->resolveAnonName($p2);
+
+        $this->assertNotSame($name1, $name2, 'Colliding base names must be disambiguated');
+        // The second name should be the first name suffixed with " 2"
+        $this->assertSame("{$name1} 2", $name2, 'Suffix must be " 2" for the first collision');
+    }
+
+    public function testThreeWayCollisionProducesCorrectSuffixes(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+
+        $sharedSalt = str_repeat('ff', 32);
+        $p1 = $this->makeParticipant($room, $this->makeUser('u1'), $sharedSalt);
+        $p2 = $this->makeParticipant($room, $this->makeUser('u2'), $sharedSalt);
+        $p3 = $this->makeParticipant($room, $this->makeUser('u3'), $sharedSalt);
+        $this->addParticipantToRoom($room, $p1);
+        $this->addParticipantToRoom($room, $p2);
+        $this->addParticipantToRoom($room, $p3);
+
+        $name1 = $room->resolveAnonName($p1);
+        $name2 = $room->resolveAnonName($p2);
+        $name3 = $room->resolveAnonName($p3);
+
+        $this->assertSame("{$name1} 2", $name2);
+        $this->assertSame("{$name1} 3", $name3);
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveAnonName – session-less chatroom (null session_started_at)
+    // -----------------------------------------------------------------------
+
+    public function testResolveAnonNameWorksWhenSessionStartedAtIsNull(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        // Leave session_started_at as null (default)
+        $p    = $this->makeParticipant($room, $this->makeUser('u1'), str_repeat('00', 32));
+
+        $name = $room->resolveAnonName($p);
+
+        $this->assertStringStartsWith('Anonymous ', $name);
+        $this->assertSame('unknown', $p->getSessionSnapshot());
+    }
+
+    // -----------------------------------------------------------------------
+    // regenerateAnonNames
+    // -----------------------------------------------------------------------
+
+    public function testRegenerateAnonNamesClearsAllParticipantNames(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setSessionStartedAt(new \DateTime('2024-01-01 10:00:00'));
+
+        // Resolve names for three participants so the cache is warm.
+        // Participants must be in the room's collection so regenerateAnonNames()
+        // can iterate over them.
+        $participants = [];
+        for ($i = 0; $i < 3; $i++) {
+            $p = new ChatroomParticipant($room, $this->makeUser("u{$i}"));
+            $this->addParticipantToRoom($room, $p);
+            $room->resolveAnonName($p);
+            $participants[] = $p;
+        }
+
+        $room->regenerateAnonNames();
+
+        foreach ($participants as $p) {
+            $this->assertNull($p->getAnonName(), 'All cached names must be cleared after regeneration');
+            $this->assertNull($p->getSessionSnapshot(), 'All session snapshots must be cleared after regeneration');
+        }
+    }
+
+    public function testRegenerateAnonNamesBumpsSessionStartedAt(): void {
+        $host        = $this->makeUser('host1');
+        $room        = $this->makeChatroom(1, $host);
+        $oldTime     = new \DateTime('2024-01-01 10:00:00');
+        $room->setSessionStartedAt($oldTime);
+
+        $before = $room->getSessionStartedAt()?->format('Y-m-d H:i:s');
+        $room->regenerateAnonNames();
+        $after  = $room->getSessionStartedAt()?->format('Y-m-d H:i:s');
+
+        $this->assertNotSame($before, $after, 'regenerateAnonNames() must update session_started_at');
+    }
+
+    // -----------------------------------------------------------------------
+    // Chatroom state helpers (non-anon, but verifying entity correctness)
+    // -----------------------------------------------------------------------
+
+    public function testNewChatroomIsInactiveByDefault(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+
+        $this->assertFalse($room->isActive());
+    }
+
+    public function testNewChatroomAllowsAnonByDefault(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+
+        $this->assertTrue($room->isAllowAnon());
+    }
+
+    public function testNewChatroomIsNotDeletedByDefault(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+
+        $this->assertFalse($room->chatDeleted());
+    }
+
+    public function testToggleActiveStatusFlipsState(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+
+        $this->assertFalse($room->isActive());
+        $room->toggleActiveStatus();
+        $this->assertTrue($room->isActive());
+        $room->toggleActiveStatus();
+        $this->assertFalse($room->isActive());
+    }
+
+    public function testIsReadOnlyOnlyWhenInactiveAndAllowReadOnly(): void {
+        $host = $this->makeUser('host1');
+        $room = $this->makeChatroom(1, $host);
+        $room->setAllowReadOnlyAfterEnd(true);
+
+        // inactive + allow_read_only_after_end  → read-only
+        $this->assertTrue($room->isReadOnly());
+
+        // active + allow_read_only_after_end → NOT read-only
+        $room->toggleActiveStatus();
+        $this->assertFalse($room->isReadOnly());
+    }
+}
+


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
Fixes #11999 

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

Instead of the previous method of inputing user information into crc32 and using that number result to directly choose the base adjective and base name, we instead generate a unique salt for each user using hmac_sha256. We then use both the number result and our original user information to pick out an anonymous username. Various information including th user, their salt, and their username will be stored in the new table classroom_participants. To fix the issue where two people are assigned the same base name, 

**Before.**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/c9a69f6e-4a54-4bd2-adae-15183082f1e0" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/67465650-fd95-48d4-8b9e-3386c99d2ee8" />

One noun and one adjective

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/6ad440dc-d6b2-475e-b9de-f228ad17905f" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/abd97f9e-ed6f-4892-a51f-6ce7ace667e8" />
As can be seen in the database, both instructor and aphacker are given the same anonymous name. This is not obvious to someone looking through the livechat on the website

**After:**

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f19f7321-ba34-4ffc-bca4-2b3b86947211" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/0c06df24-6872-487b-91fc-04a6ac592809" />


one noun and one adjective
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/cb974041-7aa6-4d71-9677-73cece676518" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/122c6c70-70eb-4f4f-a8d9-0e4c6188dd4b" />
Even though both people are given the same base name, they can be differetiated by their numbers.


### What steps should a reviewer take to reproduce or test the bug or new feature?

Our change to HMAC and utilizing salts can be seen in submitty_s26_sample.public.chatroom_participants. Every salt should be unique to each person. Each name should be unique to each person (ibase names can have multiples if we run out of unused base names)

To test all names being filled and adding a new anonymous participant without an error, temporarily reduce the list of adjectives and nouns to 1 each in the file site/app/entities/chat/Chatroom.php. Log in as 2 or more users. even though there is only 1 possible base name, each user should differ by their number (eg. Quick Swan, Quick Swan 2, Quick Swan 3)

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
