### PR TITLE
[Bugfix:Developer] Fix CI Status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
 </p>
 
-[![CI](https://github.com/Submitty/Submitty/actions/workflows/submitty_ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/ci.yml)
+[![CI](https://github.com/Submitty/Submitty/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/ci.yml)
 [![Vagrant Up](https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml/badge.svg)](https://github.com/Submitty/Submitty/actions/workflows/vagrant_up.yaml)
 
 # Usage


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The `README.md` file for the Submitty repository includes a status indicator for CI. I noticed that the status consistently is `no status`.
<img width="896" height="166" alt="image" src="https://github.com/user-attachments/assets/1ba43986-8e7b-43ad-bbd0-d592a5f159a5" />

### What is the New Behavior?
Changed this line to look for `ci.yml` instead of `submitty_ci.yml`:
```
[![CI](https://github.com/Submitty/Submitty/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/Submitty/Submitty/actions/workflows/ci.yml)
```
Now, the status of CI is `passing`:
<img width="896" height="166" alt="image" src="https://github.com/user-attachments/assets/d5add559-4200-4360-ba72-f0c09b893e79" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
To replicate, I made a fork of the Submitty repository, and observed the `no status` status. I then changed the `README.md` to look for `ci.yml` instead of `submitty_ci.yml`, and the status became `passing`.

### Automated Testing & Documentation
N / A

### Other information
N / A
