### PR TITLE
[Bugfix:InstructorUI] Change Colors to match in Docker UI table

### DIFF
--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -134,7 +134,7 @@
                 <td>{{ image.created_timestamp }}</td>
                 <td>
                     {% for capability in image.capabilities %}
-                        <span class="badge badge-{{ capability_to_color_mapping[capability] % 8 + 1 }}">{{capability}}</span>
+                        <span class="badge badge-{{ capability_to_color_mapping[capability]}}">{{capability}}</span>
                     {% endfor %}
                 </td>
                 <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes: #12738 
- This change avoids confusion when filtering for certain things by correctly matching the colors

### What is the New Behavior?
- Colors in the filter buttons now match the colors in the table

Old:
<img width="1433" height="671" alt="Screenshot 2026-04-02 at 7 11 52 PM" src="https://github.com/user-attachments/assets/d43077b4-f330-42c3-89e5-94c3443b8dbf" />
New:
<img width="1436" height="676" alt="Screenshot 2026-04-02 at 7 27 01 PM" src="https://github.com/user-attachments/assets/88e09b42-52d5-4d78-8e69-ab872dc1c9d5" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Navigate to Docker UI tabe once logged in to a user
2. Scroll down a little bit to see the Autograding Docker Images

### Automated Testing & Documentation
NA

### Other information
NA- Simple UI change
