### PR TITLE
[Feature:System] Validate autograding_workers.json schema

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -6,6 +6,7 @@ import time
 import signal
 import string
 import json
+import jsonschema
 
 import shutil
 import contextlib
@@ -1788,6 +1789,23 @@ def monitoring_loop(
 
 
 # ==================================================================================
+AUTOGRADING_WORKERS_SCHEMA = {
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "required": ["address", "username", "num_autograding_workers", "enabled", "capabilities"],
+        "properties": {
+            "address": {"type": "string"},
+            "username": {"type": "string"},
+            "num_autograding_workers": {"type": "integer", "minimum": 1},
+            "enabled": {"type": "boolean"},
+            "capabilities": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        },
+        "additionalProperties": False,
+    },
+}
+
+
 def load_autograding_workers_json(config: submitty_config.Config):
     print("LOAD AUTOGRADING WORKERS JSON")
 
@@ -1803,6 +1821,11 @@ def load_autograding_workers_json(config: submitty_config.Config):
     except Exception as e:
         config.logger.log_stack_trace(traceback.format_exc())
         raise SystemExit(f"ERROR: could not locate the autograding workers json: {e}")
+
+    try:
+        jsonschema.validate(autograding_workers, AUTOGRADING_WORKERS_SCHEMA)
+    except jsonschema.ValidationError as e:
+        raise SystemExit(f"ERROR: autograding_workers.json is invalid: {e.message} (path: {list(e.absolute_path)})")
 
     # There must always be a primary machine, it may or may not have
     # autograding workers.

--- a/autograder/tests/test_submitty_autograding_shipper.py
+++ b/autograder/tests/test_submitty_autograding_shipper.py
@@ -1,9 +1,11 @@
 import os
 import json
 import shutil
+import tempfile
 import unittest
 import contextlib
 import copy
+from unittest.mock import MagicMock
 
 import submitty_autograding_shipper as shipper
 from autograder import config
@@ -344,3 +346,105 @@ class TestAutogradingShipper(unittest.TestCase):
             file for file in os.listdir(paths['checkout']) if file.startswith('failed')
         ]
         self.assertTrue(len(failed_files) == 0)
+
+
+class TestLoadAutogradingWorkersJson(unittest.TestCase):
+    """Tests for load_autograding_workers_json schema validation."""
+
+    VALID_WORKERS = {
+        "primary": {
+            "address": "localhost",
+            "username": "",
+            "num_autograding_workers": 5,
+            "enabled": True,
+            "capabilities": ["default"],
+        }
+    }
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        config_dir = os.path.join(self.temp_dir, 'config')
+        os.makedirs(config_dir)
+        self.workers_json_path = os.path.join(config_dir, 'autograding_workers.json')
+
+        self.mock_config = MagicMock()
+        self.mock_config.submitty = {'submitty_install_dir': self.temp_dir}
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def _write_workers(self, workers):
+        with open(self.workers_json_path, 'w') as f:
+            json.dump(workers, f)
+
+    def test_valid_config_loads_successfully(self):
+        """A correctly formed autograding_workers.json should load without error."""
+        self._write_workers(self.VALID_WORKERS)
+        result = shipper.load_autograding_workers_json(self.mock_config)
+        self.assertEqual(result, self.VALID_WORKERS)
+
+    def test_missing_num_autograding_workers_raises(self):
+        """Missing num_autograding_workers should raise SystemExit with a clear message."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        del workers['primary']['num_autograding_workers']
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit) as ctx:
+            shipper.load_autograding_workers_json(self.mock_config)
+        self.assertIn('num_autograding_workers', str(ctx.exception))
+
+    def test_missing_enabled_raises(self):
+        """Missing enabled field should raise SystemExit with a clear message."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        del workers['primary']['enabled']
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit) as ctx:
+            shipper.load_autograding_workers_json(self.mock_config)
+        self.assertIn('enabled', str(ctx.exception))
+
+    def test_wrong_type_for_num_workers_raises(self):
+        """num_autograding_workers as a string should raise SystemExit."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        workers['primary']['num_autograding_workers'] = "five"
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit) as ctx:
+            shipper.load_autograding_workers_json(self.mock_config)
+        self.assertIn('num_autograding_workers', str(ctx.exception))
+
+    def test_num_workers_below_minimum_raises(self):
+        """num_autograding_workers of 0 should raise SystemExit."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        workers['primary']['num_autograding_workers'] = 0
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit):
+            shipper.load_autograding_workers_json(self.mock_config)
+
+    def test_empty_capabilities_raises(self):
+        """An empty capabilities list should raise SystemExit."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        workers['primary']['capabilities'] = []
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit):
+            shipper.load_autograding_workers_json(self.mock_config)
+
+    def test_unknown_key_raises(self):
+        """An unrecognised key (e.g. a typo) should raise SystemExit."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        workers['primary']['capabilites'] = ["default"]  # common typo
+        self._write_workers(workers)
+        with self.assertRaises(SystemExit) as ctx:
+            shipper.load_autograding_workers_json(self.mock_config)
+        self.assertIn('capabilites', str(ctx.exception))
+
+    def test_multiple_workers_valid(self):
+        """Multiple valid worker entries should load successfully."""
+        workers = copy.deepcopy(self.VALID_WORKERS)
+        workers['worker2'] = {
+            "address": "192.168.1.50",
+            "username": "submitty",
+            "num_autograding_workers": 10,
+            "enabled": False,
+            "capabilities": ["default", "python"],
+        }
+        self._write_workers(workers)
+        result = shipper.load_autograding_workers_json(self.mock_config)
+        self.assertEqual(result, workers)


### PR DESCRIPTION
### Why is this Change Important & Necessary?

A typo or missing field in \`autograding_workers.json\` currently causes a cryptic \`KeyError\` or \`TypeError\` deep inside the shipper when the first job is submitted — not at startup. This makes misconfiguration difficult to diagnose, especially for administrators adding or reconfiguring a worker machine for the first time.

### What is the New Behavior?

\`load_autograding_workers_json()\` now validates the parsed JSON against a schema immediately after loading. If the file is invalid, the shipper exits with a clear, actionable error at startup. For example:

- Missing field: \`ERROR: autograding_workers.json is invalid: 'num_autograding_workers' is a required property (path: ['primary'])\`
- Wrong type: \`ERROR: autograding_workers.json is invalid: 'five' is not of type 'integer' (path: ['primary', 'num_autograding_workers'])\`
- Typo in key name: \`ERROR: autograding_workers.json is invalid: Additional properties are not allowed ('capabilites' was unexpected) (path: ['primary'])\`

The schema enforces that every worker entry has: \`address\` (string), \`username\` (string), \`num_autograding_workers\` (integer ≥ 1), \`enabled\` (boolean), and \`capabilities\` (non-empty array of strings). \`jsonschema\` is already a pinned dependency (\`jsonschema==4.26.0\` in \`.setup/pip/system_requirements.txt\`), so no new dependency is introduced.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Edit \`autograding_workers.json\` to remove the \`num_autograding_workers\` field from the primary entry
2. Restart the shipper: \`sudo systemctl restart submitty_autograding_shipper\`
3. **Before:** shipper starts, accepts jobs, then fails with a \`KeyError\` when the first job is processed
4. **After:** shipper exits immediately with a descriptive error identifying the missing field and which worker entry contains it

### Automated Testing & Documentation

8 unit tests added to \`autograder/tests/test_submitty_autograding_shipper.py\` covering:

- Valid config loads successfully
- Missing \`num_autograding_workers\` raises \`SystemExit\` with field name in message
- Missing \`enabled\` raises \`SystemExit\` with field name in message
- Wrong type for \`num_autograding_workers\` raises \`SystemExit\`
- \`num_autograding_workers\` of 0 raises \`SystemExit\`
- Empty \`capabilities\` list raises \`SystemExit\`
- Unknown/misspelled key raises \`SystemExit\` with the bad key name in message
- Multiple valid worker entries load successfully

Tests use \`tempfile\` and \`unittest.mock.MagicMock\` — each is self-contained with no dependency on global state or test ordering. No documentation changes required.

### Other information

Not a breaking change for correctly configured installations. No migrations required. No security concerns.

---

This change was written by [Claude Code](https://claude.com/claude-code) (claude-sonnet-4-6).