### PR TITLE
[BUGFIX:INTERFACE] Fix Safari panel layout logic

### DIFF
--- a/site/ts/ta-grading-panels.ts
+++ b/site/ts/ta-grading-panels.ts
@@ -140,7 +140,7 @@ export function toggleFullScreenMode() {
 // Keep only those panels which are part of the two panel layout
 function setMultiPanelModeVisiblities() {
     panelElements.forEach((panel) => {
-        const id_str = document.getElementById(`#${panel.str}_btn`)
+        const id_str = document.getElementById(`${panel.str}_btn`)
             ? `#${panel.str}_btn`
             : `#${panel.str}-btn`;
 
@@ -183,8 +183,8 @@ function updatePanelLayoutModes() {
             continue;
         }
         // Move all the panels from the left and right buckets to the main panels-container
-        for (let idx = 0; idx < panelCont.length; idx++) {
-            document.querySelector('.panels-container')!.append(panelCont[idx]);
+        while (panelCont.length > 0) {
+            document.querySelector('.panels-container')!.append(panelCont[0]);
         }
     }
 
@@ -297,9 +297,13 @@ export function updatePanelOptions() {
                     && taLayoutDet.dividedColName === 'RIGHT')
             ) {
                 panelOptions[idx].classList.add('hide');
+                panelOptions[idx].hidden = true;
+                panelOptions[idx].disabled = true;
             }
             else {
                 panelOptions[idx].classList.remove('hide');
+                panelOptions[idx].hidden = false;
+                panelOptions[idx].disabled = false;
             }
         }
         else if (panelOptions[idx].value === 'rightTop') {
@@ -321,9 +325,13 @@ export function updatePanelOptions() {
                     && taLayoutDet.dividedColName !== 'RIGHT')
             ) {
                 panelOptions[idx].classList.add('hide');
+                panelOptions[idx].hidden = true;
+                panelOptions[idx].disabled = true;
             }
             else {
                 panelOptions[idx].classList.remove('hide');
+                panelOptions[idx].hidden = false;
+                panelOptions[idx].disabled = false;
             }
         }
     });


### PR DESCRIPTION
Why is this Change Important & Necessary?
Fixes #11968. Safari does not support `display: none` on `<option>` elements, which caused invalid panel positions to remain visible and selectable in 2-panel mode. This resulted in panels opening in incorrect locations and breaking the layout. This change ensures consistent cross-browser behavior.

What is the New Behavior?
Invalid panel position options are now properly hidden and disabled in Safari and other browsers. Panels cannot be placed in unsupported positions in 2-panel mode. Additionally:
- Button icons now correctly highlight when active.
- Panels move correctly between layout containers without skipping.

What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open the grading interface and enable the panel layout controls.
2. Switch to 2-panel mode.
3. Observe the panel position dropdown.
4. Previously, invalid "bottom" positions were visible and selectable in Safari.
5. With this fix, those options are hidden and disabled.
6. Verify panel movement between layout containers works correctly.

### Screenshots
| Before | After |
| :---: | :---: |


<img width="813" height="809" alt="before_fix_1772908190392" src="https://github.com/user-attachments/assets/d6e2f727-dddb-43e7-b979-04611e9d788e" />

<img width="813" height="809" alt="after_fix_1772908210518" src="https://github.com/user-attachments/assets/f8aee13d-2673-4413-8cde-382ecb404e1e" />
]
