### PR TITLE
[Testing:Submission] Stabilize leaderboard Cypress

### DIFF
--- a/site/cypress/e2e/Cypress-Gradeable/leaderboard_gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/leaderboard_gradeable.spec.js
@@ -1,7 +1,7 @@
 describe('Tests leaderboard access', () => {
     const updateSubmissionOpenDate = (date) => {
         cy.intercept('POST', '**/courses/*/sample/gradeable/leaderboard/update').as('saveGradeableUpdate');
-        cy.get('[data-testid="submission-open-date"]').clear({ force: true }).invoke('val', date).trigger('change', { force: true });
+        cy.get('[data-testid="submission-open-date"]').clear().invoke('val', date).trigger('change');
         cy.get('body').click(0, 0);
         cy.wait('@saveGradeableUpdate', { timeout: 30000 }).then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
@@ -77,7 +77,7 @@ describe('Tests leaderboard access', () => {
         cy.get('#page_5_nav').click();
         // Keep date ordering valid before moving submission-open-date into the past.
         cy.intercept('POST', '**/courses/*/sample/gradeable/leaderboard/update').as('saveGradeableUpdateTA');
-        cy.get('[data-testid="ta-view-start-date"]').clear({ force: true }).invoke('val', '1999-01-15 23:59:59').trigger('change', { force: true });
+        cy.get('[data-testid="ta-view-start-date"]').clear().invoke('val', '1999-01-15 23:59:59').trigger('change');
         cy.get('body').click(0, 0);
         cy.wait('@saveGradeableUpdateTA', { timeout: 30000 }).its('response.statusCode').should('eq', 200);
         cy.wait(1000);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12683.

The `leaderboard_gradeable.spec.js` Cypress test was failing intermittently because it depended on a transient save-status message (`All Changes Saved`). Even when the update request succeeded, the UI text assertion could time out and fail CI.

### What is the New Behavior?
The test now validates persisted state instead of relying on transient status text.

Before:
- Waited for `#save_status` to contain `All Changes Saved`.

After:
- Waits for the update request to return HTTP 200.
- Reloads the page.
- Verifies the submission open date input still has the expected saved value.

This keeps the same behavior verification but makes the test deterministic and less flaky.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Check out this branch.
2. Run the Gradeable Cypress suite (or targeted leaderboard spec) in the CI-like environment.
3. Verify the leaderboard date-update setup no longer depends on `#save_status` text timing.
4. Confirm tied-ranking assertions still execute and validate expected leaderboard behavior.

### Automated Testing & Documentation
- Updated existing Cypress E2E coverage in `leaderboard_gradeable.spec.js`.
- This PR is test-only and improves reliability of existing automated testing.
- No submitty.org documentation updates are needed.

### Other information
- No breaking changes.
- No migrations.
- No security impact known.