### PR TITLE
[Refactor:System] : Remove unused batchImportJSON function

### DIFF
--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -1159,25 +1159,6 @@ function resizeFrame(id, max_height = 500, force_height = -1) {
     }
 }
 
-/**
- * TODO: This may be unused.  Check, and potentially remove this function.
- */
-function batchImportJSON(url, csrf_token) {
-    $.ajax(url, {
-        type: 'POST',
-        data: {
-            csrf_token: csrf_token,
-        },
-    })
-        .done((response) => {
-            window.alert(response);
-            location.reload(true);
-        })
-        .fail(() => {
-            window.alert('[AJAX ERROR] Refresh page');
-        });
-}
-
 function submitAJAX(url, data, callbackSuccess, callbackFailure) {
     $.ajax(url, {
         type: 'POST',


### PR DESCRIPTION
## Summary                                                          
   - Remove the unused `batchImportJSON()` function from
   `site/public/js/server.js`
   - The function had a TODO comment noting it may be unused
   - A codebase-wide search confirmed zero references to this
   function

   ## Test plan
   - [ ] Verify no JavaScript errors on pages that load server.js
   - [ ] Confirm no functionality regression in course management
   pages
   EOF