### PR TITLE
[Bugfix:Forum] Fix false unsaved changes popup

### DIFF
--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -230,6 +230,7 @@ function publishFormWithAttachments(form, test_category, error_message, is_threa
             cancelDeferredSave(autosaveKeyFor(form));
             clearReplyBoxAutosave(form);
 
+            form.trigger('reinitialize.areYouSure');
             window.location.href = json['data']['next_page'];
         },
         error: function () {
@@ -807,6 +808,7 @@ function modifyOrSplitPost(e) {
                 return;
             }
 
+            form.trigger('reinitialize.areYouSure');
             // modify
             if (form.attr('id') === 'thread_form') {
                 window.location.reload();
@@ -2378,6 +2380,7 @@ function updateThread(e) {
                 response = JSON.parse(response);
                 if (response.status === 'success') {
                     displaySuccessMessage('Thread post updated successfully!');
+                    form.trigger('reinitialize.areYouSure');
                 }
                 else {
                     displayErrorMessage('Failed to update thread post');


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #11337
Related to #6188

When submitting a forum reply, editing a post, or updating a thread, the browser shows a false "Leave site? Changes you made may not be saved" popup during page navigation. The jquery.are-you-sure plugin marks the form as dirty when the user types content, and the AJAX-based submission does not reset this state before the page navigates away. Users who press cancel and resubmit end up creating duplicate posts (#6188).

### What is the New Behavior?
After a successful forum submission, `form.trigger('reinitialize.areYouSure')` resets the plugin's stored field values to the current state, clearing the dirty flag before navigation. The popup no longer appears after successful submissions. If the submission fails, the form correctly remains dirty so the warning still protects unsaved work.

Three AJAX success callbacks are patched:
- `publishFormWithAttachments` (new threads and replies)
- `modifyOrSplitPost` (post edits and thread splits)
- `updateThread` (thread metadata updates)

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Navigate to Discussion Forum
2. Open any thread and type a reply
3. Click Submit Reply to All
4. **Before fix:** The browser shows a "Leave site?" popup (see screenshot below)
5. **After fix:** No popup, the page navigates cleanly to the new post

**Before (on main, without fix) -- typing in reply box and navigating away triggers false warning:**

<img width="1512" height="890" alt="Screenshot 2026-03-26 at 1 32 14 AM" src="https://github.com/user-attachments/assets/4df36819-5c5f-498d-9cce-69d9c447aa58" />

**After (with fix) -- reply submits and page navigates without false warning:**

<img width="1512" height="892" alt="Screenshot 2026-03-26 at 12 41 01 AM" src="https://github.com/user-attachments/assets/a3ad0723-aa90-4d02-a552-daff0f815f7d" />

Also test:
- Editing an existing post (triggers modifyOrSplitPost)
- Updating thread title/categories (triggers updateThread)
- Navigating away from a partially typed (unsubmitted) reply still correctly shows the warning

### Automated Testing & Documentation
No new automated tests added. The beforeunload dialog is browser-native and difficult to test reliably in Cypress. The existing forum Cypress tests (`forums.spec.js`) cover thread creation and reply flows and will confirm no regressions.

### Other information
This follows the same reinitialize.areYouSure pattern already used in ThreadPostForm.twig line 277 for the Ctrl+Enter keyboard shortcut, which calls `theForm.trigger('reinitialize.areYouSure')` before `theForm.submit()`.

The fix is placed in the AJAX success callbacks rather than on the form submit event so that the dirty state is only cleared when the submission actually succeeds. This preserves the unsaved-changes warning when a request fails.

Not a breaking change. No migrations. No security concerns.
