### PR TITLE
[Bugfix:Autograding] Fix Python input echo and newline

### DIFF
--- a/grading/execute.cpp
+++ b/grading/execute.cpp
@@ -657,6 +657,17 @@ void parse_command_line(const std::string &cmd,
 // =====================================================================================
 // =====================================================================================
 
+std::string get_std_outfile(std::string cmd)
+{
+  size_t index = cmd.find("1>");
+  if (index == std::string::npos) return "";
+  std::string file = cmd.substr(index + 2);
+  size_t space_index = file.find(" ");
+  if (space_index != std::string::npos) {
+      file = file.substr(0, space_index);
+  }
+  return file;
+}
 std::string get_std_errfile(std::string cmd)
 {
 	size_t index = cmd.find("2>");
@@ -1012,8 +1023,14 @@ void cin_reader(std::mutex* lock, std::queue<std::string>* input_queue, bool* CH
       ret = poll(&fds, 1, 100); //.1 second timeout
 
       if (ret > 0){
-        std::getline (std::cin,my_string);
-        std::cout << "Cin received: " << my_string << std::endl;
+       if(std::getline(std::cin,my_string)) {
+         if(!my_string.empty()&& my_string.back()=='\r'){
+           my_string.pop_back();
+         }
+          std::cout << "Cin received: " << my_string << std::endl;
+        }else{
+          continue;
+        }
 
         lock->lock();
         input_queue->push(my_string);
@@ -1286,6 +1303,13 @@ int execute(const std::string &cmd,
               dispatcher_actions_ended = true;
             }else{
               write(dispatcherpipe[1], piped_message, strlen(popped_nl.c_str()));
+              std::string std_outfile = get_std_outfile(cmd);
+              if (std_outfile != "") {
+                std::ofstream student_stdout(std_outfile, std::ios_base::app);
+                if (student_stdout.is_open()) {
+                  student_stdout << popped_nl << std::flush;
+                }
+              }
               std::cout << "Writing to student stdin: " << popped << std::endl;
             }
           }


### PR DESCRIPTION
## Why is this change important & necessary?

Fixes #7583 

This PR fixes two major discrepancies between local Python execution and Submitty's autograding environment:

1. **Missing echo:** When using `dispatcher_actions` (interactive input), student output logs previously omitted the user's typed input because STDIN was redirected from a pipe.
2. **Extra newline bug:** Input lines containing Windows-style carriage returns (`\r`) were not being normalized, leading to unexpected character counts and logic errors in student code.

## What is the new behavior?

- **Manual input echo:** The C++ supervisor (`execute.cpp`) now identifies the student's output file and manually appends an echo of every input line sent via the dispatcher. This ensures the STDOUT log matches what a student would see in a real terminal.
- **Input normalization:** The `cin_reader` thread now surgically strips trailing `\r` characters from input lines, ensuring cross-platform compatibility for instructor-provided input files.
- **Improved robustness:** Added a `get_std_outfile` helper to accurately locate the redirection target from the command string.

## How to reproduce or test

1. Create a Python gradeable using `dispatcher_actions` to provide interactive input.
2. Include a prompt like `s = input("Enter name: ")` and a length check `len(s)`.
3. Submit a solution and verify that:
   - The input text appears on the same line as the prompt in the "Student Program Output".
   - The length of the received string does not include hidden carriage returns.

## Screenshots

**Before**

<img width="706" height="194" alt="260320_16h13m38s_screenshot" src="https://github.com/user-attachments/assets/af796625-8e47-4223-8688-d4994811ce1f" />

**After**

<img width="1004" height="191" alt="260321_17h25m42s_screenshot" src="https://github.com/user-attachments/assets/faa915c9-6290-421d-b12f-6cc6e6bdb0dd" />

## Other information

- **Breaking change?** No
- **Migrations?** No.