### PR TITLE
[Bugfix:Authentication] Enforce password validation during password change

### DIFF
--- a/site/app/controllers/UserProfileController.php
+++ b/site/app/controllers/UserProfileController.php
@@ -5,6 +5,7 @@ namespace app\controllers;
 use app\authentication\DatabaseAuthentication;
 use app\libraries\Core;
 use app\libraries\DateUtils;
+use app\libraries\Utils;
 use app\libraries\response\JsonResponse;
 use app\libraries\response\MultiResponse;
 use app\libraries\response\RedirectResponse;
@@ -92,13 +93,21 @@ class UserProfileController extends AbstractController {
             && !empty($_POST['confirm_new_password'])
             && $_POST['new_password'] == $_POST['confirm_new_password']
         ) {
-            $user->setPassword($_POST['new_password']);
-            $this->core->getQueries()->updateUser($user);
-            $this->core->addSuccessMessage("Updated password");
+
+            if (!Utils::isValidPassword($_POST['new_password'])) {
+                $this->core->addErrorMessage("Password does not meet the requirements.");
+            }
+            else {
+                $user->setPassword($_POST['new_password']);
+                $this->core->getQueries()->updateUser($user);
+                $this->core->addSuccessMessage("Updated password");
+            }
+
         }
         else {
             $this->core->addErrorMessage("Must put same password in both boxes.");
         }
+
         return MultiResponse::RedirectOnlyResponse(
             new RedirectResponse($this->core->buildUrl(['home']))
         );


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #11884

Password validation was enforced during account creation but not when changing a password, allowing users to bypass the requirements.

### What is the New Behavior?
Password changes now validate the new password using `Utils::isValidPassword()` before updating it.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Log in and go to the user profile page.
2. Try changing the password to a weak one and verify it is rejected.
3. Change it to a valid password and verify it updates successfully.

### Automated Testing & Documentation
No new tests were added since this change reuses existing validation logic.

### Other information
Not a breaking change and requires no database migrations.