### PR TITLE
[Bugfix:Forum] Fix crash when editing category with invalid visible date

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -304,12 +304,17 @@ class ForumController extends AbstractController {
             }
         }
         if (!empty($_POST["visibleDate"]) && $this->core->getUser()->accessAdmin()) {
-            if ($_POST["visibleDate"] === "    ") {
+            $visible_date_raw = trim($_POST["visibleDate"]);
+            if ($visible_date_raw === "") {
                 $category_visible_date = "";
             }
             else {
-                $category_visible_date = DateUtils::parseDateTime($_POST['visibleDate'], $this->core->getUser()->getUsableTimeZone());
-                //ASSUME NO ISSUE
+                try {
+                    $category_visible_date = DateUtils::parseDateTime($visible_date_raw, $this->core->getUser()->getUsableTimeZone());
+                }
+                catch (\InvalidArgumentException $e) {
+                    return $this->core->getOutput()->renderJsonFail("Invalid date format for category visible date.");
+                }
             }
         }
         else {


### PR DESCRIPTION
## Summary

Fixes #12327 — editing a forum category with an invalid or whitespace-only visible date causes a FATAL `InvalidArgumentException` crash.

## Root Cause

In `ForumController.php` line 307, the check for an empty date only matched exactly four spaces:

```php
if ($_POST["visibleDate"] === "    ") {
```

Any other whitespace string (e.g. spaces from a cleared date picker, tabs, different lengths) or an invalid date string would be passed directly to `DateUtils::parseDateTime()`, which throws an `InvalidArgumentException` that was not caught—resulting in a 500 error / frog robot page.

## Changes

### `site/app/controllers/forum/ForumController.php`

1. **Trim the input** before checking if it's empty, so all whitespace-only inputs are handled correctly
2. **Wrap `parseDateTime()`** in a try-catch to return a user-friendly JSON error response instead of crashing

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Date field has 4 spaces | Cleared correctly | Cleared correctly |
| Date field has other whitespace | 500 error / crash | Cleared correctly |
| Date field has invalid text | 500 error / crash | JSON error: "Invalid date format..." |
| Valid date | Works | Works (no change) |