### PR TITLE
[Bugfix:System] Fix PHP 8.2 Migrator

### DIFF
--- a/migration/migrator/migrations/system/20251015200752_upgrade_php_82.py
+++ b/migration/migrator/migrations/system/20251015200752_upgrade_php_82.py
@@ -111,6 +111,12 @@ def up(config):
     # Remove existing PHP packages
     env = os.environ.copy()
     env['DEBIAN_FRONTEND'] = 'noninteractive'
+
+    subprocess.run(
+        ["apt-get", "update", "-qqy"],
+        env=env
+    )
+
     subprocess.run(
         ["apt-get", "remove", "-qqy", "php8.1"] + installed_php_packages,
         env=env


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12667.

### What is the New Behavior?
Before: Migrator fails if apt is not up to date, and completely uninstalls PHP

<img width="1440" height="900" alt="Screenshot_20260327_162324" src="https://github.com/user-attachments/assets/c4f158d4-edd1-4257-ae07-42859ea2ea1a" />

After: Migrator succeeds, php still exists after `submitty_install`

<img width="1440" height="900" alt="Screenshot_20260327_164407" src="https://github.com/user-attachments/assets/4407473b-2f94-4fce-b5ca-47610c09fbad" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Load an old vagrant box of the Submitty vm (e.g. [25.12.00.2512070428](https://portal.cloud.hashicorp.com/vagrant/discover/SubmittyBot/ubuntu22-dev/versions/25.12.00.2512070428). This is needed to intentionally make the package list metadata in apt out of date, which triggers the error. (`vagrant box add SubmittyBot/ubuntu22-dev --box-version 25.12.00.2512070428`)
2. Run: `vagrant up; vagrant ssh; submitty_install`.
3. See if the installation succeeded or not
4. Run `php -v` to see if php exists and what version it is. If the command fails, php is no longer installed. This should never happen with this PR's changes.

### Automated Testing & Documentation
None

### Other information
If the migration has already been run, and the system is working normally, it does not need to be run again; the migration system should do this automatically. If the migration has not yet been run, it should be run with the changes here.

Perhaps we should add `sudo apt-get update` to `submitty_install`, but that would be another PR.