### PR TITLE
[Bugfix:Notifications] Settings font alignment

### DIFF
--- a/site/vue/src/components/NotificationsDisplay.vue
+++ b/site/vue/src/components/NotificationsDisplay.vue
@@ -84,7 +84,7 @@ function markSeen() {
 }
 
 function goToNotificationSettings() {
-  window.location.href = buildCourseUrl(['notifications', 'settings']);
+    window.location.href = buildCourseUrl(['notifications', 'settings']);
 }
 
 // mark notification as seen without reloading


### PR DESCRIPTION
<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
Closes #12716 
This change fixes a UI inconsistency where the "Settings" button in the Notifications tab used a different font and was vertically misaligned compared to the "Mark as Seen" and "Show All" buttons.


### What is the New Behavior?
The "Settings" button now uses the same font and vertical alignment as the other notification action buttons.
All three buttons appear visually consistent.

Before: "Settings" button text was a different font and 2px higher than the others.
<img width="3500" height="1058" alt="image" src="https://github.com/user-attachments/assets/91e239d6-fce3-4964-b2dd-1d4d41aa28f9" />

After: All buttons have matching font and alignment.
<img width="791" height="127" alt="Screenshot 2026-04-02 011531" src="https://github.com/user-attachments/assets/79a4f531-0107-4e14-88d6-87aebfd5666f" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Go to the Notifications tab in a course.
2. Observe the "Settings", "Mark as Seen", and "Show All" buttons.
3. Confirm that all three buttons now have the same font and are vertically aligned.
4. Test in both light and dark mode, and on different browsers if possible.

### Automated Testing & Documentation

1. This is a UI-only change; no new unit or end-to-end tests were added.
2. Existing Cypress UI tests for notifications should continue to pass.
3. No documentation changes are required.


### Other information

1. Not a breaking change.
2. No migrations required.
3. No security concerns.