### PR TITLE
[UI/UX:System] : Standardize alert banner 

### DIFF
--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -236,22 +236,26 @@
                 {% endif %}
             </nav>
         {% endif %}
-        <noscript class="system-message danger">
-            You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.
+        <noscript class="alert-banner alert-danger">
+            <i class="fas fa-exclamation-circle"></i>
+            <div>You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.</div>
         </noscript>
         {% if system_message is not null and system_message|length > 0 %}
-            <div class="system-message warning">
-                {{ system_message }}
+            <div class="alert-banner alert-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                <div>{{ system_message }}</div>
             </div>
         {% endif %}
-        <div class="system-message warning" id="server-time-not-aligned" hidden>
-            Warning: The server time is not aligned with the browser time. 
-            Please check your system time settings.
+        <div class="alert-banner alert-warning" id="server-time-not-aligned" hidden>
+            <i class="fas fa-exclamation-triangle"></i>
+            <div>Warning: The server time is not aligned with the browser time. 
+            Please check your system time settings.</div>
         </div>
-        <div class="system-message warning" id="socket-server-system-message" hidden>
-            Warning: Failed to connect to websocket server. This page will not dynamically update.
+        <div class="alert-banner alert-warning" id="socket-server-system-message" hidden>
+            <i class="fas fa-exclamation-triangle"></i>
+            <div>Warning: Failed to connect to websocket server. This page will not dynamically update.
             Manually reload this page to see updates.{% if sysadmin_email is not empty %} Notify the
-            sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}
+            sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}</div>
         </div>
         {% include 'Vue.twig' with {
             'type': 'component',

--- a/site/app/templates/GlobalHeader.twig
+++ b/site/app/templates/GlobalHeader.twig
@@ -236,36 +236,6 @@
                 {% endif %}
             </nav>
         {% endif %}
-        <noscript class="alert-banner alert-danger">
-            <i class="fas fa-exclamation-circle"></i>
-            <div>You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.</div>
-        </noscript>
-        {% if system_message is not null and system_message|length > 0 %}
-            <div class="alert-banner alert-warning">
-                <i class="fas fa-exclamation-triangle"></i>
-                <div>{{ system_message }}</div>
-            </div>
-        {% endif %}
-        <div class="alert-banner alert-warning" id="server-time-not-aligned" hidden>
-            <i class="fas fa-exclamation-triangle"></i>
-            <div>Warning: The server time is not aligned with the browser time. 
-            Please check your system time settings.</div>
-        </div>
-        <div class="alert-banner alert-warning" id="socket-server-system-message" hidden>
-            <i class="fas fa-exclamation-triangle"></i>
-            <div>Warning: Failed to connect to websocket server. This page will not dynamically update.
-            Manually reload this page to see updates.{% if sysadmin_email is not empty %} Notify the
-            sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}</div>
-        </div>
-        {% include 'Vue.twig' with {
-            'type': 'component',
-            'name': 'PerformanceWarning',
-            'args': {
-                "performanceWarning": performance_warning,
-                "submittyQueries": submitty_queries,
-                "courseQueries": course_queries
-            }
-        } %}
         {% include 'Vue.twig' with {
             'name': 'Toasts',
             'type': 'component',
@@ -287,4 +257,34 @@
                 </aside>
             {% endif %}
             <main id="main" data-testid="content-main">
+                <noscript class="alert-banner alert-danger">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <div>You must have JavaScript enabled for Submitty to function properly. Please re-enable it when browsing this site.</div>
+                </noscript>
+                {% if system_message is not null and system_message|length > 0 %}
+                    <div class="alert-banner alert-warning">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div>{{ system_message }}</div>
+                    </div>
+                {% endif %}
+                <div class="alert-banner alert-warning" id="server-time-not-aligned" hidden>
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <div>Warning: The server time is not aligned with the browser time.
+                    Please check your system time settings.</div>
+                </div>
+                <div class="alert-banner alert-warning" id="socket-server-system-message" hidden>
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <div>Warning: Failed to connect to websocket server. This page will not dynamically update.
+                    Manually reload this page to see updates.{% if sysadmin_email is not empty %} Notify the
+                    sysadmin at <a href='mailto:{{ sysadmin_email }}'>{{ sysadmin_email }}</a>.{% endif %}</div>
+                </div>
+                {% include 'Vue.twig' with {
+                    'type': 'component',
+                    'name': 'PerformanceWarning',
+                    'args': {
+                        "performanceWarning": performance_warning,
+                        "submittyQueries": submitty_queries,
+                        "courseQueries": course_queries
+                    }
+                } %}
 {# Looks mismatched because this lines up with GlobalFooter.twig #}

--- a/site/app/templates/admin/Extensions.twig
+++ b/site/app/templates/admin/Extensions.twig
@@ -68,13 +68,16 @@
         </fieldset>
     </form>
     {% if current_exceptions is null %}
-        <p id="empty-table" class="warning">
+        <div id="empty-table" class="alert-banner alert-warning">
+            <i class="fas fa-exclamation-triangle"></i>
+            <div>
             {% if current_gradeable is null %}
                 No gradeable has been selected
             {% else %}
                 No extensions are currently entered for this gradeable
             {% endif %}
-        </p>
+            </div>
+        </div>
     {% else %}
         {# This is a data table #}
         <table id="extensions-table" class="table table-striped mobile-table">

--- a/site/app/templates/admin/GradeOverride.twig
+++ b/site/app/templates/admin/GradeOverride.twig
@@ -45,9 +45,10 @@
             </label>
         </fieldset>
         <input class="btn btn-primary" type="submit" value="Submit" data-testid="grade-override-submit">
-        <p id="empty-table" class="warning" data-testid="grade-override-message-box">
-            No gradeable has been selected
-        </p>
+        <div id="empty-table" class="alert-banner alert-warning" data-testid="grade-override-message-box">
+            <i class="fas fa-exclamation-triangle"></i>
+            <div>No gradeable has been selected</div>
+        </div>
         <div id="load-overridden-grades" class="d-none" data-testid="load-overridden-grades">
             {# This is a data table #}
             <table id="grade-override-table" class="table table-striped table-bordered persist-area mobile-table">

--- a/site/app/templates/admin/LateDays.twig
+++ b/site/app/templates/admin/LateDays.twig
@@ -57,7 +57,10 @@
     </form>
     {# This is a data table #}
     {% if not users or (users|length < 1) %}
-        <p id="empty-table" class="warning">No late days are currently entered</p>
+        <div id="empty-table" class="alert-banner alert-warning">
+            <i class="fas fa-exclamation-triangle"></i>
+            <div>No late days are currently entered</div>
+        </div>
     {% else %}
         <table id="late-day-table" class="table table-striped mobile-table">
             <caption>Late Days Allowed</caption>

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -1,6 +1,9 @@
-<div class="warning-banner content" id="gradeable-dates-warnings-banner" data-testid="gradeable-dates-warnings-banner" hidden>
-    <p class="dates-warning" id="grade-inquiry-dates-warning" data-testid="grade-inquiry-dates-warning" hidden>Warning: Grade Inquiry ends before it starts. Students will not be able to make Grade Inquires.</p>
-    <p class="dates-warning" id="no-grade-inquiry-warning" data-testid="no-grade-inquiry-warning" hidden>Warning: Grade Inquiry ends before the assignment is released. Students will not be able to make Grade Inquires.</p>
+<div class="alert-banner alert-warning" id="gradeable-dates-warnings-banner" data-testid="gradeable-dates-warnings-banner" hidden>
+    <i class="fas fa-exclamation-triangle"></i>
+    <div>
+        <p class="dates-warning" id="grade-inquiry-dates-warning" data-testid="grade-inquiry-dates-warning" hidden>Warning: Grade Inquiry ends before it starts. Students will not be able to make Grade Inquires.</p>
+        <p class="dates-warning" id="no-grade-inquiry-warning" data-testid="no-grade-inquiry-warning" hidden>Warning: Grade Inquiry ends before the assignment is released. Students will not be able to make Grade Inquires.</p>
+    </div>
 </div>
 <div id="gradeable-dates">
     <input data-testid="ta-view-start-date" name="ta_view_start_date" id="date_ta_view" class="date_picker" type="text" value="{{ gradeable.getTaViewStartDate()|date(date_format, timezone_string) }}">

--- a/site/app/templates/officeHoursQueue/QueueHeader.twig
+++ b/site/app/templates/officeHoursQueue/QueueHeader.twig
@@ -1,12 +1,16 @@
 {% if viewer.getQueueMessage() | length > 0 %}
-    {% include 'Vue.twig' with {
-        type: "component",
-        name: "Markdown",
-        args: {
-            content: viewer.getQueueMessage()
-        },
-        class: "content gradeable_message",
-    } only %}
+    <div class="alert-banner alert-info">
+        <i class="fas fa-info-circle"></i>
+        <div style="width: 100%;">
+            {% include 'Vue.twig' with {
+                type: "component",
+                name: "Markdown",
+                args: {
+                    content: viewer.getQueueMessage()
+                }
+            } only %}
+        </div>
+    </div>
 {% endif %}
 
 <div class="content">

--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -1,7 +1,10 @@
 {% if rainbow_grade_active is defined and not rainbow_grade_active %}
-    <div class="content warning-banner" data-testid="rainbow-grades-not-active-banner">
-        <p>Rainbow Grades are not available to students.</p>
-        <p>You can choose to toggle it on within the <a href="{{ config_url }}">course settings.</a></p>
+    <div class="alert-banner alert-warning" data-testid="rainbow-grades-not-active-banner">
+        <i class="fas fa-exclamation-triangle"></i>
+        <div>
+            <p>Rainbow Grades are not available to students.</p>
+            <p>You can choose to toggle it on within the <a href="{{ config_url }}">course settings.</a></p>
+        </div>
     </div>
 {% endif %}
 

--- a/site/app/templates/submission/homework/LateDayMessage.twig
+++ b/site/app/templates/submission/homework/LateDayMessage.twig
@@ -2,11 +2,9 @@
 
 {% if messages|length > 0 %}
 {# WRAP THE LATE DAY INFORMATION IN A DIV #}
-<div class="content"
-    {% if error %}
-        style="background-color: var(--standard-light-red);"
-    {% endif %}
->
+<div class="alert-banner {% if error %}alert-danger{% else %}alert-info{% endif %}">
+    <i class="fas {% if error %}fa-exclamation-circle{% else %}fa-info-circle{% endif %}"></i>
+    <div>
     <h4>
         {% for message in messages %}
             {% if message.type == 'extension' %}
@@ -89,6 +87,7 @@
         <br>
         For more information, see your complete <a href="{{ late_days_url }}">"My Late Days/Extensions"</a> page.
     </h4>
+    </div>
 </div>
 {% endif %}
 

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -2,21 +2,28 @@
 
 {# Display the gradeable_message if one exists at the top of the page #}
 {% if has_gradeable_message %}
-    {% include 'Vue.twig' with {
-        type: "component",
-        name: "Markdown",
-        args: {
-            content: gradeable_message
-        },
-        class: "content gradeable_message",
-    } only %}
+    <div class="alert-banner alert-info">
+        <i class="fas fa-info-circle"></i>
+        <div style="width: 100%;">
+            {% include 'Vue.twig' with {
+                type: "component",
+                name: "Markdown",
+                args: {
+                    content: gradeable_message
+                }
+            } only %}
+        </div>
+    </div>
 {% endif %}
 
 {% if has_overridden_grades %}
-    <div class='content overridden-message'>
-        <p>NOTE: The numeric score for this assignment has been overridden by your instructor.</p>
-        {% if rainbow_grades_active %} <p>Your numeric score for the assignment will be visible in <a href={{ rainbow_grades_url }}>Rainbow Grades.</a></p> {% endif %}
-        <p>Please see your instructor if you have questions about your grade for this assignment.</p>
+    <div class="alert-banner alert-warning">
+        <i class="fas fa-exclamation-triangle"></i>
+        <div>
+            <p>NOTE: The numeric score for this assignment has been overridden by your instructor.</p>
+            {% if rainbow_grades_active %} <p>Your numeric score for the assignment will be visible in <a href={{ rainbow_grades_url }}>Rainbow Grades.</a></p> {% endif %}
+            <p>Please see your instructor if you have questions about your grade for this assignment.</p>
+        </div>
     </div>
 {% endif %}
 

--- a/site/public/css/colors.css
+++ b/site/public/css/colors.css
@@ -238,6 +238,22 @@
     --diff-background-expected: #defae1;
     --diff-char-background-actual: #fbc1c0;
     --diff-char-background-expected: #a8edb0;
+
+    /* Clean Alert Banners */
+    --alert-banner-bg: #ffffff;
+    --alert-banner-error: #dc3545;
+    --alert-banner-warning: #ffc107;
+    --alert-banner-success: #28a745;
+    --alert-banner-info: #17a2b8;
+    --alert-banner-text: #000000;
+}
+[data-theme="dark"] {
+    --alert-banner-bg: #2a2a2a;
+    --alert-banner-text: #e0e0e0;
+    --alert-banner-error: #ff6b6b;
+    --alert-banner-warning: #ffd93d;
+    --alert-banner-success: #6bcb77;
+    --alert-banner-info: #4d96ff;
 }
 
 [data-black_mode="black"][data-theme="dark"] {
@@ -369,6 +385,14 @@
     --diff-background-expected: #16261e;
     --diff-char-background-actual: #7a3133;
     --diff-char-background-expected: #29562d;
+
+    /*banner*/
+    --alert-banner-bg: #2b2b2b;
+    --alert-banner-error: #ff7a7a;
+    --alert-banner-warning: #ffc107;
+    --alert-banner-success: #28a745;
+    --alert-banner-info: #17a2b8;
+    --alert-banner-text: #ffffff;
 }
 
 /* Dark Theme Versions of Colors */

--- a/site/public/css/global.css
+++ b/site/public/css/global.css
@@ -110,6 +110,7 @@ main {
     width: 100%;
     min-width: 0;
     position: relative;
+    z-index: 1;
 }
 
 footer {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1,6 +1,45 @@
 @import url("reset.css");
 @import url("google/inconsolata.css");
 
+.alert-banner {
+    background-color: var(--alert-banner-bg) !important;
+    color: var(--alert-banner-text) !important;
+    padding: 15px 20px;
+    margin: 10px 10px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px var(--box-shadow-slightly-transparent);
+    display: flex;
+    align-items: center;
+    border: 1px solid transparent;
+    border-left: 5px solid transparent !important;
+}
+
+.alert-banner .fas, .alert-banner .far {
+    margin-right: 15px;
+    font-size: 1.2em;
+}
+
+.alert-danger {
+    border-color: var(--alert-banner-error) !important;
+}
+.alert-danger .fas, .alert-danger .far { color: var(--alert-banner-error); }
+
+.alert-warning {
+    border-color: var(--alert-banner-warning) !important;
+}
+.alert-warning .fas, .alert-warning .far { color: var(--alert-banner-warning); }
+
+.alert-success {
+    border-color: var(--alert-banner-success) !important;
+}
+.alert-success .fas, .alert-success .far { color: var(--alert-banner-success); }
+
+.alert-info {
+    border-color: var(--alert-banner-info) !important;
+}
+.alert-info .fas, .alert-info .far { color: var(--alert-banner-info); }
+
+
 /* stylelint-disable no-descending-specificity */
 
 a,

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -2,8 +2,8 @@
 @import url("google/inconsolata.css");
 
 .alert-banner {
-    background-color: var(--alert-banner-bg) !important;
-    color: var(--alert-banner-text) !important;
+    background-color: var(--alert-banner-bg);
+    color: var(--alert-banner-text);
     padding: 15px 20px;
     margin: 10px 10px;
     border-radius: 4px;
@@ -11,7 +11,13 @@
     display: flex;
     align-items: center;
     border: 1px solid transparent;
-    border-left: 5px solid transparent !important;
+    border-left: 5px solid var(--alert-banner-info);
+    position: relative;
+    z-index: 1000;
+}
+
+.alert-banner[hidden] {
+    display: none;
 }
 
 .alert-banner .fas, .alert-banner .far {
@@ -19,25 +25,29 @@
     font-size: 1.2em;
 }
 
-.alert-danger {
+.alert-banner.alert-danger, .alert-danger {
+    background-color: var(--alert-banner-bg);
     border-color: var(--alert-banner-error) !important;
 }
-.alert-danger .fas, .alert-danger .far { color: var(--alert-banner-error); }
+.alert-banner.alert-danger .fas, .alert-banner.alert-danger .far { color: var(--alert-banner-error); }
 
-.alert-warning {
+.alert-banner.alert-warning, .alert-warning {
+    background-color: var(--alert-banner-bg);
     border-color: var(--alert-banner-warning) !important;
 }
-.alert-warning .fas, .alert-warning .far { color: var(--alert-banner-warning); }
+.alert-banner.alert-warning .fas, .alert-banner.alert-warning .far { color: var(--alert-banner-warning); }
 
-.alert-success {
+.alert-banner.alert-success, .alert-success {
+    background-color: var(--alert-banner-bg);
     border-color: var(--alert-banner-success) !important;
 }
-.alert-success .fas, .alert-success .far { color: var(--alert-banner-success); }
+.alert-banner.alert-success .fas, .alert-banner.alert-success .far { color: var(--alert-banner-success); }
 
-.alert-info {
+.alert-banner.alert-info, .alert-info {
+    background-color: var(--alert-banner-bg);
     border-color: var(--alert-banner-info) !important;
 }
-.alert-info .fas, .alert-info .far { color: var(--alert-banner-info); }
+.alert-banner.alert-info .fas, .alert-banner.alert-info .far { color: var(--alert-banner-info); }
 
 
 /* stylelint-disable no-descending-specificity */

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -5,15 +5,15 @@
     background-color: var(--alert-banner-bg);
     color: var(--alert-banner-text);
     padding: 15px 20px;
-    margin: 10px 10px;
+    margin: 10px;
+    box-sizing: border-box;
     border-radius: 4px;
     box-shadow: 0 2px 4px var(--box-shadow-slightly-transparent);
     display: flex;
     align-items: center;
     border: 1px solid transparent;
     border-left: 5px solid var(--alert-banner-info);
-    position: relative;
-    z-index: 1000;
+    max-width: 100%;
 }
 
 .alert-banner[hidden] {

--- a/site/public/css/sidebar.css
+++ b/site/public/css/sidebar.css
@@ -5,11 +5,12 @@ aside {
 @media (min-width: 541px) {
     aside {
         display: block;
-        margin: 0 -30px 0 0;
+        position: relative;
+        margin: 0;
         padding-top: 30px;
         width: 250px;
         min-width: 250px;
-        z-index: 1;
+        z-index: 2;
         transition: all 0.3s ease-out;
     }
 

--- a/site/vue/src/components/PerformanceWarning.vue
+++ b/site/vue/src/components/PerformanceWarning.vue
@@ -12,8 +12,9 @@ const isVisible = ref(props.performanceWarning);
   <div
     v-if="isVisible"
     id="performance-warning-system-message"
-    class="system-message warning performance-warning"
+    class="alert-banner alert-warning performance-warning"
   >
+    <i class="fas fa-exclamation-triangle"></i>
     <span id="performance-warning-system-message-text">
       Developer Warning: Excessive or duplicate database queries observed: {{ submittyQueries.length + courseQueries.length }} queries executed. Click "Show Page Details" at the bottom of the page for more info.
     </span>

--- a/site/vue/src/components/Toasts.vue
+++ b/site/vue/src/components/Toasts.vue
@@ -84,7 +84,7 @@ window.displayWarningMessage = (message: string) => displayMessage(message, 'war
       v-for="message in activeMessages"
       :id="`${message.type}-${message.key}`"
       :key="message.key"
-      :class="`inner-message alert alert-${message.type}`"
+      :class="['inner-message', 'alert-banner', message.type === 'error' ? 'alert-danger' : `alert-${message.type}`]"
       data-testid="popup-message"
     >
       <span>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #12431 
This change is important because the banners contain important messages. Making them standardized helps users know what the important instructions are.

### What is the New Behavior?
Before: The banners are not readable and not standardized with respect to colour.

<img width="728" height="136" alt="image" src="https://github.com/user-attachments/assets/3b42a597-6f17-45ca-9a78-4f4cf10b6e64" />
<img width="1600" height="312" alt="image" src="https://github.com/user-attachments/assets/217d26f4-a5ae-4c79-a9e6-72a949c64023" />
<img width="1600" height="115" alt="image" src="https://github.com/user-attachments/assets/88c2d4fa-0cd7-4c78-a3b7-8511761a7943" />

After: Now the banners are readable and standardized.

<img width="761" height="99" alt="image" src="https://github.com/user-attachments/assets/57f90277-b62d-48ee-a0c9-3fddf25c5b8c" />
<img width="1600" height="250" alt="image" src="https://github.com/user-attachments/assets/0e1bce7c-f696-48cb-a48e-b64640a727f4" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Login as anyone Eg. Instructor , Full-Access Grader , Limited-Access Grader , Student
<img width="760" height="99" alt="image" src="https://github.com/user-attachments/assets/c8add4f1-b560-471f-b6ed-569fee3f2313" /> -- This is the change
2. Click spring 2026 sample
3. Scroll and go to past due and click LATE RESUBMIT
<img width="1478" height="394" alt="image" src="https://github.com/user-attachments/assets/c6769ff5-9bc9-4bb0-ad9d-1d9d30c7fe23" />
4. Now u can see the chnage
<img width="1507" height="218" alt="image" src="https://github.com/user-attachments/assets/705d5530-1f75-4350-846b-6a315900f65c" />

### Automated Testing & Documentation
No new automated tests are required as this is a visual fix.
Manual verification: 
Visited different pages to see the banners and some of them are attached as screenshot

### Other information
- No breaking
- No migrations
- No security concerns
