### PR TITLE
[Testing:Autograding] Fix flaky leaderboard Cypress test

### DIFF
--- a/site/cypress/e2e/Cypress-Gradeable/leaderboard_gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/leaderboard_gradeable.spec.js
@@ -5,9 +5,8 @@ describe('Tests leaderboard access', () => {
         cy.get('#page_5_nav').click();
         cy.get('[data-testid="submission-open-date"]').clear();
         cy.get('[data-testid="submission-open-date"]').type('2100-01-15 23:59:59');
-        // clicks out of the calendar and save
-        cy.get('body').click(0, 0);
-        cy.get('#save_status', { timeout: 10000 }).should('have.text', 'All Changes Saved');
+        cy.get('[data-testid="submission-open-date"]').type('{enter}');
+        cy.get('#save_status', { timeout: 20000 }).should('have.text', 'All Changes Saved');
     });
 
     it('Should check if leaderboard is accessible to users', () => {
@@ -48,8 +47,8 @@ describe('Tests leaderboard access', () => {
         cy.get('#page_5_nav').click();
         cy.get('[data-testid="submission-open-date"]').clear();
         cy.get('[data-testid="submission-open-date"]').type('2000-01-15 23:59:59');
-        cy.get('body').click(0, 0);
-        cy.get('#save_status', { timeout: 10000 }).should('have.text', 'All Changes Saved');
+        cy.get('[data-testid="submission-open-date"]').type('{enter}');
+        cy.get('#save_status', { timeout: 20000 }).should('have.text', 'All Changes Saved');
         cy.logout();
 
         const testCode = '#include <iostream>\nint main() { return 0; }';


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12683

The `leaderboard_gradeable.spec.js` test has been failing intermittently with a timeout waiting for "All Changes Saved" status.

### What is the New Behavior?

Instead of using `cy.get('body').click(0, 0)` to close the date picker (which is unreliable), the test now presses Enter after typing the date - same approach used in `late_submission_warning_messages.spec.js`.

Also increased the timeout from 10s to 20s to match other similar tests.

### What steps should a reviewer take to test this?

The fix follows the same pattern as other gradeable tests. The Cypress CI run on this PR should confirm the test passes consistently.

### Automated Testing & Documentation

This is a test fix itself - the Cypress (Gradeable) check should validate it.