### PR TITLE
[Bugfix:TAGrading] Fix comment box formatting on narrow panel

### DIFF
--- a/site/public/css/markdown.css
+++ b/site/public/css/markdown.css
@@ -273,3 +273,53 @@
     background-color: white;
     max-width: 100%;
 }
+
+.markdown-area-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.markdown-mode-tab {
+    padding: 6px 10px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    background: #f5f5f5;
+    min-width: fit-content;   /* key change */
+}
+
+.markdown-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.markdown-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.markdown-mode-tab.active {
+    background: #ddd;
+    border-bottom: 2px solid #000;
+    font-weight: 600;
+}
+
+.markdown-preview {
+    width: 100%;
+    min-height: 120px;
+    padding: 8px;
+    border: 1px solid #ccc;
+    background: #fff;
+}
+
+.markdown-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.markdown-toolbar button {
+    margin: 2px;
+}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12712

The Write/Preview tabs in the TA grading comment box appear misaligned on narrow panels.

### What is the New Behavior?
Tabs are now responsive and properly aligned using flexbox. They wrap cleanly on smaller widths and appear as proper buttons.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open TA grading interface
2. Resize screen to narrow width
3. Observe Write/Preview tabs before and after fix

### Automated Testing & Documentation
No new tests required (UI fix)

### Other information
No breaking changes