### PR TITLE
[Bugfix:InstructorUI] Always show correct calendar view

### DIFF
--- a/site/public/js/calendar.js
+++ b/site/public/js/calendar.js
@@ -18,7 +18,9 @@ const DateTime = luxon.DateTime;
  * @returns {void} : loads the updated calendar
  */
 function changeView(view_type, view_year, view_month, view_day) {
-    Cookies.set('view', view_type);
+    const type = view_type.value;
+
+    Cookies.set('view', type);
 
     let cookie_year = parseInt(Cookies.get('calendar_year'));
     let cookie_month = parseInt(Cookies.get('calendar_month'));
@@ -33,7 +35,7 @@ function changeView(view_type, view_year, view_month, view_day) {
         cookie_day = view_day;
     }
     // Load the calendar to the correct day
-    loadCalendar(cookie_month, cookie_year, cookie_day, view_type);
+    loadCalendar(cookie_month, cookie_year, cookie_day, type);
 }
 
 /**


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12605 
- A user can correctly see any calendar view

### What is the New Behavior?
Old Behavior:
<img width="1710" height="1107" alt="Screenshot 2026-03-16 at 10 04 48 PM" src="https://github.com/user-attachments/assets/c6142efd-ebd2-4d09-8243-f6f17cac3dac" />

New Behavior:
<img width="1710" height="1107" alt="Screenshot 2026-03-18 at 8 45 30 PM" src="https://github.com/user-attachments/assets/112ac015-6295-48fd-ac65-22486a1576b7" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open the web app in any browser
2. Log in as any user and go to the calendar tab
3. Click on the month button in the top right and switch to any view
4. Should correctly display now

### Automated Testing & Documentation
-Small change

### Other information
NA