### PR TITLE
[Refactor:System] Remove unnecessary setup script commits

### DIFF
--- a/.setup/bin/sample_courses/models/course/course_create.py
+++ b/.setup/bin/sample_courses/models/course/course_create.py
@@ -115,7 +115,7 @@ class Course_create:
                     registration_section_id=str(section)
                 )
             )
-            submitty_conn.commit()
+        submitty_conn.commit()
         table = Table("courses", submitty_metadata, autoload_with=submitty_engine)
         print("(tables loaded)...")
         if self.self_registration_type != 0:
@@ -132,7 +132,7 @@ class Course_create:
         for section in range(1, self.rotating_sections + 1):
             print(f"Create section {section}")
             self.conn.execute(insert(table).values(sections_rotating_id=section))
-            self.conn.commit()
+        self.conn.commit()
 
         print("Create users ", end="")
         submitty_users = Table("courses_users", submitty_metadata, autoload_with=submitty_engine)
@@ -177,7 +177,6 @@ class Course_create:
                 update_query,
                 {"rotating_section": rot_section, "b_user_id": user.id}
             )
-            self.conn.commit()
             if user.get_detail(self.code, "grading_registration_section") is not None:
                 try:
                     grading_registration_sections = str(
@@ -195,7 +194,7 @@ class Course_create:
                             sections_registration_id=str(grading_registration_section),
                         )
                     )
-                    self.conn.commit()
+            self.conn.commit()
 
             if user.unix_groups is None:
                 if user.get_detail(self.code, "group") <= 1:

--- a/.setup/bin/sample_courses/models/course/course_create_gradeables.py
+++ b/.setup/bin/sample_courses/models/course/course_create_gradeables.py
@@ -70,7 +70,7 @@ class Course_create_gradeables:
                         anon_id=anon_id
                     )
                 )
-                self.conn.commit()
+            self.conn.commit()
             random.setstate(prev_state)
             # create_teams
             if gradeable.team_assignment is True:
@@ -202,7 +202,6 @@ class Course_create_gradeables:
                                         g_id=gradeable.id, user_id=None, team_id=team_id,
                                         g_version=version, submission_time=current_time_string
                                     ))
-                                    self.conn.commit()
                                     if version == versions_to_submit:
                                         self.conn.execute(
                                             insert(self.electronic_gradeable_version).values(
@@ -210,7 +209,6 @@ class Course_create_gradeables:
                                                 active_version=active_version, g_notification_sent=g_notification_sent
                                             )
                                         )
-                                        self.conn.commit()
                                     json_history["team_history"] = json_team_history[team_id]
                                 else:
                                     self.conn.execute(
@@ -218,14 +216,13 @@ class Course_create_gradeables:
                                                 g_id=gradeable.id, user_id=user.id, g_version=version, submission_time=current_time_string
                                             )
                                     )
-                                    self.conn.commit()
                                     if version == versions_to_submit:
                                         self.conn.execute(
                                             insert(self.electronic_gradeable_version).values(
                                                 g_id=gradeable.id, user_id=user.id, active_version=active_version, g_notification_sent=g_notification_sent
                                             )
                                         )
-                                        self.conn.commit()
+                                self.conn.commit()
                                 json_history["history"].append({"version": version, "time": current_time_string, "who": user.id, "type": "upload"})
 
                                 with open(os.path.join(submission_path, str(version), ".submit.timestamp"), "w") as open_file:
@@ -350,7 +347,6 @@ class Course_create_gradeables:
                                 if skip_grading > 0.3 and random.random() > 0.01:
                                     ins = insert(self.gradeable_data_overall_comment).values(**overall_comment_values)
                                     res = self.conn.execute(ins)
-                                    self.conn.commit()
                                 for component in gradeable.components:
                                     if random.random() < 0.01 and skip_grading < 0.3:
                                         # This is used to simulate unfinished grading.
@@ -369,7 +365,6 @@ class Course_create_gradeables:
                                             gcd_grade_time=grade_time, gcd_graded_version=versions_to_submit
                                         )
                                     )
-                                    self.conn.commit()
                                     first = True
                                     first_set = False
                                     for mark in component.marks:
@@ -383,6 +378,7 @@ class Course_create_gradeables:
                                             if(first):
                                                 first_set = True
                                         first = False
+                                self.conn.commit()
 
                     if gradeable.type == 0 and os.path.isdir(submission_path):
                         os.system(f"chown -R submitty_php:{self.code}_tas_www {submission_path}")
@@ -393,7 +389,6 @@ class Course_create_gradeables:
                     if (gradeable.type != 0 and gradeable.grade_start_date < NOW and ((gradeable.has_release_date is True and gradeable.grade_released_date < NOW) or random.random() < 0.5) and
                        random.random() < 0.9 and (ungraded_section != (user.get_detail(self.code, 'registration_section') if gradeable.grade_by_registration else user.get_detail(self.code, 'rotating_section')))):
                         res = self.conn.execute(insert(self.gradeable_data).values({"g_id": gradeable.id, "gd_user_id": user.id }))
-                        self.conn.commit()
                         gd_id = res.inserted_primary_key[0]
                         skip_grading = random.random()
                         for component in gradeable.components:
@@ -412,7 +407,7 @@ class Course_create_gradeables:
                                     gcd_grader_id=self.instructor.id, gcd_grade_time=grade_time, gcd_graded_version=-1
                                 )
                             )
-                            self.conn.commit()
+                        self.conn.commit()
 
         # This segment adds the sample data for features in the sample course only
         if self.code == 'sample':

--- a/.setup/bin/sample_courses/models/course/course_data.py
+++ b/.setup/bin/sample_courses/models/course/course_data.py
@@ -203,7 +203,6 @@ class Course_data:
                     release_histogram=poll["release_histogram"],
                 )
             )
-            self.conn.commit()
             for i in range(len(poll["responses"])):
                 self.conn.execute(
                     insert(poll_options_table).values(
@@ -213,7 +212,7 @@ class Course_data:
                         correct=(i in poll["correct_responses"]),
                     )
                 )
-            self.conn.commit()
+        self.conn.commit()
 
         # generate responses to the polls
         poll_responses_data = []

--- a/.setup/bin/sample_courses/models/course/course_generate_utils.py
+++ b/.setup/bin/sample_courses/models/course/course_generate_utils.py
@@ -305,7 +305,6 @@ class Course_generate_utils:
                                 state=1,
                             )
                         )
-                        self.conn.commit()
                         team_id_section = team_in_section["team_id"]
                         temp_json_team_history = {
                             "action": "admin_create",
@@ -337,7 +336,6 @@ class Course_generate_utils:
                         state=1,
                     )
                 )
-                self.conn.commit()
                 json_team_history[unique_team_id] = [
                     {
                         "action": "admin_create",
@@ -351,4 +349,5 @@ class Course_generate_utils:
                 ucounter += 1
             res.close()
             anon_team_ids.append(anon_team_id)
+        self.conn.commit()
         return json_team_history


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The setup sample courses script currently commits after almost every database statement.  The overhead of committing so frequently is nontrivial.

### What is the New Behavior?
The setup sample courses script now commits fewer times inside loops.  There's more work to be done here, but it'll require a broader overhaul of these scripts.