### PR TITLE
[Bugfix:Submission] Fix scroll lock after photo upload

### DIFF
--- a/site/cypress/e2e/Cypress-UI/profile.spec.js
+++ b/site/cypress/e2e/Cypress-UI/profile.spec.js
@@ -126,6 +126,8 @@ describe('Test cases revolving around user profile page', () => {
         cy.get('[data-testid="user-image-button"]').selectFile(filePath);
         cy.get('[data-testid="submit-button"]').click();
         cy.get('[data-testid="popup-message"]').next().next().next().should('contain.text', 'Profile photo updated successfully!');
+        // Assert that scrolling is not disabled after upload
+        cy.get('body').should('not.have.class', 'no-scroll');
     });
 
     it('Flagging an innapropriate photo', () => {

--- a/site/public/js/user-profile.js
+++ b/site/public/js/user-profile.js
@@ -337,8 +337,8 @@ function updateUserProfilePhoto() {
             displayErrorMessage('Some went wrong while updating profile photo!');
         },
     });
-    // hide the form from view
-    $('.popup-form').css('display', 'none');
+    // hide the modal and restore document scrolling
+    closePopup('edit-profile-photo-form');
     $('#user-image-button').val(null);
     return false;
 }


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Closes #12628 
Fixes a bug where scrolling was disabled after uploading a profile photo on the My Profile page. Ensures that the page scroll is restored immediately after the popup closes.


### What was changed:
<!-- Include before & after screenshots/videos if the user interface has changed. -->

- Refactored the profile photo upload logic to use [closePopup('edit-profile-photo-form')](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for consistent popup closing and scroll restoration.
- Added a Cypress test assertion to verify that the no-scroll class is not present on the body after uploading a profile photo, preventing scroll lock regressions.



### How to test?
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

1. Go to the My Profile page.
2. Upload a new profile photo.
3. Confirm that you can scroll the page immediately after the upload, without needing to reload.
4. Run the Cypress test suite to ensure the new assertion passes.

