### PR TITLE
[Refactor:Developer] Clean up ESLint globals in JS files.

### DIFF
--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -1,4 +1,5 @@
 /* exported collapseSection, confirmationDialog, removeImage, addImage, updateImage */
+/* global csrfToken, displayErrorMessage, displaySuccessMessage */
 /**
 * toggles visibility of a content sections on the Docker UI
 * @param {string} id of the section to toggle
@@ -76,7 +77,6 @@ function removeImage(url, id) {
         type: 'POST',
         data: {
             image: id,
-            // eslint-disable-next-line no-undef
             csrf_token: csrfToken,
         },
         success: (data) => {
@@ -86,7 +86,6 @@ function removeImage(url, id) {
                 location.reload();
             }
             else {
-                // eslint-disable-next-line no-undef
                 displayErrorMessage(json.message);
             }
         },
@@ -106,7 +105,6 @@ function addImage(url) {
         data: {
             capability: capability,
             image: image,
-            // eslint-disable-next-line no-undef
             csrf_token: csrfToken,
         },
         success: (data) => {
@@ -117,7 +115,6 @@ function addImage(url) {
                 location.reload();
             }
             else {
-                // eslint-disable-next-line no-undef
                 displayErrorMessage(json.message);
             }
         },
@@ -133,17 +130,14 @@ function updateImage(url) {
         url: url,
         type: 'GET',
         data: {
-            // eslint-disable-next-line no-undef
             csrf_token: csrfToken,
         },
         success: (data) => {
             const json = JSON.parse(data);
             if (json.status === 'success') {
-                // eslint-disable-next-line no-undef
                 displaySuccessMessage(json.data);
             }
             else {
-                // eslint-disable-next-line no-undef
                 displayErrorMessage(json.message);
             }
         },
@@ -253,7 +247,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
     const successMessage = sessionStorage.getItem('successMessage');
     if (successMessage) {
-        // eslint-disable-next-line no-undef
         displaySuccessMessage(successMessage);
 
         // Clear the message from sessionStorage so it doesn't show again

--- a/site/public/js/latedays.js
+++ b/site/public/js/latedays.js
@@ -1,4 +1,4 @@
-/* global luxon */
+/* global luxon, flatpickr, ShortcutButtonsPlugin, buildCourseUrl, csrfToken */
 const DateTime = luxon.DateTime;
 
 function calculateLateDays(inputDate) {
@@ -16,9 +16,7 @@ function calculateLateDays(inputDate) {
 }
 
 $(document).ready(() => {
-    // eslint-disable-next-line no-undef
     flatpickr('#late-calendar', {
-        // eslint-disable-next-line no-undef
         plugins: [ShortcutButtonsPlugin(
             {
                 button: [
@@ -58,7 +56,6 @@ $(document).ready(() => {
 function updateLateDays(data) {
     const fd = new FormData($('#late-day-form').get(0));
     const selected_csv_option = $('input:radio[name=csv_option]:checked').val();
-    // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['late_days', 'update'])}?csv_option=${selected_csv_option}`;
     $.ajax({
         url: url,
@@ -79,7 +76,6 @@ function updateLateDays(data) {
 function deleteLateDays(user_id, datestamp) {
     // Convert 'MM/DD/YYYY HH:MM:SS A' to 'MM/DD/YYYY'
     // datestamp_mmddyy = datestamp.split(" ")[0];
-    // eslint-disable-next-line no-undef
     const url = buildCourseUrl(['late_days', 'delete']);
     const confirm = window.confirm('Are you sure you would like to delete this entry?');
     if (confirm) {
@@ -87,7 +83,6 @@ function deleteLateDays(user_id, datestamp) {
             url: url,
             type: 'POST',
             data: {
-                // eslint-disable-next-line no-undef
                 csrf_token: csrfToken,
                 user_id: user_id,
                 datestamp: datestamp,
@@ -127,7 +122,6 @@ function updateCacheBuildStatus(url, confirm_message, status) {
 }
 
 function calculateLateDayCache() {
-    // eslint-disable-next-line no-undef
     const url = buildCourseUrl(['bulk_late_days', 'calculate']);
     const confirm_message = 'Are you sure you want to recalculate the cache? Calculating the remaining late day information for every user may take a while.';
     const status = 'Recaclulating...';
@@ -135,7 +129,6 @@ function calculateLateDayCache() {
 }
 
 function flushLateDayCache() {
-    // eslint-disable-next-line no-undef
     const url = buildCourseUrl(['bulk_late_days', 'flush']);
     const confirm_message = 'Are you sure you want to flush the cache? This will remove the late day cache for every user.';
     const status = 'Flushing...';

--- a/site/public/js/plagiarism.js
+++ b/site/public/js/plagiarism.js
@@ -1,3 +1,4 @@
+/* global initializeResizablePanels, CodeMirror, buildCourseUrl */
 // MODEL + CONTROLLERS /////////////////////////////////////////////////////////
 /**
  * On document.ready, JS in PlagiarismResult.twig will call this function
@@ -7,11 +8,9 @@
  * @param {array} user_1_list
  */
 function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_list) {
-    // eslint-disable-next-line no-undef
     initializeResizablePanels('.left-sub-item', '.plag-drag-bar');
 
     // initialize editors
-    // eslint-disable-next-line no-undef
     const editor1 = CodeMirror.fromTextArea(document.getElementById('code_box_1'), {
         lineNumbers: true,
         readOnly: true,
@@ -19,7 +18,6 @@ function setUpPlagView(gradeable_id, term_course_gradeable, config_id, user_1_li
         lineWrapping: true,
         autoRefresh: true,
     });
-    // eslint-disable-next-line no-undef
     const editor2 = CodeMirror.fromTextArea(document.getElementById('code_box_2'), {
         lineNumbers: true,
         readOnly: true,
@@ -237,7 +235,6 @@ function user2DropdownChanged(state) {
 }
 
 function loadUser1VersionDropdownList(state) {
-    // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'versionlist'])}?user_id_1=${state.user_1_selected.user_id}`;
     requestAjaxData(url, (data) => {
         state.user_1_version_dropdown_list = data;
@@ -255,7 +252,6 @@ function loadUser1VersionDropdownList(state) {
 
 function loadUser2DropdownList(state) {
     // acquire ajax data for user 2 dropdown and send to the refresher
-    // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'match'])}?user_id_1=${state.user_1_selected.user_id}&version_user_1=${state.user_1_selected.version}`;
     requestAjaxData(url, (data) => {
         state.user_2_dropdown_list = data;
@@ -280,7 +276,6 @@ function loadConcatenatedFileForEditor(state, editor) {
     // to the selected user + version in panel number #editor
     let url = '';
     if (editor === 1) {
-        // eslint-disable-next-line no-undef
         url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'concat'])}?user_id=${state.user_1_selected.user_id}&version=${state.user_1_selected.version}`;
     }
     else { // editor 2
@@ -289,7 +284,6 @@ function loadConcatenatedFileForEditor(state, editor) {
             state.editor2.refresh();
             return;
         }
-        // eslint-disable-next-line no-undef
         url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'concat'])}?user_id=${state.user_2_selected.user_id}&version=${state.user_2_selected.version}&source_gradeable=${state.user_2_selected.source_gradeable}`;
     }
     requestAjaxData(url, (data) => {
@@ -327,7 +321,6 @@ function loadColorInfo(state) {
         return;
     }
 
-    // eslint-disable-next-line no-undef
     const url = `${buildCourseUrl(['plagiarism', 'gradeable', state.gradeable_id, state.config_id, 'colorinfo'])}?user_id_1=${state.user_1_selected.user_id}&version_user_1=${state.user_1_selected.version}&user_id_2=${state.user_2_selected.user_id}&version_user_2=${state.user_2_selected.version}&source_gradeable_user_2=${state.user_2_selected.source_gradeable}`;
     requestAjaxData(url, (data) => {
         state.color_info = data;

--- a/site/public/js/user-profile.js
+++ b/site/public/js/user-profile.js
@@ -3,7 +3,8 @@ showUpdatePronounsForm, showDisplayNameOrderForm, showUpdatePasswordForm, showUp
 updateUserPreferredNames, updateUserLastInitialFormat, updateUserProfilePhoto, updateUserSecondaryEmail, updateDisplayNameOrder,
 changeSecondaryEmail, previewUserLastInitialFormat, clearPronounsBox
  */
-/* global displaySuccessMessage, displayErrorMessage, buildUrl, showPopup */
+/* global displaySuccessMessage, displayErrorMessage, buildUrl, showPopup, csrfToken, updateSidebarPreference, CollapseSidebarOnNarrowView, DisableAutomaticCollapse,
+  updateTheme, displayWarningMessage */
 
 // This variable is to store changes to the pronouns form that have not been submitted
 let pronounsLastVal = null;
@@ -116,7 +117,6 @@ function updateUserPronouns(e) {
     else {
         const data = new FormData();
         const isForumDisplayChecked = forumDisplay.prop('checked');
-        // eslint-disable-next-line no-undef
         data.append('csrf_token', csrfToken);
         data.append('pronouns', pronouns.val());
         data.append('pronouns-forum-display', isForumDisplayChecked);
@@ -165,7 +165,6 @@ function updateDisplayNameOrder(e) {
     displayNameOrderLast = displayNameOrder.val();
 
     const data = new FormData();
-    // eslint-disable-next-line no-undef
     data.append('csrf_token', csrfToken);
     data.append('display-name-order', displayNameOrder.val());
     const url = buildUrl(['user_profile', 'change_display_name_order']);
@@ -213,7 +212,6 @@ function updateUserPreferredNames() {
     }
     else {
         const data = new FormData();
-        // eslint-disable-next-line no-undef
         data.append('csrf_token', csrfToken);
         data.append('given_name', given_name_field.val());
         data.append('family_name', family_name_field.val());
@@ -355,7 +353,6 @@ function updateUserSecondaryEmail() {
         }
         else {
             const data = new FormData();
-            // eslint-disable-next-line no-undef
             data.append('csrf_token', csrfToken);
             data.append('secondary_email', second_email.val());
             data.append('secondary_email_notify', second_email_notify.get(0).checked);
@@ -416,23 +413,19 @@ function previewUserLastInitialFormat() {
 
 $(document).ready(() => {
     $('#desktop_sidebar_preference').change(() => {
-        // eslint-disable-next-line no-undef
         updateSidebarPreference();
         location.reload();
     });
     if (localStorage.getItem('desktop-sidebar-preference')) {
         if (localStorage.getItem('desktop-sidebar-preference') === 'automatic') {
-            // eslint-disable-next-line no-undef
             CollapseSidebarOnNarrowView();
         }
         else {
-            // eslint-disable-next-line no-undef
             DisableAutomaticCollapse();
         }
     }
 
     $('#theme_change_select').change(() => {
-        // eslint-disable-next-line no-undef
         updateTheme();
         if (JSON.parse(localStorage.getItem('rainbow-mode')) === true) {
             $(document.body).find('#rainbow-mode').remove();
@@ -469,7 +462,6 @@ $(document).ready(() => {
             type: 'POST',
             url: buildUrl(['user_profile', 'change_time_zone']),
             data: {
-                // eslint-disable-next-line no-undef
                 csrf_token: csrfToken,
                 time_zone,
             },
@@ -483,7 +475,6 @@ $(document).ready(() => {
                     // Check user's current time zone, give a warning message if the user's current time zone differs from systems' time-zone
                     const offset = getCurrentUTCOffset();
                     if (response.data.utc_offset !== offset) {
-                        // eslint-disable-next-line no-undef
                         displayWarningMessage('Selected time-zone does not match system time-zone.');
                     }
                 }
@@ -516,7 +507,6 @@ $(document).ready(() => {
             type: 'POST',
             url: buildUrl(['user_profile', 'set_pref_locale']),
             data: {
-                // eslint-disable-next-line no-undef
                 csrf_token: csrfToken,
                 locale: $(this).val(),
             },


### PR DESCRIPTION


### Why is this Change Important & Necessary?
Partially adresses #10506 . Several JS files use '//eslint-disable-next-line no-undef' comments instead of properly declaring globals in '/*global*/' comments at the top of each file.

### What is the New Behavior?
Added proper '/*global*/' declarations and removed '/*eslint-disable-next-line no-undef*/' comments in:

- docker_interface.js
- latedays.js
- plagiarism.js
- user-profile.js

### Files not included in this PR
- server.js - The no-undef warnings in this file stem from undeclared local variables that require 'let' or 'const' declarations, not global additions. This change might be best suited for a separate PR

-forum.js - This file was excluded due to its large size and high number of instances, which will be tackled in a follow-up PR.

-PDFInitToolbar.js - This file no longer exists in the codebase

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open the modified files and verify that `// eslint-disable-next-line no-undef` comments have been removed.      
         
2. Verify that the variables referenced on the lines following removed lint comments are now declared in the global comment at the top of each file.

3. Confirm that other 'eslint-disable' comments, for instance 'no-restricted-syntax', are untouched.

### Automated Testing & Documentation
ESLint passes on all modified files. No functional changes, only lint comments were cleaned up and global declarations added.

### Other information
This is not a breaking change.
No migrations or security concerns.

