### PR TITLE
[Testing:System] Add sample gradeable for graded-but-not-released state

### DIFF
--- a/.setup/data/courses/sample.yml
+++ b/.setup/data/courses/sample.yml
@@ -1216,6 +1216,74 @@ gradeables:
     gradeable_config: python_simple_homework
     g_bucket: homework
 
+  - g_id: graded_not_released_homework
+    components:
+      - gc_lower_clamp: 0
+        gc_default: 2
+        gc_max_value: 2
+        gc_upper_clamp: 2
+        gc_title: Read Me
+        marks:
+          - gcm_note: Full Credit
+            gcm_points: 0
+          - gcm_note: Minor errors in Read Me
+            gcm_points: -1
+          - gcm_note: Major errors in Read Me or Read Me missing
+            gcm_points: -2
+      - gc_lower_clamp: 0
+        gc_default: 5
+        gc_max_value: 5
+        gc_upper_clamp: 5
+        gc_title: Coding Style
+        marks:
+          - gcm_note: Full Credit
+            gcm_points: 0
+          - gcm_note: Code is unreadable
+            gcm_points: -5
+          - gcm_note: Code is very difficult to understand
+            gcm_points: -3
+          - gcm_note: Code is difficult to understand
+            gcm_points: -1
+      - gc_lower_clamp: 0
+        gc_default: 5
+        gc_max_value: 5
+        gc_upper_clamp: 5
+        gc_title: Documentation
+        marks:
+          - gcm_note: Full Credit
+            gcm_points: 0
+          - gcm_note: No documentation
+            gcm_points: -5
+          - gcm_note: Very little documentation or documentation makes no sense
+            gcm_points: -3
+          - gcm_note: Way too much documentation and/or documentation makes no sense
+            gcm_points: -1
+      - gc_lower_clamp: 0
+        gc_default: 0
+        gc_max_value: 0
+        gc_upper_clamp: 5
+        gc_title: Extra Credit
+        marks:
+          - gcm_note: No Credit
+            gcm_points: 0
+          - gcm_note: Extra credit done poorly
+            gcm_points: 2
+          - gcm_note: Extra credit is acceptable
+            gcm_points: 5
+    g_ta_view_start_date: 1970-01-01 23:59:59
+    eg_submission_open_date: 1971-01-01 23:59:59
+    eg_submission_due_date: 1972-01-01 23:59:59
+    g_grade_start_date: 1973-01-01 23:59:59
+    g_grade_due_date: 1974-01-01 23:59:59
+    g_grade_released_date: 9998-12-31 23:59:59
+    eg_grade_inquiry_start_date: 9999-01-01 23:59:59
+    eg_grade_inquiry_due_date: 9999-01-06 23:59:59
+    eg_has_due_date: true
+    eg_has_release_date: true
+    g_title: Graded (Not Released) Homework
+    gradeable_config: python_simple_homework
+    g_bucket: homework
+
   - g_id: grades_released_homework
     components:
       - gc_lower_clamp: 0


### PR DESCRIPTION
Add a new electronic gradeable 'graded_not_released_homework' to the sample course that represents the lifecycle state where grading is complete (grade_due_date in the past) but grades have not yet been released to students (grade_released_date far in the future). Closes #2181

### Why is this Change Important & Necessary?
Closes #2181

The sample course was missing a gradeable that represents the lifecycle state where grading is fully complete but grades have not yet been released to students. This state (submission closed → grading past due → release date in the future) is a common real-world scenario but was untestable with existing sample data.

### What is the New Behavior?
A new electronic gradeable graded_not_released_homework ("Graded (Not Released) Homework") is added to the sample course with the following date configuration:

TA view start — 1970 (past)
Submission open — 1971 (past)
Submission due — 1972 (past, submissions closed)
Grade start — 1973 (past, grading complete)
Grade due — 1974 (past, past grading deadline)
Grade released — 9998 (far future, not yet released to students)
This gradeable appears in the "Closed" section of the navigation page for students, while TAs can see it and its graded data in the grading interface.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Provision a Submitty Vagrant development environment
Run .setup/bin/setup_sample_courses.py (or recreate sample courses)
Log in as instructor and navigate to the sample course
Verify that "Graded (Not Released) Homework" appears in the gradeable list in the Closed section
Log in as a student (e.g., aphacker) and confirm the gradeable is not visible or shows no grade
Log in as a TA and confirm grading data is present in the grading interface

### Automated Testing & Documentation
This change does not affect application logic, only sample/test data. No new automated tests are required. The YAML is validated by the existing Gradeable class assertions in gradeable.py (date ordering checks at lines 302–307).

### Other information
Not a breaking change
No migrations required
No security concerns
