### PR TITLE
[Bugfix:TAGrading]:TA overall comment box formatting

### DIFF
--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -47,9 +47,12 @@ const emit = defineEmits<{
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const kebabMenuRef = ref<HTMLElement | null>(null);
 const kebabButtonRef = ref<HTMLButtonElement | null>(null);
+const toolbarRef = ref<HTMLElement | null>(null);
 const mode = ref('edit');
 const content = ref(props.markdownAreaValue);
 const isLoadingPreview = ref(false);
+const toolbarWidth = ref(Number.POSITIVE_INFINITY);
+let toolbarResizeObserver: ResizeObserver | null = null;
 
 watch(content, (newValue) => {
     emit('update:modelValue', newValue ?? '');
@@ -244,6 +247,39 @@ function handleMarkdownAction(type: string) {
   closeKebabMenu(true);
 }
 
+const kebabActions = computed(() => {
+  const actions = new Set<string>();
+
+  // Move right-most actions into kebab progressively as width shrinks.
+  if (toolbarWidth.value <= 740) {
+    actions.add('blockquote');
+  }
+  if (toolbarWidth.value <= 680) {
+    actions.add('italic');
+  }
+  if (toolbarWidth.value <= 620) {
+    actions.add('bold');
+  }
+  if (toolbarWidth.value <= 560) {
+    actions.add('code');
+  }
+  if (toolbarWidth.value <= 500) {
+    actions.add('link');
+  }
+
+  return actions;
+});
+
+const hasKebabActions = computed(() => kebabActions.value.size > 0);
+
+function isActionInToolbar(action: string) {
+  return !kebabActions.value.has(action);
+}
+
+function isActionInKebab(action: string) {
+  return kebabActions.value.has(action);
+}
+
 function getKebabItems() {
   if (!kebabMenuRef.value) {
     return [] as HTMLButtonElement[];
@@ -371,6 +407,30 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('click', closeKebabOnOutsideClick);
   document.removeEventListener('keydown', closeKebabOnEscape);
+  toolbarResizeObserver?.disconnect();
+  toolbarResizeObserver = null;
+});
+
+watch(hasKebabActions, (hasItems) => {
+  if (!hasItems && isKebabOpen.value) {
+    closeKebabMenu(false);
+  }
+});
+
+onMounted(() => {
+  if (!toolbarRef.value) {
+    return;
+  }
+
+  const updateToolbarWidth = () => {
+    if (toolbarRef.value) {
+      toolbarWidth.value = toolbarRef.value.clientWidth;
+    }
+  };
+
+  updateToolbarWidth();
+  toolbarResizeObserver = new ResizeObserver(updateToolbarWidth);
+  toolbarResizeObserver.observe(toolbarRef.value);
 });
 </script>
 
@@ -438,6 +498,7 @@ onBeforeUnmount(() => {
 
       <div
         v-if="mode === 'edit'"
+        ref="toolbarRef"
         class="markdown-area-toolbar"
       >
         <a
@@ -451,6 +512,7 @@ onBeforeUnmount(() => {
           />
         </a>
         <button
+          v-if="isActionInToolbar('link')"
           type="button"
           title="Insert a link"
           class="btn btn-default btn-markdown btn-markdown-link"
@@ -460,6 +522,7 @@ onBeforeUnmount(() => {
           <span class="md-btn-text">Link </span><i class="fas fa-link fa-1x" />
         </button>
         <button
+          v-if="isActionInToolbar('code')"
           type="button"
           title="Insert a code segment"
           class="btn btn-default btn-markdown btn-markdown-code"
@@ -469,6 +532,7 @@ onBeforeUnmount(() => {
           <span class="md-btn-text">Code </span><i class="fas fa-code fa-1x" />
         </button>
         <button
+          v-if="isActionInToolbar('bold')"
           type="button"
           title="Insert bold text"
           class="btn btn-default btn-markdown btn-markdown-bold"
@@ -478,6 +542,7 @@ onBeforeUnmount(() => {
           <span class="md-btn-text">Bold </span><i class="fas fa-bold fa-1x" />
         </button>
         <button
+          v-if="isActionInToolbar('italic')"
           type="button"
           title="Insert italic text"
           class="btn btn-default btn-markdown btn-markdown-italic"
@@ -487,6 +552,7 @@ onBeforeUnmount(() => {
           <span class="md-btn-text">Italics </span><i class="fas fa-italic fa-1x" />
         </button>
         <button
+          v-if="isActionInToolbar('blockquote')"
           type="button"
           title="Insert blockquote text"
           class="btn btn-default btn-markdown btn-markdown-blockquote"
@@ -498,6 +564,7 @@ onBeforeUnmount(() => {
         
         <!-- Kebab menu for narrow screens -->
         <div
+          v-if="hasKebabActions"
           ref="kebabMenuRef"
           class="markdown-kebab-menu"
         >
@@ -519,6 +586,7 @@ onBeforeUnmount(() => {
             @keydown="handleKebabMenuKeydown"
           >
             <button
+              v-if="isActionInKebab('bold')"
               type="button"
               class="kebab-item"
               tabindex="0"
@@ -527,6 +595,7 @@ onBeforeUnmount(() => {
               <i class="fas fa-bold" /> Bold
             </button>
             <button
+              v-if="isActionInKebab('italic')"
               type="button"
               class="kebab-item"
               tabindex="0"
@@ -535,6 +604,7 @@ onBeforeUnmount(() => {
               <i class="fas fa-italic" /> Italic
             </button>
             <button
+              v-if="isActionInKebab('blockquote')"
               type="button"
               class="kebab-item"
               tabindex="0"
@@ -543,6 +613,7 @@ onBeforeUnmount(() => {
               <i class="fas fa-quote-left" /> Quote
             </button>
             <button
+              v-if="isActionInKebab('code')"
               type="button"
               class="kebab-item"
               tabindex="0"
@@ -551,6 +622,7 @@ onBeforeUnmount(() => {
               <i class="fas fa-code" /> Code
             </button>
             <button
+              v-if="isActionInKebab('link')"
               type="button"
               class="kebab-item"
               tabindex="0"
@@ -653,7 +725,8 @@ onBeforeUnmount(() => {
 
 .markdown-kebab-menu {
   position: relative;
-  display: none;
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
 }
 
@@ -723,15 +796,6 @@ onBeforeUnmount(() => {
 }
 
 @container markdownarea (max-width: 650px) {
-  .markdown-kebab-menu {
-    display: flex;
-  }
-  
-  /* Hide all individual buttons and help icon */
-  .btn-markdown {
-    display: none !important;
-  }
-  
   .markdown-help-icon {
     display: none;
   }

--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -139,7 +139,7 @@ function addMarkdown(type: string) {
 
 function handleKeyup(event: Event) {
     emit('keyup', event);
-
+    // Call global function if specified
     if (
         props.textareaOnKeyup
         && window[props.textareaOnKeyup as keyof Window]
@@ -401,33 +401,25 @@ function syncMarkdownToggle() {
 </template>
 
 <style>
-/* =========================================================
-   STRUCTURAL LAYOUT & RESPONSIVENESS
-   Note: Tab colors are handled by native Submitty CSS
-   ========================================================= */
-
-/* 1. Setup the container query on the main wrapper */
 .markdown-area {
   container-type: inline-size;
   container-name: markdownarea;
   width: 100%;
 }
 
-/* 2. The Header Row */
 .markdown-area-header {
   display: flex;
-  justify-content: space-between; /* Pushes tabs left, toolbar right */
-  align-items: flex-end; /* Keeps them bottom-aligned */
-  flex-wrap: nowrap; /* FORCES them to stay on one line */
+  justify-content: space-between; 
+  align-items: flex-end; 
+  flex-wrap: nowrap; 
   width: 100%;
-  overflow: hidden; /* Prevents awkward bleeding if it gets too tight */
+  overflow: hidden; 
 }
 
-/* 3. The Toolbar */
 .markdown-area-toolbar {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap; /* FORCES buttons to stay on one line */
+  flex-wrap: nowrap;
   gap: 4px;
   padding-bottom: 2px;
 }
@@ -436,17 +428,11 @@ function syncMarkdownToggle() {
   margin-right: 4px;
 }
 
-/* =========================================================
-   RESPONSIVE TEXT HIDING (Triggers when panel is narrow)
-   ========================================================= */
-
 @container markdownarea (max-width: 650px) {
-  /* Hide the text inside the formatting buttons */
   .md-btn-text {
     display: none;
   }
   
-  /* Make the remaining icon buttons square and compact */
   .markdown-area-toolbar .btn-markdown {
     padding-left: 10px !important;
     padding-right: 10px !important;
@@ -454,7 +440,6 @@ function syncMarkdownToggle() {
 }
 
 @container markdownarea (max-width: 350px) {
-  /* Extreme case: if the TA panel is tiny, shrink the gaps */
   .markdown-area-toolbar {
     gap: 2px;
   }

--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import Markdown from './Markdown.vue';
 
 interface Props {
@@ -45,6 +45,8 @@ const emit = defineEmits<{
 }>();
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
+const kebabMenuRef = ref<HTMLElement | null>(null);
+const kebabButtonRef = ref<HTMLButtonElement | null>(null);
 const mode = ref('edit');
 const content = ref(props.markdownAreaValue);
 const isLoadingPreview = ref(false);
@@ -215,6 +217,8 @@ onMounted(() => {
 });
 
 const showHeader = ref(!!props.renderHeader);
+const isKebabOpen = ref(false);
+
 function toggleMarkdown() {
     if (props.markdownStatusId) {
         const markdownStatusElement = document.getElementById(props.markdownStatusId) as HTMLInputElement;
@@ -234,6 +238,140 @@ function syncMarkdownToggle() {
         }
     }
 }
+
+function handleMarkdownAction(type: string) {
+    addMarkdown(type);
+  closeKebabMenu(true);
+}
+
+function getKebabItems() {
+  if (!kebabMenuRef.value) {
+    return [] as HTMLButtonElement[];
+  }
+  return Array.from(kebabMenuRef.value.querySelectorAll('.kebab-item')) as HTMLButtonElement[];
+}
+
+function focusKebabItem(index: number) {
+  const items = getKebabItems();
+  if (!items.length) {
+    return;
+  }
+  const boundedIndex = Math.max(0, Math.min(index, items.length - 1));
+  const item = items[boundedIndex];
+  if (item) {
+    item.focus();
+  }
+}
+
+function openKebabMenu(focusFirst = false) {
+  isKebabOpen.value = true;
+  if (focusFirst) {
+    requestAnimationFrame(() => {
+      focusKebabItem(0);
+    });
+  }
+}
+
+function closeKebabMenu(focusButton = false) {
+  isKebabOpen.value = false;
+  if (focusButton) {
+    requestAnimationFrame(() => {
+      kebabButtonRef.value?.focus();
+    });
+  }
+}
+
+function toggleKebabMenu(event: Event) {
+  event.stopPropagation();
+  if (isKebabOpen.value) {
+    closeKebabMenu();
+  }
+  else {
+    openKebabMenu(false);
+  }
+}
+
+function handleKebabButtonKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    openKebabMenu(true);
+  }
+  else if (event.key === 'Escape') {
+    event.preventDefault();
+    closeKebabMenu(true);
+  }
+}
+
+function handleKebabMenuKeydown(event: KeyboardEvent) {
+  if (!isKebabOpen.value) {
+    return;
+  }
+
+  const items = getKebabItems();
+  if (!items.length) {
+    return;
+  }
+
+  const currentIndex = items.findIndex((item) => item === document.activeElement);
+
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeKebabMenu(true);
+    return;
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
+    focusKebabItem(nextIndex);
+    return;
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    const prevIndex = currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+    focusKebabItem(prevIndex);
+    return;
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault();
+    focusKebabItem(0);
+    return;
+  }
+
+  if (event.key === 'End') {
+    event.preventDefault();
+    focusKebabItem(items.length - 1);
+  }
+}
+
+function closeKebabOnOutsideClick(event: Event) {
+  if (!isKebabOpen.value) {
+    return;
+  }
+
+  const target = event.target as Node | null;
+  if (kebabMenuRef.value && target && !kebabMenuRef.value.contains(target)) {
+    closeKebabMenu();
+  }
+}
+
+function closeKebabOnEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape' && isKebabOpen.value) {
+    closeKebabMenu(true);
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', closeKebabOnOutsideClick);
+  document.addEventListener('keydown', closeKebabOnEscape);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', closeKebabOnOutsideClick);
+  document.removeEventListener('keydown', closeKebabOnEscape);
+});
 </script>
 
 <template>
@@ -357,6 +495,71 @@ function syncMarkdownToggle() {
         >
           <span class="md-btn-text">Blockquote </span><i class="fas fa-quote-left fa-1x" />
         </button>
+        
+        <!-- Kebab menu for narrow screens -->
+        <div
+          ref="kebabMenuRef"
+          class="markdown-kebab-menu"
+        >
+          <button
+            ref="kebabButtonRef"
+            type="button"
+            class="btn btn-default btn-kebab"
+            tabindex="0"
+            title="More options"
+            @click="toggleKebabMenu"
+            @keydown="handleKebabButtonKeydown"
+          >
+            <i class="fas fa-ellipsis-v" />
+          </button>
+          <div
+            v-if="isKebabOpen"
+            class="kebab-dropdown"
+            @click.stop
+            @keydown="handleKebabMenuKeydown"
+          >
+            <button
+              type="button"
+              class="kebab-item"
+              tabindex="0"
+              @click="handleMarkdownAction('bold')"
+            >
+              <i class="fas fa-bold" /> Bold
+            </button>
+            <button
+              type="button"
+              class="kebab-item"
+              tabindex="0"
+              @click="handleMarkdownAction('italic')"
+            >
+              <i class="fas fa-italic" /> Italic
+            </button>
+            <button
+              type="button"
+              class="kebab-item"
+              tabindex="0"
+              @click="handleMarkdownAction('blockquote')"
+            >
+              <i class="fas fa-quote-left" /> Quote
+            </button>
+            <button
+              type="button"
+              class="kebab-item"
+              tabindex="0"
+              @click="handleMarkdownAction('code')"
+            >
+              <i class="fas fa-code" /> Code
+            </button>
+            <button
+              type="button"
+              class="kebab-item"
+              tabindex="0"
+              @click="handleMarkdownAction('link')"
+            >
+              <i class="fas fa-link" /> Link
+            </button>
+          </div>
+        </div>
       </div>
     </div>
     
@@ -416,7 +619,7 @@ function syncMarkdownToggle() {
   align-items: flex-end; 
   flex-wrap: nowrap; 
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
   gap: 8px;
 }
 
@@ -439,7 +642,7 @@ function syncMarkdownToggle() {
   justify-content: flex-end;
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
   gap: 4px;
   padding-bottom: 2px;
 }
@@ -448,53 +651,88 @@ function syncMarkdownToggle() {
   margin-right: 4px;
 }
 
+.markdown-kebab-menu {
+  position: relative;
+  display: none;
+  flex: 0 0 auto;
+}
+
+.btn-kebab {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #555 !important;
+  border-radius: 4px !important;
+  background: #3a3a3a !important;
+  color: #e8e8e8 !important;
+  padding: 0 !important;
+}
+
+.btn-kebab:hover,
+.btn-kebab:focus {
+  background: #4b4b4b !important;
+  border-color: #666 !important;
+}
+
+.kebab-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  background: #3a3a3a;
+  border: 1px solid #555;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+  z-index: 1000;
+  min-width: 200px;
+  padding: 4px;
+}
+
+.kebab-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.95rem;
+  color: #e8e8e8;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+}
+
+.kebab-item:hover {
+  background-color: #4b4b4b;
+}
+
+.kebab-item i {
+  width: 16px;
+  text-align: center;
+  color: #d0d0d0;
+}
+
+.kebab-item:focus-visible {
+  border-color: #337ab7;
+  outline: 2px solid #337ab7;
+  outline-offset: 0;
+}
+
 @container markdownarea (max-width: 650px) {
-  .md-btn-text {
-    display: none;
+  .markdown-kebab-menu {
+    display: flex;
   }
   
-  .markdown-area-toolbar .btn-markdown {
-    padding-left: 10px !important;
-    padding-right: 10px !important;
+  /* Hide all individual buttons and help icon */
+  .btn-markdown {
+    display: none !important;
   }
-}
-
-@container markdownarea (max-width: 500px) {
-  .btn-markdown-blockquote {
-    display: none;
-  }
-}
-
-@container markdownarea (max-width: 460px) {
-  .btn-markdown-italic {
-    display: none;
-  }
-}
-
-@container markdownarea (max-width: 420px) {
-  .btn-markdown-bold {
-    display: none;
-  }
-}
-
-@container markdownarea (max-width: 380px) {
-  .btn-markdown-code {
-    display: none;
-  }
-}
-
-@container markdownarea (max-width: 350px) {
-  .markdown-area-toolbar {
-    gap: 2px;
-  }
-  .markdown-area-toolbar .btn-markdown {
-    padding-left: 6px !important;
-    padding-right: 6px !important;
-  }
-}
-
-@container markdownarea (max-width: 330px) {
-  .btn-markdown-link {
+  
+  .markdown-help-icon {
     display: none;
   }
 }

--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -140,7 +140,6 @@ function addMarkdown(type: string) {
 function handleKeyup(event: Event) {
     emit('keyup', event);
 
-    // Call global function if specified
     if (
         props.textareaOnKeyup
         && window[props.textareaOnKeyup as keyof Window]
@@ -155,7 +154,6 @@ function handleKeyup(event: Event) {
 function handleKeydown(event: Event) {
     emit('keydown', event);
 
-    // Call global function if specified
     if (
         props.textareaOnkeydown
         && window[props.textareaOnkeydown as keyof Window]
@@ -170,7 +168,6 @@ function handleKeydown(event: Event) {
 function handlePaste(event: Event) {
     emit('paste', event);
 
-    // Call global function if specified
     if (
         props.textareaOnPaste
         && window[props.textareaOnPaste as keyof Window]
@@ -185,7 +182,6 @@ function handlePaste(event: Event) {
 function handleChange(event: Event) {
     emit('change', event);
 
-    // Call global function if specified
     if (
         props.textareaOnChange
         && window[props.textareaOnChange as keyof Window]
@@ -262,6 +258,7 @@ function syncMarkdownToggle() {
       class="far fa-question-circle disabled"
     /></a>
   </div>
+  
   <div
     :class="[rootClass]"
     class="markdown-area fill-available"
@@ -273,9 +270,7 @@ function syncMarkdownToggle() {
       class="markdown-area-header"
       :data-mode="mode"
     >
-      <div
-        class="markdown-mode-buttons"
-      >
+      <div class="markdown-mode-buttons">
         <button
           title="Edit Markdown"
           type="button"
@@ -299,6 +294,7 @@ function syncMarkdownToggle() {
           Preview
         </button>
       </div>
+
       <div
         v-if="mode === 'edit'"
         class="markdown-area-toolbar"
@@ -306,6 +302,7 @@ function syncMarkdownToggle() {
         <a
           target="_blank"
           href="https://submitty.org/student/communication/markdown"
+          class="markdown-help-icon"
         >
           <i
             style="font-style: normal"
@@ -319,46 +316,47 @@ function syncMarkdownToggle() {
           tabindex="0"
           @click="addMarkdown('link')"
         >
-          Link <i class="fas fa-link fa-1x" />
+          <span class="md-btn-text">Link </span><i class="fas fa-link fa-1x" />
         </button>
         <button
-          title="Insert a code segment"
           type="button"
+          title="Insert a code segment"
           class="btn btn-default btn-markdown btn-markdown-code"
           tabindex="0"
           @click="addMarkdown('code')"
         >
-          Code <i class="fas fa-code fa-1x" />
+          <span class="md-btn-text">Code </span><i class="fas fa-code fa-1x" />
         </button>
         <button
-          title="Insert bold text"
           type="button"
+          title="Insert bold text"
           class="btn btn-default btn-markdown btn-markdown-bold"
           tabindex="0"
           @click="addMarkdown('bold')"
         >
-          Bold <i class="fas fa-bold fa-1x" />
+          <span class="md-btn-text">Bold </span><i class="fas fa-bold fa-1x" />
         </button>
         <button
-          title="Insert italic text"
           type="button"
+          title="Insert italic text"
           class="btn btn-default btn-markdown btn-markdown-italic"
           tabindex="0"
           @click="addMarkdown('italic')"
         >
-          Italics <i class="fas fa-italic fa-1x" />
+          <span class="md-btn-text">Italics </span><i class="fas fa-italic fa-1x" />
         </button>
         <button
-          title="Insert blockquote text"
           type="button"
+          title="Insert blockquote text"
           class="btn btn-default btn-markdown btn-markdown-blockquote"
           tabindex="0"
           @click="addMarkdown('blockquote')"
         >
-          Blockquote <i class="fas fa-quote-left fa-1x" />
+          <span class="md-btn-text">Blockquote </span><i class="fas fa-quote-left fa-1x" />
         </button>
       </div>
     </div>
+    
     <div class="markdown-area-body">
       <div
         v-if="isPreviewLoading || isLoadingPreview"
@@ -401,3 +399,68 @@ function syncMarkdownToggle() {
     </div>
   </div>
 </template>
+
+<style>
+/* =========================================================
+   STRUCTURAL LAYOUT & RESPONSIVENESS
+   Note: Tab colors are handled by native Submitty CSS
+   ========================================================= */
+
+/* 1. Setup the container query on the main wrapper */
+.markdown-area {
+  container-type: inline-size;
+  container-name: markdownarea;
+  width: 100%;
+}
+
+/* 2. The Header Row */
+.markdown-area-header {
+  display: flex;
+  justify-content: space-between; /* Pushes tabs left, toolbar right */
+  align-items: flex-end; /* Keeps them bottom-aligned */
+  flex-wrap: nowrap; /* FORCES them to stay on one line */
+  width: 100%;
+  overflow: hidden; /* Prevents awkward bleeding if it gets too tight */
+}
+
+/* 3. The Toolbar */
+.markdown-area-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap; /* FORCES buttons to stay on one line */
+  gap: 4px;
+  padding-bottom: 2px;
+}
+
+.markdown-help-icon {
+  margin-right: 4px;
+}
+
+/* =========================================================
+   RESPONSIVE TEXT HIDING (Triggers when panel is narrow)
+   ========================================================= */
+
+@container markdownarea (max-width: 650px) {
+  /* Hide the text inside the formatting buttons */
+  .md-btn-text {
+    display: none;
+  }
+  
+  /* Make the remaining icon buttons square and compact */
+  .markdown-area-toolbar .btn-markdown {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+  }
+}
+
+@container markdownarea (max-width: 350px) {
+  /* Extreme case: if the TA panel is tiny, shrink the gaps */
+  .markdown-area-toolbar {
+    gap: 2px;
+  }
+  .markdown-area-toolbar .btn-markdown {
+    padding-left: 6px !important;
+    padding-right: 6px !important;
+  }
+}
+</style>

--- a/site/vue/src/components/MarkdownArea.vue
+++ b/site/vue/src/components/MarkdownArea.vue
@@ -154,6 +154,7 @@ function handleKeyup(event: Event) {
 function handleKeydown(event: Event) {
     emit('keydown', event);
 
+  // Call global function if specified
     if (
         props.textareaOnkeydown
         && window[props.textareaOnkeydown as keyof Window]
@@ -168,6 +169,7 @@ function handleKeydown(event: Event) {
 function handlePaste(event: Event) {
     emit('paste', event);
 
+  // Call global function if specified
     if (
         props.textareaOnPaste
         && window[props.textareaOnPaste as keyof Window]
@@ -182,6 +184,7 @@ function handlePaste(event: Event) {
 function handleChange(event: Event) {
     emit('change', event);
 
+  // Call global function if specified
     if (
         props.textareaOnChange
         && window[props.textareaOnChange as keyof Window]
@@ -413,13 +416,30 @@ function syncMarkdownToggle() {
   align-items: flex-end; 
   flex-wrap: nowrap; 
   width: 100%;
-  overflow: hidden; 
+  overflow: hidden;
+  gap: 8px;
+}
+
+.markdown-mode-buttons {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  flex: 0 0 auto;
+  min-width: max-content;
+}
+
+.markdown-mode-tab {
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 .markdown-area-toolbar {
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
   gap: 4px;
   padding-bottom: 2px;
 }
@@ -439,6 +459,30 @@ function syncMarkdownToggle() {
   }
 }
 
+@container markdownarea (max-width: 500px) {
+  .btn-markdown-blockquote {
+    display: none;
+  }
+}
+
+@container markdownarea (max-width: 460px) {
+  .btn-markdown-italic {
+    display: none;
+  }
+}
+
+@container markdownarea (max-width: 420px) {
+  .btn-markdown-bold {
+    display: none;
+  }
+}
+
+@container markdownarea (max-width: 380px) {
+  .btn-markdown-code {
+    display: none;
+  }
+}
+
 @container markdownarea (max-width: 350px) {
   .markdown-area-toolbar {
     gap: 2px;
@@ -446,6 +490,19 @@ function syncMarkdownToggle() {
   .markdown-area-toolbar .btn-markdown {
     padding-left: 6px !important;
     padding-right: 6px !important;
+  }
+}
+
+@container markdownarea (max-width: 330px) {
+  .btn-markdown-link {
+    display: none;
+  }
+}
+
+@container markdownarea (max-width: 300px) {
+  .markdown-help-icon {
+    display: none;
+    margin-right: 0;
   }
 }
 </style>


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
closes #12712 
Fixes the UI bug where "Write" and "Preview" tabs overlapped with formatting icons in narrow layouts, specifically within the TA grading rubric panel. This ensures the editor remains functional and professional-looking regardless of the side-panel width.
### What is the New Behavior?

- Unified Header: Uses Flexbox to anchor tabs to the left and formatting buttons to the right on a single, non-wrapping line.

- Responsive Hiding: Implemented CSS Container Queries to automatically hide button text (leaving only icons) when the editor width drops below 650px.

- Themed Tabs: Restored native Submitty CSS classes to ensure "Write/Preview" tabs maintain correct background and text colors in both Light and Dark modes.

<img width="617" height="341" alt="Screenshot 2026-04-01 003828" src="https://github.com/user-attachments/assets/ce17228a-683d-4030-81fe-0da70a56cb41" />
<img width="850" height="340" alt="Screenshot 2026-04-01 003841" src="https://github.com/user-attachments/assets/46e1a24f-5b02-4284-aa47-416f0d8bc5f6" />
<img width="819" height="329" alt="Screenshot 2026-04-01 003857" src="https://github.com/user-attachments/assets/9c5a2d9a-767f-43d9-8a3f-51a0b1c2ca81" />


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Open the TA Grading Rubric for any gradeable.
2. Locate the "Overall Comment" Markdown editor.
3. Manually shrink the width of the grading panel using the dragger.
4. Observe: The "Link", "Code", and "Bold" text should disappear as the panel narrows, leaving only the icons, preventing any overlap with the tabs.
5. Toggle between Light and Dark modes to verify tab visibility.

### Automated Testing & Documentation
The change is purely visual/CSS-based and does not alter Markdown logic. Manual verification across different panel widths is sufficient.

### Other information
This is a non-breaking UI enhancement. No migrations or security concerns.
