### PR TITLE
[Feature] Add global fullscreen mode to all pages

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -121,7 +121,48 @@
         detectColorScheme();
     </script>
     {% endif %}
+<script>
+    function toggleGlobalFullScreen() {
+        const main = document.querySelector('main#main');
+        const icon = document.getElementById('fullscreen-icon');
+        const exitBtn = document.getElementById('fullscreen-exit-btn');
+        main.classList.toggle('full-screen-mode');
+        if (main.classList.contains('full-screen-mode')) {
+            icon.classList.remove('fa-expand');
+            icon.classList.add('fa-compress');
+            exitBtn.classList.add('visible');
+            showFullscreenHint();
+        } else {
+            icon.classList.remove('fa-compress');
+            icon.classList.add('fa-expand');
+            exitBtn.classList.remove('visible');
+        }
+    }
 
+    function showFullscreenHint() {
+        const hint = document.createElement('div');
+        hint.className = 'fullscreen-hint';
+        hint.innerHTML = 'Press <strong>ESC</strong> or <strong>Shift+F</strong> to exit fullscreen';
+        document.body.appendChild(hint);
+        setTimeout(() => {
+            hint.style.opacity = '0';
+            setTimeout(() => hint.remove(), 1000);
+        }, 2000);
+    }
+
+    // Handle keyboard shortcuts
+    document.addEventListener('keydown', function(e) {
+        const main = document.querySelector('main#main');
+        const tag = document.activeElement.tagName.toLowerCase();
+        const isTyping = tag === 'input' || tag === 'textarea';
+
+        if (e.key === 'Escape' && main.classList.contains('full-screen-mode')) {
+            toggleGlobalFullScreen();
+        } else if (e.shiftKey && e.key === 'F' && !isTyping) {
+            toggleGlobalFullScreen();
+        }
+    });
+</script>
 </head>
 <body data-base-url="{{ base_url }}" data-course-url="{{ course_url }}" data-course-path="{{ course_path }}" data-csrf-token="{{ csrf_token }}" data-user-tz-off="{{ core.getUser().getUTCOffset() ?? "NONE" }}">
 <a id="skip-nav" class="skip-btn" href="#main">Skip to main content</a>
@@ -184,6 +225,24 @@
                         {% endfor %}
                     </div>
                 </div>
+                <button 
+    id="global-fullscreen-btn"
+    class="black-btn"
+    onclick="toggleGlobalFullScreen()"
+    title="Toggle Full Screen Mode"
+    aria-label="Toggle Full Screen Mode"
+>
+    <i id="fullscreen-icon" class="fas fa-expand"></i>
+</button>
+<button
+    id="fullscreen-exit-btn"
+    onclick="toggleGlobalFullScreen()"
+    title="Exit Full Screen"
+    aria-label="Exit Full Screen"
+>
+    <i class="fas fa-times"></i>
+</button>
+
                 <div style="display: flex">
                     <span id="duckdiv" style="position: relative">
                     {% if not enable_banner %}

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -173,3 +173,63 @@ footer .footer-separator {
 #loading-bar-percentage {
     margin-left: 10px;
 }
+
+/* full screen mode - hides nav and sidebar */
+main#main.full-screen-mode {
+    z-index: 10;
+    position: fixed;
+    height: 100vh;
+    width: 100vw;
+    top: 0;
+    left: 0;
+    overflow-y: auto;
+    background: var(--background-blue);
+}
+#global-fullscreen-btn {
+    color: var(--text-black);
+    background: transparent;
+    border: none;
+    font-size: 1.2em;
+    padding: 5px 10px;
+    cursor: pointer;
+}
+
+#global-fullscreen-btn:hover {
+    opacity: 0.7;
+}
+
+#fullscreen-exit-btn {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 35px;
+    height: 35px;
+    font-size: 1em;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    display: none;
+    margin: 1rem;
+}
+
+#fullscreen-exit-btn.visible {
+    display: flex;
+}
+.fullscreen-hint {
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 10px 20px;
+    border-radius: 5px;
+    z-index: 9999;
+    font-size: 1em;
+    transition: opacity 1s ease;
+}


### PR DESCRIPTION
Closes #12269

### Why is this Change Important & Necessary?
The fullscreen mode was previously only available on the TA grading page. 
Many other pages like the discussion forum, checkpoint gradeables, and live 
chat would benefit from this feature to maximize screen real estate.

### What is the New Behavior?
A fullscreen toggle button now appears in the navigation bar on every page.
Users can enter and exit fullscreen mode by:
- Clicking the expand/compress icon in the nav bar
- Pressing Shift+F on desktop
- Pressing ESC to exit on desktop
- Tapping the floating X button on mobile/tablet devices

A brief toast notification appears when entering fullscreen to inform users 
of the available keyboard shortcuts.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Log in to Submitty
2. Navigate to any page (discussion forum, gradeables, etc.)
3. Click the expand icon in the top navigation bar
4. Verify the page enters fullscreen mode and toast hint appears
5. Press ESC or Shift+F to exit fullscreen
6. Test on mobile screen size to verify the floating X button appears

### Automated Testing & Documentation
No automated tests added. New GitHub issue should be created to add 
Cypress end-to-end tests for this feature.

### Other information
Not a breaking change. No migrations required. No security concerns.