### PR TITLE
[Feature:System] : Add registration_timestamp tracking for self-registered students

### DIFF
--- a/migration/migrator/migrations/master/20260310120000_registration_timestamp.py
+++ b/migration/migrator/migrations/master/20260310120000_registration_timestamp.py
@@ -1,0 +1,31 @@
+"""Migration for the Submitty master database."""
+
+
+def up(config, database):
+    """
+    Run up migration.
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("""
+        ALTER TABLE courses_users
+        ADD COLUMN IF NOT EXISTS registration_timestamp TIMESTAMP DEFAULT NOW();
+    """)
+
+
+def down(config, database):
+    """
+    Run down migration (rollback).
+
+    :param config: Object holding configuration details about Submitty
+    :type config: migrator.config.Config
+    :param database: Object for interacting with given database for environment
+    :type database: migrator.db.Database
+    """
+    database.execute("""
+        ALTER TABLE courses_users
+        DROP COLUMN IF EXISTS registration_timestamp;
+    """)

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -278,6 +278,10 @@ class ReportController extends AbstractController {
         /** @var User $current_user */
         $current_user = null;
         $results = [];
+        $registration_timestamps = $this->core->getQueries()->getCourseRegistrationTimestamps(
+            $this->core->getConfig()->getTerm(),
+            $this->core->getConfig()->getCourse()
+        );
 
         // get all gradeables and cache team graded gradeables
         [$all_gradeables, $user_gradeables, $team_gradeables] = $this->getSplitGradeables($gradeable_sort_keys);
@@ -297,7 +301,8 @@ class ReportController extends AbstractController {
         $this->all_overrides = $this->core->getQueries()->getAllOverriddenGrades();
 
         // Method to call the callback with the required parameters
-        $call_callback = function ($all_gradeables, User $current_user, $user_graded_gradeables, $team_graded_gradeables, $per_user_callback) use ($all_late_days) {
+        $call_callback = function ($all_gradeables, User $current_user, $user_graded_gradeables, $team_graded_gradeables, $per_user_callback) use ($all_late_days, $registration_timestamps) {
+            $current_user->setRegistrationTimestamp($registration_timestamps[$current_user->getId()] ?? null);
             $ggs = $this->mergeGradedGradeables($all_gradeables, $current_user, $user_graded_gradeables, $team_graded_gradeables);
             $late_days = new LateDays($this->core, $current_user, $ggs, $all_late_days[$current_user->getId()] ?? []);
             return $per_user_callback($current_user, $ggs, $late_days);
@@ -324,6 +329,7 @@ class ReportController extends AbstractController {
             foreach ($this->core->getQueries()->getAllUsers() as $u) {
                 if (!isset($results[$u->getId()])) {
                     // This user had no results, so generate results
+                    $u->setRegistrationTimestamp($registration_timestamps[$u->getId()] ?? null);
                     $ggs = $this->mergeGradedGradeables($all_gradeables, $u, [], $team_graded_gradeables);
                     $late_days = new LateDays($this->core, $u, $ggs, $all_late_days[$u->getId()] ?? []);
                     $results[$u->getId()] = $per_user_callback($u, $ggs, $late_days);
@@ -395,6 +401,7 @@ class ReportController extends AbstractController {
         $user_data['course_section_id'] = $user->getCourseSectionId();
         $user_data['rotating_section'] = $user->getRotatingSection();
         $user_data['registration_type'] = $user->getRegistrationType();
+        $user_data['registration_timestamp'] = $this->formatIso8601Timestamp($user->getRegistrationTimestamp());
         $user_data['default_allowed_late_days'] = $this->core->getConfig()->getDefaultStudentLateDays();
         $user_data['last_update'] = date("l, F j, Y h:i A T");
 
@@ -404,6 +411,19 @@ class ReportController extends AbstractController {
         }
 
         file_put_contents(FileUtils::joinPaths($base_path, $user->getId() . '_summary.json'), FileUtils::encodeJson($user_data));
+    }
+
+    private function formatIso8601Timestamp(?string $timestamp): ?string {
+        if ($timestamp === null || $timestamp === '') {
+            return null;
+        }
+
+        try {
+            return (new \DateTime($timestamp, $this->core->getConfig()->getTimezone()))->format('c');
+        }
+        catch (\Exception) {
+            return null;
+        }
     }
 
     /**

--- a/site/app/controllers/course/CourseRegistrationController.php
+++ b/site/app/controllers/course/CourseRegistrationController.php
@@ -78,7 +78,7 @@ class CourseRegistrationController extends AbstractController {
         $default_section = $this->core->getQueries()->getDefaultRegistrationSection($term, $course);
         if ($this->core->getQueries()->wasStudentEverInCourse($user_id, $course, $term)) {
             $this->core->getUser()->setRegistrationSection($default_section);
-            $this->core->getQueries()->updateUser($user, $term, $course);
+            $this->core->getQueries()->selfRegisterCourseUser($user, $term, $course);
         }
         else {
             $this->core->getUser()->setRegistrationSection($default_section);

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1013,6 +1013,52 @@ VALUES (?,?,?,?,?,?)",
     }
 
     /**
+     * Re-activate an existing enrollment for a self-registering student and refresh the join timestamp.
+     */
+    public function selfRegisterCourseUser(User $user, string $semester, string $course): void {
+        $params = [
+            $user->getGroup(),
+            $user->getRegistrationSection(),
+            $this->submitty_db->convertBoolean($user->isManualRegistration()),
+            $user->getRegistrationType(),
+            $semester,
+            $course,
+            $user->getId()
+        ];
+        $this->submitty_db->query(
+            "
+UPDATE courses_users
+SET user_group=?,
+    registration_section=?,
+    manual_registration=?,
+    registration_type=?,
+    registration_timestamp=NOW()
+WHERE term=? AND course=? AND user_id=?",
+            $params
+        );
+
+        $params = [$user->getRotatingSection(), $user->getRegistrationSubsection(), $user->getRegistrationType(), $user->getId()];
+        $this->course_db->query("UPDATE users SET rotating_section=?, registration_subsection=?, registration_type=? WHERE user_id=?", $params);
+        $this->updateGradingRegistration($user->getId(), $user->getGroup(), $user->getGradingRegistrationSections());
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function getCourseRegistrationTimestamps(string $semester, string $course): array {
+        $this->submitty_db->query(
+            "SELECT user_id, registration_timestamp FROM courses_users WHERE term=? AND course=?",
+            [$semester, $course]
+        );
+
+        $timestamps = [];
+        foreach ($this->submitty_db->rows() as $row) {
+            $timestamps[$row['user_id']] = $row['registration_timestamp'];
+        }
+        return $timestamps;
+    }
+
+    /**
      * @param User $user
      * @param string|null $semester
      * @param string|null $course

--- a/site/app/models/RainbowCustomizationJSON.php
+++ b/site/app/models/RainbowCustomizationJSON.php
@@ -62,7 +62,8 @@ class RainbowCustomizationJSON extends AbstractModel {
 
     // The order of allowed_display and allowed_display_description has to match
     const allowed_display = ['grade_summary', 'grade_details', 'exam_seating', 'section',
-        'messages', 'warning', 'final_grade', 'final_cutoff', 'instructor_notes', 'display_rank_to_individual'];
+        'messages', 'warning', 'final_grade', 'final_cutoff', 'instructor_notes', 'display_rank_to_individual',
+        'registration_timestamp'];
 
     const allowed_display_description = [
         "Display a column(row) for each gradeable bucket on the syllabus.", //grade_summary
@@ -74,7 +75,8 @@ class RainbowCustomizationJSON extends AbstractModel {
         "Configure cutoffs and display the student's final term letter grade.", //final_grade
         "Display the histogram of average overall grade and count of students with each final term letter grade.", //final_cutoff
         "Optional message for specific students that are only visible on the instructor gradebook, these messages are never displayed to students.", //instructor_notes
-        "Display each student's rank in the course to themselves." //display_rank_to_individual
+        "Display each student's rank in the course to themselves.", //display_rank_to_individual
+        "Display the timestamp when the student joined the course." //registration_timestamp
     ];
 
 

--- a/site/app/models/User.php
+++ b/site/app/models/User.php
@@ -46,6 +46,8 @@ use Egulias\EmailValidator\Validation\RFCValidation;
  * @method void setCourseSectionId(string $Id)
  * @method int getRotatingSection()
  * @method string getRegistrationType()
+ * @method string|null getRegistrationTimestamp()
+ * @method void setRegistrationTimestamp(?string $timestamp)
  * @method void setManualRegistration(bool $flag)
  * @method bool isManualRegistration()
  * @method void setUserUpdated(bool $flag)
@@ -176,6 +178,9 @@ class User extends AbstractModel implements \JsonSerializable {
     /** @prop
      * @var string What is the registration type of the user (graded, audit, withdrawn, staff) for the course */
     protected $registration_type;
+    /** @prop
+     * @var string|null Timestamp when the user joined the course */
+    protected $registration_timestamp = null;
 
     /**
      * @prop
@@ -313,6 +318,7 @@ class User extends AbstractModel implements \JsonSerializable {
 
         // Use registration type data or default to "graded" for students and "staff" for others
         $this->registration_type = $details['registration_type'] ?? ($this->group == 4 ? 'graded' : 'staff');
+        $this->registration_timestamp = $details['registration_timestamp'] ?? null;
     }
 
     /**

--- a/site/tests/app/controllers/admin/ReportControllerTester.php
+++ b/site/tests/app/controllers/admin/ReportControllerTester.php
@@ -5,6 +5,8 @@ namespace tests\app\controllers\admin;
 use app\controllers\admin\ReportController;
 use app\libraries\response\JsonResponse;
 use app\models\gradeable\Gradeable;
+use app\models\gradeable\LateDays;
+use app\models\User;
 use tests\BaseUnitTest;
 use app\libraries\FileUtils;
 
@@ -63,7 +65,7 @@ class ReportControllerTester extends BaseUnitTest {
             'omit_section_from_stats' => ['1'],
             'display_benchmark' => ['average', 'lowest_a-', 'lowest_b-', 'lowest_c-', 'lowest_d'],
             'messages' => ['Instructor Message'],
-            'display' => ['grade_summary', 'grade_details', 'final_cutoff'],
+            'display' => ['grade_summary', 'grade_details', 'final_cutoff', 'registration_timestamp'],
             'benchmark_percent' => ['lowest_a-' => 0.9, 'lowest_b-' => 0.8, 'lowest_c-' => 0.7, 'lowest_d' => 0.6, 'average' => 0.5],
             'final_cutoff' => ['A' => 93, 'A-' => 90, 'B+' => 87, 'B' => 83, 'B-' => 80, 'C+' => 77, 'C' => 73, 'C-' => 70, 'D+' => 67, 'D' => 60],
             'gradeables' => [
@@ -225,5 +227,38 @@ class ReportControllerTester extends BaseUnitTest {
         // Test the addition of a gradeable in an unused bucket, leading to no changes
         $this->gradeables[] = $this->createMockGradeable('lab1', 'Lab 1', 'lab', 100, '2025-01-01 23:59:59-0500');
         $this->submitCustomization($content);
+    }
+
+    public function testSaveUserToFileIncludesRegistrationTimestamp(): void {
+        $base_path = $this->course_path . '/reports/all_grades';
+        FileUtils::createDir($base_path, true);
+
+        $core = $this->createMockCore([
+            'course_path' => $this->course_path,
+        ], [
+            'access_admin' => true,
+        ]);
+        $core->getConfig()->method('getDefaultStudentLateDays')->willReturn(2);
+
+        $controller = new ReportController($core);
+        $user = new User($core, [
+            'user_id' => 'student123',
+            'user_givenname' => 'Student',
+            'user_familyname' => 'Example',
+            'user_pronouns' => '',
+            'display_pronouns' => false,
+            'user_email' => 'student@example.com',
+            'user_email_secondary' => '',
+            'user_email_secondary_notify' => false,
+            'user_group' => User::GROUP_STUDENT,
+            'registration_section' => '1',
+            'registration_timestamp' => '2025-03-22 14:30:00',
+        ]);
+        $late_days = $this->createMock(LateDays::class);
+
+        $this->invokeMethod($controller, 'saveUserToFile', $base_path, $user, [], $late_days);
+
+        $saved = json_decode(file_get_contents($base_path . '/student123_summary.json'), true);
+        $this->assertSame('2025-03-22T14:30:00-04:00', $saved['registration_timestamp']);
     }
 }

--- a/site/tests/app/models/UserTester.php
+++ b/site/tests/app/models/UserTester.php
@@ -31,7 +31,8 @@ class UserTester extends \PHPUnit\Framework\TestCase {
             'course_section_id' => null,
             'rotating_section' => null,
             'manual_registration' => false,
-            'grading_registration_sections' => [1, 2]
+            'grading_registration_sections' => [1, 2],
+            'registration_timestamp' => '2025-03-22 14:30:00'
         ];
         $user = new User($this->core, $details);
         $this->assertEquals($details['user_id'], $user->getId());
@@ -48,6 +49,7 @@ class UserTester extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($details['rotating_section'], $user->getRotatingSection());
         $this->assertEquals($details['manual_registration'], $user->isManualRegistration());
         $this->assertEquals([1,2], $user->getGradingRegistrationSections());
+        $this->assertEquals($details['registration_timestamp'], $user->getRegistrationTimestamp());
         $this->assertEquals('staff', $user->getRegistrationType());
         $this->assertTrue($user->accessAdmin());
         $this->assertTrue($user->accessFullGrading());
@@ -214,6 +216,7 @@ class UserTester extends \PHPUnit\Framework\TestCase {
                 'self_registration_email' => true,
             ],
             'registration_subsection' => '',
+            'registration_timestamp' => null,
             'enforce_single_session' => false,
             'instructor_courses' => false,
         ];

--- a/tests/rainbowGrades/test_sample.py
+++ b/tests/rainbowGrades/test_sample.py
@@ -60,6 +60,8 @@ def remove_extra_raw_data_fields(raw_line):
         return False
     if 'last_update' in raw_line:
         return False
+    if 'registration_timestamp' in raw_line:
+        return False
     if 'date:' in raw_line:
         return False
     return True


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #11547.

Currently, when a course allows **self-registration**, Submitty does not record when a student joins the course. This makes it difficult for instructors to determine how long a student has been enrolled, particularly when evaluating gradeables without strict deadlines.

This change introduces a `registration_timestamp` field to track when a student registers for a course. This timestamp is stored in the database and exported with grade summary data so it can be used by Rainbow Grades.

---

### What is the New Behavior?

- A new column `registration_timestamp` is added to the `courses_users` table.
- When a student **self-registers or re-registers** for a course, the timestamp is updated to the current time.
- The timestamp is exported in the grade summary JSON files generated by Submitty.
- Rainbow Grades can optionally display the `registration_timestamp` in grade reports and CSV exports.
- The timestamp is formatted as **ISO 8601** when exported.

No existing functionality is changed.

---

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Enable **self-registration** for a course.
2. Have a student register for the course.
3. Verify that `registration_timestamp` is stored in the `courses_users` table.
4. Generate grade summaries from the instructor interface.
5. Inspect the generated JSON files under `reports/all_grades`.
6. Confirm that each student entry includes `registration_timestamp`.
7. Enable the display option in Rainbow Grades and verify that the timestamp appears in the report.

---

### Automated Testing & Documentation

- Added unit tests for:
  - `User` model to verify `registration_timestamp` storage.
  - `ReportController` to verify timestamp export in grade summary JSON.
- Updated Rainbow Grades test filtering to ignore the new field when comparing raw data.
- No documentation updates required at this time.

---

### Other information

- Includes a database migration to add the `registration_timestamp` column.
- Migration uses `DEFAULT NOW()` to maintain backward compatibility with existing records.
- This change is **not a breaking change**.
- No security concerns identified.