### PR TITLE
[Bugfix:InstructorUI] Fix Instructor Edit Team Add User Menu 

### DIFF
--- a/site/public/js/admin-team-form.js
+++ b/site/public/js/admin-team-form.js
@@ -248,6 +248,13 @@ function getTeamFormMultipleInvitesWarningString() {
             </div>`;
 }
 
+function initTeamMemberAutocomplete(member_element, student_full, form = $('#admin-team-form')) {
+    member_element.autocomplete({
+        source: student_full,
+    });
+    member_element.autocomplete('option', 'appendTo', form);
+}
+
 function removeTeamMemberInput(i) {
     const removed_member_element = $(`#user_id_${i}`);
     // remove the Remove button associated with this member;
@@ -258,9 +265,7 @@ function removeTeamMemberInput(i) {
 
     // update autocomplete
     const student_full = JSON.parse($('#student_full_id').val());
-    removed_member_element.autocomplete({
-        source: student_full,
-    });
+    initTeamMemberAutocomplete(removed_member_element, student_full);
 }
 
 function approveTeamMemberInput(i) {
@@ -282,9 +287,7 @@ function approveTeamMemberInput(i) {
 
     // update autocomplete
     const student_full = JSON.parse($('#student_full_id').val());
-    new_member_element.autocomplete({
-        source: student_full,
-    });
+    initTeamMemberAutocomplete(new_member_element, student_full);
 }
 
 function addTeamMemberInput(old, i) {
@@ -309,9 +312,7 @@ function addTeamMemberInput(old, i) {
 
     // update autocomplete
     const student_full = JSON.parse($('#student_full_id').val());
-    $(`#user_id_${i}`).autocomplete({
-        source: student_full,
-    });
+    initTeamMemberAutocomplete($(`#user_id_${i}`), student_full);
 }
 
 function importTeamForm() {


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
Closes #12755 and fixes #12769 
When instructors edit a team and add more than two members via the admin team form modal, the jQuery UI autocomplete suggestion dropdown was rendering **behind the popup** instead of above it, making it impossible to select students. This is a usability bug that affects the team management workflow.

### What is the New Behavior?

The autocomplete suggestion menu now consistently displays **above/inside the modal** for all dynamically added member input fields, matching the behavior of the initial two member inputs. Users can now successfully add 3+ members to a team without the dropdown being obscured.

<img width="1913" height="895" alt="Screenshot 2026-04-07 134112" src="https://github.com/user-attachments/assets/62c89702-be68-4119-b55a-b291893aa2da" />
<img width="1919" height="774" alt="Screenshot 2026-04-07 134833" src="https://github.com/user-attachments/assets/70682e8b-6570-4c5d-b269-696bf496ca40" />


### What steps should a reviewer take to reproduce or test the bug/new feature?

1. Navigate to a team gradeable's grading details page
2. Edit a team
3. Click "Add More Users" to create a 3rd member input field
4. Type a student name/ID in the field to trigger autocomplete
5. **Verify**: The suggestion dropdown appears **inside the modal**, not behind it
6. Select a suggestion and submit to confirm the new member is added

### Automated Testing & Documentation

This is a UI/styling fix. Existing form validation tests remain unchanged. Manual testing confirms the correct behavior.

### Other information

- Not a breaking change
- No database migrations needed
- No security concerns