### PR TITLE
Fix null array error in Rainbow Grades customization

### DIFF
--- a/site/app/models/RainbowCustomization.php
+++ b/site/app/models/RainbowCustomization.php
@@ -137,6 +137,11 @@ class RainbowCustomization extends AbstractModel {
                 // instructor entered value instead
                 $bucket = $json_bucket->type;
 
+                // Skip buckets from the JSON that no longer exist in the current syllabus
+                if (!isset($this->customization_data[$bucket]) || !is_array($this->customization_data[$bucket])) {
+                    continue;
+                }
+
                 // Filter out removed gradeables or updated gradeable buckets
                 $this->customization_data[$bucket] = array_values(array_filter($this->customization_data[$bucket], function ($g) use ($gradeable_buckets, $json_bucket) {
                     $removed = !isset($gradeable_buckets[$g['id']]);
@@ -144,7 +149,7 @@ class RainbowCustomization extends AbstractModel {
                     return !$removed && !$swapped;
                 }));
 
-                if ($json_bucket->count > $this->bucket_counts[$bucket]) {
+                if ($json_bucket->count > ($this->bucket_counts[$bucket] ?? 0)) {
                     $this->bucket_counts[$bucket] = $json_bucket->count;
                 }
                 $this->bucket_remove_lowest[$bucket] = $json_bucket->remove_lowest ?? 0;
@@ -187,6 +192,9 @@ class RainbowCustomization extends AbstractModel {
                 }
 
                 // Assign percents to customization_data gradeables by matching ids
+                if (!isset($this->customization_data[$c_bucket]) || !is_array($this->customization_data[$c_bucket])) {
+                    continue;
+                }
                 foreach ($this->customization_data[$c_bucket] as &$c_gradeable) {
                     if (isset($percent_map[$c_gradeable['id']])) {
                         $c_gradeable['override_percent'] = true;


### PR DESCRIPTION
## Summary

Fixes #12544

When accessing Rainbow Grades customization for an old course (e.g. Spring 2020), `buildCustomization()` crashes with:

```
array_filter(): Argument #1 ($array) must be of type array, null given
```

This happens because the course's `customization.json` can contain bucket types that are not present in the current `syllabus_buckets` list. Since `$this->customization_data` is only initialized with keys from `syllabus_buckets`, accessing it with an unknown bucket type yields null.

**Changes:**
- Added a guard before the `array_filter` call (line 141) to skip bucket types that don't exist in `customization_data`
- Added the same guard before the percent-assignment loop (line 195) which has the same access pattern
- Used null coalescing on the `bucket_counts` comparison as a defensive measure

## Test plan

- [ ] Verify that Rainbow Grades customization page loads without error for old courses whose `customization.json` references bucket types not in the current `syllabus_buckets`
- [ ] Verify that Rainbow Grades customization page still works correctly for current courses with valid bucket types
- [ ] Verify no regressions in the gradeable ordering and percent override behavior