### PR TITLE
[Bugfix:Forum] Truncate deleted forum post notification content

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -843,8 +843,9 @@ class ForumController extends AbstractController {
                 }
                 // We want to reload same thread again, in both case (thread/post undelete)
                 $metadata = json_encode(['url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string) $post_id, 'thread_id' => $thread_id, 'post_id' => $post_id]);
-                $subject = "Restored: " . $post->getContent();
-                $content = "In " . $full_course_name . "\n\nThe following post was Restored.\n\nThread: " . $thread->getTitle() . "\n\n" . $post->getContent();
+                $preview = $this->previewText($post->getContent(), 120);                
+                $subject = "Restored: " . $preview;
+                $content = "In " . $full_course_name . "\n\nThe following post was Restored.\n\nThread: " . $thread->getTitle() . "\n\n" . $preview;
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post->getAuthor()->getId(), 'preference' => 'all_modifications_forum'];
             }
         }

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -855,8 +855,9 @@ class ForumController extends AbstractController {
                 $type = "thread";
             }
             $metadata = json_encode([]);
-            $subject = "Deleted: " . $post->getContent();
-            $content = "In " . $full_course_name . "\n\nThread: " . $thread->getTitle() . "\n\nPost:\n" . $post->getContent() . " was deleted.";
+            $preview = $this->previewText($post->getContent(), 120);
+            $subject = "Deleted: " . $preview;
+            $content = "In " . $full_course_name . "\n\nThread: " . $thread->getTitle() . "\n\nPost:\n" . $preview . " was deleted.";
             $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post->getAuthor()->getId(), 'preference' => 'all_modifications_forum'];
             $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->sendSocketMessage(array_merge(


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12553

When a forum post is deleted, the notification and email currently include the entire post content. If the post message is long, this results in very large and cluttered notifications.

This change truncates the deleted post content before generating the notification subject and body.

### What is the New Behavior?
Deleted forum post notifications now show a short preview of the post instead of the full message by using the existing `previewText()` helper.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create a forum thread with a long post message.
2. Delete the post.
3. Check the generated notification or email.

Before this change: the notification includes the full post content.  
After this change: the notification only shows a truncated preview of the post.

### Automated Testing & Documentation
No automated tests were added because this change only affects notification formatting.

### Other information
This change follows the truncation approach used in PR #12277.