### PR TITLE
[Bugfix] Use rerender_pdf parameter instead of hardcoded condition in PDF download

### DIFF
--- a/site/public/js/pdf/PDFAnnotateEmbedded.js
+++ b/site/public/js/pdf/PDFAnnotateEmbedded.js
@@ -201,9 +201,7 @@ function download(gradeable_id, user_id, grader_id, file_name, file_path, page_n
         file_name: file_name,
         file_path: file_path,
     };
-    // TODO: Replace this with rerender_pdf, only rerender if rerender_pdf is set to true
-    // eslint-disable-next-line no-constant-condition
-    if (true) {
+    if (rerender_pdf) {
         window.RENDER_OPTIONS.documentId = file_name;
         // TODO: Duplicate user_id in both RENDER_OPTIONS and GENERAL_INFORMATION, also grader_id = user_id in this context.
         window.RENDER_OPTIONS.userId = grader_id;


### PR DESCRIPTION
## Summary
- Replace `if (true)` with `if (rerender_pdf)` in the `download()` function in `PDFAnnotateEmbedded.js`
- The `rerender_pdf` parameter was already passed to the function but never used
- Remove associated TODO comment and eslint-disable directive that are no longer needed
- This allows the else branch (direct file download via anchor element) to execute when PDF re-rendering is not required

## Test plan
- [ ] Test PDF annotation download with re-render enabled
- [ ] Test PDF download path when rerender_pdf is false/undefined
- [ ] Verify no regression in PDF grading annotation workflow