### PR TITLE
[Bugfix:Submission] Fix red button for all-hidden test cases

### DIFF
--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -516,12 +516,14 @@ class NavigationView extends AbstractView {
             }
 
             // Due date passed with at least 50 percent points in autograding or gradable with no autograding points
+            // Also treat all-hidden test cases (no visible points) as gray, since there's nothing visible to judge
+            $total_non_hidden = $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit();
             if (
                 $graded_gradeable->getAutoGradedGradeable()->isAutoGradingComplete()
                 && (
                     !$gradeable->getAutogradingConfig()->anyPoints()
-                    || $gradeable->getAutogradingConfig()->getTotalNonHiddenNonExtraCredit() != 0
-                    && $points_percent >= 0.5
+                    || $total_non_hidden == 0
+                    || ($total_non_hidden != 0 && $points_percent >= 0.5)
                 )
                 && $list_section == GradeableList::CLOSED
             ) {


### PR DESCRIPTION
##Description:

When all autograding test cases are set to hidden and the assignment is past due, the "Late Resubmit" button incorrectly appears red (btn-danger) instead of gray (btn-default). This happens because the condition that resets the button color from red to gray only considers two scenarios: (1) no autograding points, or (2) visible non-hidden points exist and the score is at least 50%. When all test cases are hidden, neither condition is met, so the button stays red.

This fix adds a third condition: when the total visible (non-hidden, non-extra-credit) points is zero, treat the button as gray, since there is nothing visible for the student to judge their score against.

Fixes #xxxx

##Motivation and Context:

Courses with all hidden test cases (e.g., lecture exercises in CSCI 4380 Database Systems) see a red "Late Resubmit" button for every student after the due date, which incorrectly signals that something is wrong with their submission.

##How Has This Been Tested?

Manually verified the logic flow for the following scenarios:

All test cases hidden, autograding complete, past due, late submission allowed → button now gray
Some visible test cases, score ≥ 50% → button stays gray
Some visible test cases, score < 50% → button stays red
No autograding points → button stays gray
