### PR TITLE
Improve team late days warning message logic

### DIFF
--- a/site/public/js/drag-and-drop.js
+++ b/site/public/js/drag-and-drop.js
@@ -1,6 +1,6 @@
 /* exported handleUploadBanner, initializeDropZone, handleEditCourseMaterials, handleUploadCourseMaterials, handleDownloadImages,
             handleSubmission, handleRegrade, handleBulk, deleteSplitItem, submitSplitItem, displayPreviousSubmissionOptions
-            displaySubmissionMessage, validateUserId, openFile, handle_input_keypress, addFilesFromInput,
+            displaySubmission, validateUserId, openFile, handle_input_keypress, addFilesFromInput,
             dropWithMultipleZips, initMaxNoFiles, setUsePrevious, readPrevious, createArray, initializeDragAndDrop setButtonStatus */
 /* global buildCourseUrl, buildUrl, getFileExtension, csrfToken, removeMessagePopup, newOverwriteCourseMaterialForm, displayErrorMessage, displayMessage, escapeSpecialChars */
 
@@ -1005,13 +1005,14 @@ function handleSubmission(gradeable_status, remaining_late_days_for_gradeable, c
         }
 
         // check team date
-        if (!late_warning_seen && is_team_assignment && (min_team_member_late_days - days_to_be_charged + charged_late_days < 0 || min_team_member_late_days_exception + days_to_be_charged < days_past_deadline)) {
-            message = 'There is at least 1 member on your team that does not have enough late days for this submission. This will result in them receiving a marked grade of zero. Are you sure you want to continue?';
-            if (!confirm(message)) {
-                return;
-            }
-        }
+       // check team date
+if (!late_warning_seen && is_team_assignment && (min_team_member_late_days - days_to_be_charged + charged_late_days < 0 || min_team_member_late_days_exception + days_to_be_charged < days_past_deadline)) {
+    const messageText = 'There is at least 1 member on your team that does not have enough late days for this submission. This will result in them receiving a marked grade of zero. Are you sure you want to continue?';
+    if (!confirm(messageText)) {
+        $('#submit').prop('disabled', false); // re-enable submit button
+        return;
     }
+}
 
     const formData = new FormData();
 


### PR DESCRIPTION
This PR fixes the logic for team late days warning in drag-and-drop.js.
It now re-enables the submit button if the user cancels the confirmation dialog.