### PR TITLE
[Bugfix:RainbowGrades] Gradebook Format Fix

### DIFF
--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -32,7 +32,7 @@
             {% endif %}
         </div>
     </header>
-    <div id="rainbow-grades" data-testid="rainbow-grades" style="overflow-x: auto;">
+    <div id="rainbow-grades" data-testid="rainbow-grades" style="overflow: auto; height: 100dvh;">
       {% if show_summary %}
           {{ grade_file|raw }}
       {% else %}

--- a/site/app/templates/submission/RainbowGrades.twig
+++ b/site/app/templates/submission/RainbowGrades.twig
@@ -32,7 +32,7 @@
             {% endif %}
         </div>
     </header>
-    <div id="rainbow-grades" data-testid="rainbow-grades">
+    <div id="rainbow-grades" data-testid="rainbow-grades" style="overflow-x: auto;">
       {% if show_summary %}
           {{ grade_file|raw }}
       {% else %}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This is a minor styling change related to [PR#86 in Submitty/RainbowGrades](https://github.com/Submitty/RainbowGrades/pull/86), that prevents the table from overflowing past the sticky columns.

### What is the New Behavior?
Before:
<img width="1440" height="900" alt="Screenshot_20260406_173230" src="https://github.com/user-attachments/assets/48db20fd-8876-40ea-93d3-2fb0aa453b99" />
After:
<img width="1440" height="900" alt="Screenshot_20260406_173456" src="https://github.com/user-attachments/assets/cc9c2c86-09fd-4a70-a2dc-49adeba95ecd" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
Follow the same steps as in [PR#86 in Submitty/RainbowGrades](https://github.com/Submitty/RainbowGrades/pull/86).

### Automated Testing & Documentation
N/A (style change)

### Other information
None
