### PR TITLE
[Bugfix:Forum] Show deleted post stats

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1440,15 +1440,27 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonFail("Empty edit post content.");
     }
 
+    /**
+     * @param array<string, array<string, mixed>> $users
+     */
     private function initializeForumStatsUser(array &$users, string $user): void {
         if (isset($users[$user])) {
             return;
         }
 
         $user_obj = $this->core->getQueries()->getSubmittyUser($user);
+
+        $given_name = htmlspecialchars($user);
+        $family_name = '';
+
+        if ($user_obj !== null) {
+            $given_name = htmlspecialchars($user_obj->getDisplayedGivenName());
+            $family_name = htmlspecialchars($user_obj->getDisplayedFamilyName());
+        }
+
         $users[$user] = [
-            "given_name" => htmlspecialchars($user_obj->getDisplayedGivenName()),
-            "family_name" => htmlspecialchars($user_obj->getDisplayedFamilyName()),
+            "given_name" => $given_name,
+            "family_name" => $family_name,
             "posts" => [],
             "id" => [],
             "timestamps" => [],

--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -1440,6 +1440,45 @@ class ForumController extends AbstractController {
         return $this->core->getOutput()->renderJsonFail("Empty edit post content.");
     }
 
+    private function initializeForumStatsUser(array &$users, string $user): void {
+        if (isset($users[$user])) {
+            return;
+        }
+
+        $user_obj = $this->core->getQueries()->getSubmittyUser($user);
+        $users[$user] = [
+            "given_name" => htmlspecialchars($user_obj->getDisplayedGivenName()),
+            "family_name" => htmlspecialchars($user_obj->getDisplayedFamilyName()),
+            "posts" => [],
+            "id" => [],
+            "timestamps" => [],
+            "thread_id" => [],
+            "thread_title" => [],
+            "total_threads" => 0,
+            "num_deleted_posts" => 0,
+            "total_upducks" => 0,
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getDeletedForumPostCounts(): array {
+        $this->core->getCourseDB()->query("
+            SELECT author_user_id, COUNT(*) AS num_deleted_posts
+            FROM posts
+            WHERE deleted = TRUE
+            GROUP BY author_user_id
+        ");
+
+        $deleted_post_counts = [];
+        foreach ($this->core->getCourseDB()->rows() as $row) {
+            $deleted_post_counts[$row['author_user_id']] = (int) $row['num_deleted_posts'];
+        }
+
+        return $deleted_post_counts;
+    }
+
     // TODO: getPosts() and getUpducks() are single use queries that should be used together to achieve the same effect
     #[Route("/courses/{_semester}/{_course}/forum/stats")]
     public function showStats() {
@@ -1447,22 +1486,12 @@ class ForumController extends AbstractController {
         $num_posts = count($posts);
         $upducks = $this->core->getQueries()->getUpDucks();
         $num_users_with_upducks = count($upducks);
+        $deleted_post_counts = $this->getDeletedForumPostCounts();
         $users = [];
         for ($i = 0; $i < $num_posts; $i++) {
             $user = $posts[$i]["author_user_id"];
             $content = $posts[$i]["content"];
-            if (!isset($users[$user])) {
-                $users[$user] = [];
-                $user_obj = $this->core->getQueries()->getSubmittyUser($user);
-                $users[$user]["given_name"] = htmlspecialchars($user_obj->getDisplayedGivenName());
-                $users[$user]["family_name"] = htmlspecialchars($user_obj->getDisplayedFamilyName());
-                $users[$user]["posts"] = [];
-                $users[$user]["id"] = [];
-                $users[$user]["timestamps"] = [];
-                $users[$user]["total_threads"] = 0;
-                $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
-                $users[$user]["total_upducks"] = 0;
-            }
+            $this->initializeForumStatsUser($users, $user);
             if ($posts[$i]["parent_id"] == -1) {
                 $users[$user]["total_threads"]++;
             }
@@ -1474,16 +1503,15 @@ class ForumController extends AbstractController {
         }
         for ($i = 0; $i < $num_users_with_upducks; $i++) {
             $user = $upducks[$i]["user_id"];
-            // user has only upducks and no posts, need to set some information
-            if (!isset($users[$user])) {
-                $user_obj = $this->core->getQueries()->getSubmittyUser($user);
-                $users[$user]["num_deleted_posts"] = count($this->core->getQueries()->getDeletedPostsByUser($user));
-                $users[$user]["given_name"] = htmlspecialchars($user_obj->getDisplayedGivenName());
-                $users[$user]["family_name"] = htmlspecialchars($user_obj->getDisplayedFamilyName());
-                $users[$user]["total_threads"] = 0;
-            }
+            $this->initializeForumStatsUser($users, $user);
             $users[$user]["total_upducks"] = $upducks[$i]["upducks"];
         }
+
+        foreach ($deleted_post_counts as $user => $num_deleted_posts) {
+            $this->initializeForumStatsUser($users, $user);
+            $users[$user]["num_deleted_posts"] = $num_deleted_posts;
+        }
+
         ksort($users);
         $this->core->getOutput()->renderOutput('forum\ForumThread', 'statPage', $users);
     }

--- a/site/app/templates/forum/StatPage.twig
+++ b/site/app/templates/forum/StatPage.twig
@@ -18,7 +18,7 @@
                 <th class = "cursor-pointer" style="width:15%" id="total_threads_sort"><a href="#">Total Threads</a></th>
                 <th class = "cursor-pointer" style="width:15%" id="total_deleted_sort"><a href="#">Total Deleted Posts</a></th>
                 <th class = "cursor-pointer" style="width:15%" id="total_upducks"><a href="#">Total Upducks</a></th>
-                <th style="width:25%">Show Posts</th>
+                <th style="width:25%">Show Posts (not deleted)</th>
             </tr>
 
             {% for user in userData %}

--- a/site/tests/app/controllers/forum/ForumControllerTester.php
+++ b/site/tests/app/controllers/forum/ForumControllerTester.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace tests\app\controllers\forum;
+
+use app\controllers\forum\ForumController;
+use app\libraries\Core;
+use app\libraries\Output;
+use app\libraries\database\AbstractDatabase;
+use app\libraries\database\DatabaseQueries;
+use app\models\Config;
+use app\models\User;
+use tests\BaseUnitTest;
+
+class ForumControllerTester extends BaseUnitTest {
+    private function createControllerWithCapturedStats(array $deleted_post_counts, ?User $submitty_user): array {
+        $core = new Core();
+
+        $config = $this->createMockModel(Config::class);
+        $config->method('getTimezone')->willReturn(new \DateTimeZone("America/New_York"));
+        $core->setConfig($config);
+
+        $queries = $this->createMock(DatabaseQueries::class);
+        $queries->method('getPosts')->willReturn([]);
+        $queries->method('getUpDucks')->willReturn([]);
+        $queries->method('getSubmittyUser')->willReturn($submitty_user);
+        $core->setQueries($queries);
+
+        $course_db = new class ($deleted_post_counts) extends AbstractDatabase {
+            private array $deleted_post_counts;
+            public string $last_query = '';
+
+            public function __construct(array $deleted_post_counts) {
+                parent::__construct([]);
+                $this->deleted_post_counts = $deleted_post_counts;
+            }
+
+            public function getConnectionDetails(): array {
+                return [];
+            }
+
+            public function fromDatabaseToPHPArray($text, $parse_bools = false, $start = 0, &$end = null): array {
+                return [];
+            }
+
+            public function fromPHPToDatabaseArray($array): string {
+                return '{}';
+            }
+
+            public function query($query, $parameters = []): void {
+                $this->last_query = $query;
+            }
+
+            public function rows(): array {
+                return $this->deleted_post_counts;
+            }
+        };
+        $core->setCourseDatabase($course_db);
+
+        $output = new class ($core) extends Output {
+            public ?array $rendered_output = null;
+
+            public function renderOutput($view, string $function, ...$args) {
+                $this->rendered_output = [
+                    'view' => $view,
+                    'function' => $function,
+                    'args' => $args,
+                ];
+                return null;
+            }
+        };
+        $core->setOutput($output);
+
+        return [new ForumController($core), $output, $course_db];
+    }
+
+    public function testShowStatsIncludesUserWithOnlyDeletedPosts(): void {
+        $user = $this->createMockModel(User::class);
+        $user->method('getDisplayedGivenName')->willReturn('Deleted');
+        $user->method('getDisplayedFamilyName')->willReturn('User');
+
+        [$controller, $output, $course_db] = $this->createControllerWithCapturedStats(
+            [
+                ['author_user_id' => 'deleted_only', 'num_deleted_posts' => '2'],
+            ],
+            $user
+        );
+
+        $controller->showStats();
+
+        $this->assertNotNull($output->rendered_output);
+        $this->assertSame('forum\\ForumThread', $output->rendered_output['view']);
+        $this->assertSame('statPage', $output->rendered_output['function']);
+        $this->assertStringContainsString('GROUP BY author_user_id', $course_db->last_query);
+
+        $users = $output->rendered_output['args'][0];
+        $this->assertCount(1, $users);
+        $this->assertArrayHasKey('deleted_only', $users);
+        $this->assertSame('Deleted', $users['deleted_only']['given_name']);
+        $this->assertSame('User', $users['deleted_only']['family_name']);
+        $this->assertSame(2, $users['deleted_only']['num_deleted_posts']);
+        $this->assertSame(0, $users['deleted_only']['total_threads']);
+        $this->assertSame(0, $users['deleted_only']['total_upducks']);
+        $this->assertSame([], $users['deleted_only']['posts']);
+        $this->assertSame([], $users['deleted_only']['id']);
+        $this->assertSame([], $users['deleted_only']['timestamps']);
+        $this->assertSame([], $users['deleted_only']['thread_id']);
+        $this->assertSame([], $users['deleted_only']['thread_title']);
+    }
+}


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12706

Users with only deleted forum posts do not appear on `/forum/stats`.

Currently, the stats page builds its user list from visible posts and upducks only. As a result, users with only deleted posts are never added to the stats data, even though deleted post counts are displayed in the table.

---

### What is the New Behavior?

Users with deleted-post-only activity are now included in forum stats.

The controller now:
- initializes forum stats users through a shared helper for consistent defaults
- aggregates deleted post counts efficiently
- seeds users from deleted post activity in addition to visible posts and upducks

As a result, users with only deleted posts now appear on `/forum/stats` with:
- the correct deleted post count
- zero visible post/thread counts where applicable

**Screenshots:**

- Before: stats page with only deleted posts present and no user row shown 
<img width="1470" height="956" alt="Screenshot 2026-03-31 at 22 09 39" src="https://github.com/user-attachments/assets/f28e113b-c15e-4891-9832-ca093dbbdde8" />

- After: stats page showing the deleted-post-only user row
<img width="1470" height="956" alt="Screenshot 2026-04-01 at 15 29 20" src="https://github.com/user-attachments/assets/5a3799c7-0566-45ce-9f68-ab4c8ecb2182" />

---

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Go to the discussion forum in a course
2. Create a scenario where a user has only deleted forum posts and no visible posts
3. Visit `/forum/stats`

**Before this change:**
- the user does not appear in the stats table

**After this change:**
- the user appears in the stats table with the correct deleted post count

**Additional checks:**
1. Verify a user with visible posts and deleted posts still shows correct stats
2. Verify a user with only upducks still appears correctly
3. Verify normal forum stats behavior is otherwise unchanged

---

### Automated Testing & Documentation

This change was manually tested on the forum stats page.

No automated tests were added. A follow-up issue can be opened for test coverage of forum stats edge cases if needed.

No submitty.org documentation changes are required, as this fixes existing behavior.

---

### Other information

- Not a breaking change  
- No migrations required  
- No known security concerns