### PR TITLE
[Bugfix:Submission] Fix Team Creation on VCS Gradeables

### DIFF
--- a/site/app/views/submission/TeamView.php
+++ b/site/app/views/submission/TeamView.php
@@ -26,7 +26,7 @@ class TeamView extends AbstractView {
         $this->core->getOutput()->addInternalModuleJs('team.js');
 
         $vcs_repo_exists = false;
-        $team ? $gradeable_team=$team->getId() : $gradeable_team=null;
+        $team ? $gradeable_team = $team->getId() : $gradeable_team = null;
         if ($gradeable->isVcs()) {
             $path = FileUtils::joinPaths(
                 $this->core->getConfig()->getSubmittyPath(),


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12580 

On a VCS gradeable when a user is not part of a team, there is a page error:
<img width="2666" height="1195" alt="image" src="https://github.com/user-attachments/assets/c67a336d-b8e8-4672-8338-a8b857cf4ad8" />

This is because `getId()` is being called on the `$team` variable which is `NULL`, since the team doesn't exist.

### What is the New Behavior?
Introduced a ternary operator to prevent `getId()` from getting called on `NULL`. This prevents the frog robot, and allows the path to be created to check if the VCS repo exists.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create a VCS team gradeable
2. On the gradeables page, attempt to click the `Create Team` button for the newly created gradeable
3. See error (on main) | Successfully go to the gradeable's page (feature branch)

### Automated Testing & Documentation
N/A

### Other information
Related to #12433
