### PR TITLE
[Bugfix:Forum] Handle invalid category date

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -308,8 +308,12 @@ class ForumController extends AbstractController {
                 $category_visible_date = "";
             }
             else {
-                $category_visible_date = DateUtils::parseDateTime($_POST['visibleDate'], $this->core->getUser()->getUsableTimeZone());
-                //ASSUME NO ISSUE
+                try {
+                    $category_visible_date = DateUtils::parseDateTime($_POST['visibleDate'], $this->core->getUser()->getUsableTimeZone());
+                }
+                catch (\InvalidArgumentException $e) {
+                    return $this->core->getOutput()->renderJsonFail("Invalid date format.");
+                }
             }
         }
         else {

--- a/site/app/templates/forum/ForumBar.twig
+++ b/site/app/templates/forum/ForumBar.twig
@@ -67,7 +67,7 @@
 						{% endfor %}
 						{% if core.getUser().accessGrading() %}
 							<div class="dropdown-divider"></div>
-							<a class="dropdown-item" href="{{ manage_categories_url }}" title="Edit Forum Categories" >Edit Categories</a>
+							<a class="dropdown-item" href="{{ manage_categories_url }}" title="Edit Forum Categories" data-testid="edit-categories-link">Edit Categories</a>
 						{% endif %}
 						{% if thread_exists and (is_full_threads_page is not defined or not is_full_threads_page) %}
 							<div class="dropdown-divider"></div>

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -85,14 +85,14 @@
                     <div style="float: right;width: auto;">
                         <span class="categorylistitemdate-desc">
                             <span class="categorylistitem-desc-text" style="overflow-wrap: break-word;"> {{ category.visibleDate }}</span>
-                            <i class="fas fa-edit category-button edit-category-date-button"></i>
+                            <i class="fas fa-edit category-button edit-category-date-button" data-testid="edit-category-date-button"></i>
                         </span>
 
 
                         <span class="categorylistitemdate-editdesc" style="display: none;">
-                                <input type="text" aria-label="New Date for Category" placeholder=" {{ category.visibleDate }} " class="edit-category-date-input" style="padding: 0;" maxlength="11" onkeyup="checkInputMaxLength($(this))">
-                                <a class="post_button" title="Save Changes" aria-label="Save Changes"><i class="fas fa-check category-button save-date-button"></i></a>
-                                <a class="post_button" title="Cancel Changes" aria-label="Cancel Changes"><i class="fas fa-times category-button cancel-date-button"></i></a>
+                                <input type="text" aria-label="New Date for Category" placeholder=" {{ category.visibleDate }} " class="edit-category-date-input" data-testid="edit-category-date-input" style="padding: 0;" maxlength="11" onkeyup="checkInputMaxLength($(this))">
+                                <a class="post_button" title="Save Changes" aria-label="Save Changes"><i class="fas fa-check category-button save-date-button" data-testid="save-category-date-button"></i></a>
+                                <a class="post_button" title="Cancel Changes" aria-label="Cancel Changes"><i class="fas fa-times category-button cancel-date-button" data-testid="cancel-category-date-button"></i></a>
                         </span>
 
 

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -603,3 +603,31 @@ describe('Should test Search functionality', () => {
         cy.get('#thread_list').contains('Course syllabus');
     });
 });
+
+describe('Should test Category Date Validation', () => {
+    beforeEach(() => {
+        cy.login('instructor');
+        cy.visit(['sample', 'forum']);
+    });
+
+    it('Should show error message when entering invalid date format for category', () => {
+        // Navigate to Edit Categories page
+        cy.get('[data-testid="more-dropdown"]').click();
+        cy.get('[data-testid="edit-categories-link"]').click();
+
+        // Wait for the page to load
+        cy.get('#manage-categories-view').should('be.visible');
+
+        // Find an existing category and click edit date button
+        cy.get('[data-testid="edit-category-date-button"]').first().click();
+
+        // Enter invalid date format
+        cy.get('[data-testid="edit-category-date-input"]').first().clear().type('invalid-date');
+
+        // Click save
+        cy.get('[data-testid="save-category-date-button"]').first().click();
+
+        // Verify error message is displayed
+        cy.get('[data-testid="popup-message"]').should('contain', 'Invalid date format');
+    });
+});


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12327

When editing a forum category's visible date and entering an invalid format, the system throws an unhandled `InvalidArgumentException` from `DateUtils::parseDateTime()`. This causes a poor user experience - instead of showing a helpful error message, users see a generic error or stack trace.

This PR also supersedes the abandoned PR #12328 and addresses the reviewer feedback from that PR (using data-testid attributes instead of class selectors in tests, not using `force: true` in Cypress).

### What is the New Behavior?

The system now catches the `InvalidArgumentException` and returns a friendly error message ("Invalid date format.") to the user via the standard popup notification. The page remains stable and users can correct their input.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Log in as instructor
2. Navigate to Forum > More dropdown > Edit Categories
3. Click the edit button next to a category's date field
4. Enter an invalid date format (e.g., "invalid-date" or "abc")
5. Click the save button
6. Observe that a popup appears with "Invalid date format" instead of crashing

### Automated Testing & Documentation

Added a Cypress test in `forums.spec.js` that:
- Navigates to the Edit Categories page using data-testid selectors
- Enters an invalid date format
- Verifies the error message appears in the popup

The test follows the feedback from PR #12328:
- Uses `data-testid` attributes instead of class selectors
- Does not use `force: true`
- Checks specific element (`[data-testid="popup-message"]`) for the error message

### Other information

This is not a breaking change. No migrations needed. No security concerns.