### PR TITLE
[Bugfix:Forum] Fix edit post with dated category

### DIFF
--- a/site/app/templates/forum/EditPostForm.twig
+++ b/site/app/templates/forum/EditPostForm.twig
@@ -21,6 +21,7 @@
         "categories" : categories,
         "attachment_script" : attachment_script,
         "data_testid" : "forum-update-post",
+        "ignore_category_date" : true,
     } %}
     <script>
         $("#thread_form").submit(function() {

--- a/site/app/templates/forum/ThreadPostForm.twig
+++ b/site/app/templates/forum/ThreadPostForm.twig
@@ -127,7 +127,7 @@
                  diff is used for comparison between the given date of category and the current date of user 
                  when date is above then current date then output is less than zero.
                  and when date is below then current date the output is greater then zero #}
-                {% if category.visibleDate is null or category.diff >= 0 %}
+                {% if (ignore_category_date is defined and ignore_category_date) or category.visibleDate is null or category.diff >= 0 %}
                 <div tabindex="0" class="btn cat-buttons" data-color="{{ category.color }}" aria-labelledby="cat_label" style="overflow-wrap: break-word; background-color: {{ category.color }}; color: white; max-width: 350px; text-align: left !important; white-space: unset !important;">{{ category.description }}
                     <input type="checkbox" name="cat[]" value="{{ category.id }}" data-testid="{{ category.id }}" aria-label="Category {{ category.description }}">
                 </div>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #10989

When an instructor tries to edit a forum post that belongs to a thread with a date-released category, the edit can fail because the category checkbox is not rendered in the edit form. The `ThreadPostForm.twig` template filters categories based on their `visible_date`, hiding any category whose release date has not yet arrived. This filter is appropriate for creating new threads but not for editing existing posts, where the assigned categories must always be visible.

The workaround described in the issue was to remove the date from the category before editing the post.

### What is the New Behavior?
The edit post form now passes `ignore_category_date: true` to the shared `ThreadPostForm.twig` template. When this flag is set, the visible_date filter is skipped and all categories are rendered. This ensures the thread's assigned categories are always available for selection when editing.

Other forms are not affected:
- Creating a new thread still filters unreleased categories (students cannot see them)
- Reply forms do not show the category selector at all
- The split post form has its own template and is unchanged

**Before (without fix) -- editing a post whose only category has a future visible date fails validation:**

<img width="1512" height="904" alt="Screenshot 2026-03-27 at 12 40 34 AM" src="https://github.com/user-attachments/assets/eed8c10c-38cc-4989-bed2-9851b55784a8" />

**After (with fix) -- the dated category now appears in the edit form and the post saves successfully:**

<img width="1512" height="852" alt="Screenshot 2026-03-27 at 12 45 43 AM" src="https://github.com/user-attachments/assets/c9aacd0f-d5da-4644-9021-fdbe263454c5" />

<img width="1512" height="846" alt="Screenshot 2026-03-27 at 12 46 06 AM" src="https://github.com/user-attachments/assets/6dd5fa32-1949-4b18-8d79-93d42c58e10c" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. As an instructor, go to the forum and click "Edit Categories" to create a new category (leave the visible date empty)
2. Create a new thread and assign it to that category
3. Go back to "Edit Categories" and set that category visible date to a future date
4. Try to edit the first post of that thread
5. **Before fix:** The category is not shown in the edit form and the edit fails with "At least one category must be selected"
6. **After fix:** The category appears in the edit form and the edit saves successfully

Also verify:
- Creating a new thread as a student does not show unreleased categories (date filter still applies)
- Editing a post that belongs to a category with no visible date still works as before

### Automated Testing & Documentation

No new automated tests added. The existing forum Cypress tests (`forums.spec.js`) cover post editing flows and will confirm no regressions.

### Other information

The split post form (`SplitPostForm.twig`) already renders all categories without any date filtering, confirming that date filtering should not apply to forms that operate on existing threads.

Not a breaking change. No migrations. No security concerns.