### PR TITLE
[UI/UX:Submission] repo error shown in non-VCS gradeables

### DIFF
--- a/site/app/templates/submission/Team.twig
+++ b/site/app/templates/submission/Team.twig
@@ -68,9 +68,10 @@
             {% endif %}
             <a href="{{ git_auth_token_url }}" class="btn btn-primary">Create and Manage Authentication Tokens</a>
         {% else %}
-            <br />
-            <h3>Your repository does not exist.</h3>
-            <p>Contact your instructor or sysadmin for assistance in creating your repository for this assignment.</p><br>
+          {% if gradeable.isVcs() %}
+          <br />
+          <h3>Your repository does not exist.</h3>
+          <p>Contact your instructor or sysadmin for assistance in creating your repository for this assignment.</p><br>
         {% endif %}
         {# /Repository status #}
 


### PR DESCRIPTION
### Why is this change important?
Closes #12579  where the repository error message was displayed even for non-VCS (direct upload) submissions.

### What is the new behavior?
The message "Your repository does not exist" is now shown only when the gradeable uses VCS (repository-based submission).

### Implementation details
Added a condition check using `gradeable.isVcs()` in Team.twig to ensure the error message is displayed only for repository-based submissions.