### PR TITLE
[BugFix] : Fix the certain not highlighted course staff on leaderboard

### DIFF
--- a/site/app/templates/submission/homework/leaderboard/LeaderboardTable.twig
+++ b/site/app/templates/submission/homework/leaderboard/LeaderboardTable.twig
@@ -17,7 +17,7 @@
             {% set student_rank_section = loop.index0 > user_index - 4 and loop.index0 <= user_index %}
             {% if normal_leaderboard_section or student_rank_section %}
                 <tr class="
-                    {% if entry["user_group"] < grader_value %} leaderboard-grader {% endif %}
+                    {% if entry["user_group"] <= grader_value %} leaderboard-grader {% endif %}
                     {% if user_id == entry['user_id'] %} leaderboard-you {% endif %}
                     ">
                     <td scope="row" class="row_number">


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #12583 
This change is important so that the students know this is the course staff there was rank skip already applied intially but the highlighting for the grader was not applied correctly. 

### What is the New Behavior?
Before: There was no highlight of blue colour for the limited grader 
<img width="1600" height="815" alt="image" src="https://github.com/user-attachments/assets/6d69cb71-ed06-4e93-ad7a-2e25e686f9a7" />

After: Now there is highlight of blue colour for the limited grader
<img width="1660" height="878" alt="image" src="https://github.com/user-attachments/assets/d8d1f343-25db-4325-8d48-381b46b00228" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Login as anyone Eg. Instructor , Full-Access Grader , Limited-Access Grader , Student
2. Ctrl+F and type Leaderboard
3. Click SUBMIT
<img width="1578" height="88" alt="image" src="https://github.com/user-attachments/assets/2773f317-8490-44fa-8375-3103ced9d9c7" />
4. Click view Leaderboards
<img width="1643" height="90" alt="image" src="https://github.com/user-attachments/assets/e8ad0dbf-f0d7-47ea-bbbe-5580df76d5f4" />
5. Now u can see the sloved bug
<img width="1576" height="799" alt="image" src="https://github.com/user-attachments/assets/29fe12b4-1a8e-4ab3-b9aa-96af151b94af" />

### Automated Testing & Documentation
No new automated tests are required as this is a visual fix.
Manual verification: 
Limited-access graders now correctly appear with blue highlight on the leaderboard, with the rank-skipping logic that was already correct.

### Other information
- No breaking
- No migrations
- No security concerns
