### PR TITLE
[Bugfix:TAGrading] Fix attachment delete using wrong grader path

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1370,7 +1370,21 @@ class ElectronicGraderController extends AbstractController {
             return;
         }
 
-        $attachment_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'attachments', $gradeable->getId(), $submitter_id, $grader->getId(), $_POST["attachment"]);
+        // Use the uploader's grader ID to locate the file.
+        // If a specific uploader ID is provided, validate the requesting user
+        // has sufficient privileges (instructor or full-access grader) to delete
+        // another grader's attachment.
+        $uploader_grader_id = $_POST['uploader_grader_id'] ?? $grader->getId();
+        if (strpos($uploader_grader_id, "..") !== false) {
+            $this->core->getOutput()->renderJsonFail('Invalid path.');
+            return;
+        }
+        if ($uploader_grader_id !== $grader->getId() && $grader->getGroup() > User::GROUP_FULL_ACCESS_GRADER) {
+            $this->core->getOutput()->renderJsonFail('Insufficient permissions to delete another grader\'s attachment.');
+            return;
+        }
+
+        $attachment_path = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), 'attachments', $gradeable->getId(), $submitter_id, $uploader_grader_id, $_POST["attachment"]);
         if (is_file($attachment_path)) {
             if (@unlink($attachment_path)) {
                 $this->core->getOutput()->renderJsonSuccess();

--- a/site/app/templates/autograding/Attachments.twig
+++ b/site/app/templates/autograding/Attachments.twig
@@ -7,7 +7,7 @@
         <a id = 'open_file_{{ file.name|url_encode }}' onclick='openSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Open the file in a new tab" class="key_to_click" tabindex="0"><i class="fas fa-external-link-alt" title="Open the file in a new tab"></i></a>
         <a onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
         {% if can_modify %}
-        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
+        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}"{% if uploader_id is defined %}, "{{ uploader_id|url_encode }}"{% endif %})' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
         {% endif %}
     </div>
     <div id="file_viewer_{{ id }}" data-file_name="{{ file.name }}" data-file_url="{{ file.path }}"></div>

--- a/site/public/templates/grading/Attachments.twig
+++ b/site/public/templates/grading/Attachments.twig
@@ -7,7 +7,7 @@
         <a id = 'open_file_{{ file.name|url_encode }}' onclick='openSubmittedFile("{{ file.name|url_encode }}", "{{ file.path|url_encode }}")' aria-label="Open the file in a pop up" class="key_to_click" tabindex="0"><i class="fas fa-window-restore" title="Open the file in a pop up"></i></a>
         <a onclick='downloadFile("{{ file.path|url_encode }}", "attachments")' aria-label="Download the file" class="key_to_click" tabindex="0"><i class="fas fa-download" title="Download the file"></i></a>
         {% if can_modify %}
-        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}")' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
+        <a onclick='deleteAttachment(this, "{{ file.name|url_encode }}"{% if uploader_id is defined %}, "{{ uploader_id|url_encode }}"{% endif %})' aria-label="Delete the file" class="key_to_click" tabindex="0"><i class="fas fa-trash" title="Delete the file"></i></a>
         {% endif %}
     </div>
     <div id="file_viewer_{{ id }}" data-file_name="{{ file.name }}" data-file_url="{{ file.path }}"></div>

--- a/site/public/templates/grading/GradingGradeable.twig
+++ b/site/public/templates/grading/GradingGradeable.twig
@@ -33,7 +33,8 @@
                 'editable': false,
                 'overall_comment': graded_gradeable.ta_grading_overall_comments,
                 'attachments': graded_gradeable.attachments,
-                'student_grader': student_grader
+                'student_grader': student_grader,
+                'user_group': graded_gradeable.user_group
         } only %}
     </div>
 {# /General Comment #}

--- a/site/public/templates/grading/OverallComment.twig
+++ b/site/public/templates/grading/OverallComment.twig
@@ -10,6 +10,7 @@ Required Parameters:
   - attachments["logged_in_user"]["user_id"],
   - attachments["logged_in_user"]["attachments"] = [["file_1", "file_1_path"], ["file_2", "file_2_path"], ...]
   - attachments["other_graders"][<user_id>] = [["file_1", "file_1_path"], ["file_2", "file_2_path"], ...]
+-user_group: the numeric group of the logged-in user (1=instructor, 2=full-access grader, 3=limited grader, 4=student)
 #}
 <div class="box general-comment container key_to_click" tabindex="0">
     <div class="row overall-comment-top-row">
@@ -76,7 +77,8 @@ Required Parameters:
                         file: file,
                         id: "a-0-" ~ loop.index,
                         is_grader_view: true,
-                        can_modify: true
+                        can_modify: true,
+                        uploader_id: attachments["logged_in_user"]["user_id"]
                     } only %}
                 {% endfor %}
                 </div>
@@ -87,7 +89,8 @@ Required Parameters:
                             file: file,
                             id: "a-" ~ loop.parent.loop.index ~ "-" ~ loop.index,
                             is_grader_view: true,
-                            can_modify: false
+                            can_modify: user_group is defined and user_group <= 2,
+                            uploader_id: grader
                         } only %}
                     {% endfor %}
                 </div>

--- a/site/ts/ta-grading.ts
+++ b/site/ts/ta-grading.ts
@@ -21,7 +21,7 @@ import { gotoNextStudent, gotoPrevStudent } from './ta-grading-toolbar';
 
 declare global {
     interface Window {
-        deleteAttachment(target: string, file_name: string): void;
+        deleteAttachment(target: string, file_name: string, uploader_grader_id?: string): void;
         openAll (click_class: string, class_modifier: string): void;
         changeCurrentPeer(): void;
         clearPeerMarks (submitter_id: string, gradeable_id: string, csrf_token: string): void;
@@ -797,6 +797,7 @@ window.uploadAttachment = function () {
                         );
                     }
                     else {
+                        const currentUserId = $('#attachments-list').attr('data-user') ?? '';
                         const renderedData = window.Twig.twig({
                             ref: 'Attachments',
                         }).render({
@@ -804,6 +805,7 @@ window.uploadAttachment = function () {
                             id: `a-up-${uploadedAttachmentIndex}`,
                             is_grader_view: true,
                             can_modify: true,
+                            uploader_id: currentUserId,
                         });
                         uploadedAttachmentIndex++;
                         if (origAttachment.length === 0) {
@@ -842,7 +844,7 @@ window.uploadAttachment = function () {
     }
 };
 
-window.deleteAttachment = function (target: string, file_name: string) {
+window.deleteAttachment = function (target: string, file_name: string, uploader_grader_id?: string) {
     const confirmation = confirm(
         `Are you sure you want to delete attachment '${decodeURIComponent(file_name)}'?`,
     );
@@ -851,6 +853,9 @@ window.deleteAttachment = function (target: string, file_name: string) {
         formData.append('attachment', file_name);
         formData.append('anon_id', getAnonId());
         formData.append('csrf_token', window.csrfToken);
+        if (uploader_grader_id) {
+            formData.append('uploader_grader_id', uploader_grader_id);
+        }
         $.ajax({
             url: buildCourseUrl([
                 'gradeable',


### PR DESCRIPTION
## Description

Fixes a bug where deleting an attachment in the Overall Comment section of the TA grading interface would fail with **'File not found'** because the server was searching in the wrong grader's directory.

### Root Cause

\deleteAttachment()\ in \ElectronicGraderController.php\ built the file path using \\->getId()\ (the currently logged-in user's ID). However, attachments are stored under the **original uploader's** ID:

\\\
attachments/{gradeable_id}/{submitter_id}/{uploader_id}/{filename}
\\\

When the logged-in user differed from the original uploader (e.g., the instructor viewing another grader's tab) the file path resolved to the wrong directory, causing 'File not found'.

### Fix

**Backend (\ElectronicGraderController.php\):**
- Accept an optional \uploader_grader_id\ POST parameter identifying the file's owner
- Path-traversal guard on the new parameter (just like the existing \ttachment\ check)
- Authorization check: only instructors and full-access graders (group ≤ 2) can delete another grader's file; all users can still delete their own
- Build the file path using \uploader_grader_id\ instead of the logged-in user's ID

**Frontend (Twig templates + TypeScript):**
- Both \Attachments.twig\ copies pass the uploader's ID as a third argument to \deleteAttachment()\
- \OverallComment.twig\ passes \uploader_id\ for both the logged-in user's own files and other graders' files
- \OverallComment.twig\ now sets \can_modify: user_group <= 2\ for other graders' attachments, so instructors and full-access graders see the delete button
- \GradingGradeable.twig\ passes \user_group\ to \OverallComment.twig\
- \	a-grading.ts\: \deleteAttachment()\ accepts and forwards the optional \uploader_grader_id\; newly uploaded files rendered client-side via Twig.js also receive \uploader_id\

### Testing

1. Log in as a TA and grade a student submission
2. In the Overall Comment section, upload an attachment
3. Log out and log in as an instructor
4. Navigate to the same student's grading interface
5. In the Overall Comment section, open the TA's tab
6. ✅ A delete (trash) icon is now visible on the TA's attachment
7. Click the delete icon → attachment is successfully deleted (no 'File not found' error)
8. Log back in as the original TA — verify the file is gone
9. As the original TA, upload a new attachment and delete it immediately (same-session) → still works

Closes #12510