### PR TITLE
[Refactor:System] Build CMake projects in parallel

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -245,7 +245,7 @@ mkdir -p "${SUBMITTY_INSTALL_DIR}/src/grading/lib"
 pushd "${SUBMITTY_INSTALL_DIR}/src/grading/lib"
 cmake ..
 set +e
-cmake --build . --parallel $(nproc)
+cmake --build . --parallel "$(nproc)"
 if [ "$?" -ne 0 ] ; then
     echo "ERROR BUILDING AUTOGRADING LIBRARY"
     exit 1

--- a/.setup/install_grading_dev_helper.sh
+++ b/.setup/install_grading_dev_helper.sh
@@ -16,7 +16,7 @@ sed -i -e "s|__INSTALL__FILLIN__SUBMITTY_INSTALL_DIR__|/usr/local/submitty|g" /u
 # build the grading library
 cd /usr/local/submitty/src/grading/lib || exit
 cmake ..
-cmake --build . --parallel $(nproc)
+cmake --build . --parallel "$(nproc)"
 
 # set the permissions
 chown -R  root:root /usr/local/submitty/src

--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -219,7 +219,7 @@ function build_homework {
 
     # build (in parallel)
     # quit (don't continue on to build other homeworks) if there is a compile error
-    cmake --build . --parallel $(nproc)
+    cmake --build . --parallel "$(nproc)"
 
     # capture exit code of make
     make_res="$?"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
All of our build command invocations after generating with CMake either run serially or use an inappropriate fixed parallel level.

### What is the New Behavior?
This PR switches all manual `make` invocations to use `cmake --build`, allowing us to easily switch to a different generator in the future.  Additionally, each `cmake --build` command is run with all available cores.  This results in a marginal performance improvement in my development environment.