### PR TITLE
fix: hide repository status for non-VCS team assignments

### DIFF
--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -51,28 +51,30 @@
         {% endif %} {# invitations.length #}
         {# /Team invitations status #}
 
-        {# Repository status #}
-        {% if vcs_repo_exists %}
-            <br />
-            <h3>To access your Team Repository:</h3>
-            <span>
-                <samp>git clone {{ gradeable.getRepositoryPath(user, team) }} SPECIFY_TARGET_DIRECTORY</samp>
-            <br />
-            </span>
-            <br />
-            <span><em>Log in using </em> '<code>{{user_id}}</code>'<em> as your username and either your password,
-            if allowed by your school, or a VCS / GIT Authentication Token in place of your password. </em></span>
-            <br><br>
-            {% if git_auth_token_required %}
-                <span><em>Note: Your school requires that you use Authentication Tokens.</em></span><br><br>
+        {% if gradeable.isVcs() %}
+            {# Repository status #}
+            {% if vcs_repo_exists %}
+                <br />
+                <h3>To access your Team Repository:</h3>
+                <span>
+                    <samp>git clone {{ gradeable.getRepositoryPath(user, team) }} SPECIFY_TARGET_DIRECTORY</samp>
+                <br />
+                </span>
+                <br />
+                <span><em>Log in using </em> '<code>{{user_id}}</code>'<em> as your username and either your password,
+                if allowed by your school, or a VCS / GIT Authentication Token in place of your password. </em></span>
+                <br><br>
+                {% if git_auth_token_required %}
+                    <span><em>Note: Your school requires that you use Authentication Tokens.</em></span><br><br>
+                {% endif %}
+                <a href="{{ git_auth_token_url }}" class="btn btn-primary">Create and Manage Authentication Tokens</a>
+            {% else %}
+                <br />
+                <h3>Your repository does not exist.</h3>
+                <p>Contact your instructor or sysadmin for assistance in creating your repository for this assignment.</p><br>
             {% endif %}
-            <a href="{{ git_auth_token_url }}" class="btn btn-primary">Create and Manage Authentication Tokens</a>
-        {% else %}
-            <br />
-            <h3>Your repository does not exist.</h3>
-            <p>Contact your instructor or sysadmin for assistance in creating your repository for this assignment.</p><br>
+            {# /Repository status #}
         {% endif %}
-        {# /Repository status #}
 
     {% else %} {# team #}
         {# Top content box, no team #}

--- a/site/cypress/e2e/Cypress-Gradeable/team.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/team.spec.js
@@ -1,0 +1,11 @@
+describe('Manage team page repository status', () => {
+    it('Should not show repository messaging for non-VCS team assignments', () => {
+        cy.login('aphacker');
+        cy.visit(['sample', 'gradeable', 'open_team_homework', 'team']);
+
+        cy.get('h1').contains('Manage Team For: Open Team Homework').should('be.visible');
+        cy.contains('h3', 'Your Team:').should('be.visible');
+        cy.contains('Your repository does not exist.').should('not.exist');
+        cy.contains('Create and Manage Authentication Tokens').should('not.exist');
+    });
+});


### PR DESCRIPTION
Closes #12579

## Summary
- hide the repository status section on the Manage Team page unless the gradeable uses VCS
- preserve the existing repository messaging for VCS team assignments
- add a Cypress regression test for open_team_homework, which is a team assignment without repository submission

## Testing
- Not run locally in this session