### PR TITLE
BugFix(leaderboard-highlight): fix leaderboard highlighting for all course staff to blue

### DIFF
--- a/site/app/templates/submission/homework/leaderboard/LeaderboardTable.twig
+++ b/site/app/templates/submission/homework/leaderboard/LeaderboardTable.twig
@@ -17,7 +17,7 @@
             {% set student_rank_section = loop.index0 > user_index - 4 and loop.index0 <= user_index %}
             {% if normal_leaderboard_section or student_rank_section %}
                 <tr class="
-                    {% if entry["user_group"] <= grader_value %} leaderboard-grader {% endif %}
+                   {% if entry["user_group"] <= grader_value %} leaderboard-grader {% endif %}
                     {% if user_id == entry['user_id'] %} leaderboard-you {% endif %}
                     ">
                     <td scope="row" class="row_number">


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

This change addresses the issue number #12583 where the leaderboard rankings do not include course staff, instead skipping them and highlighting the row in blue.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

All course staff (instructors, full-access graders, and limited-access graders) now receive the `leaderboard-grader` blue
highlight class.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Go to http://localhost:1511/courses/s26/sample/gradeable/leaderboard/leaderboard
2. Observe that All three levels of course staff will have their leaderboard row highlighted in blue.

