### PR TITLE
[Bugfix:Submission] Fix gradeable page crash

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6074,7 +6074,11 @@ AND gc_id IN (
         // Generate the ORDER BY clause
         $order = self::generateOrderByClause($sort_keys, []);
 
-        // Detect potential unseen grading notifications for the given user
+        // Unseen gradeable notification detection is currently disabled in this query path.
+        // Keep returning a constant FALSE so callers receive the expected column without
+        // assuming detection is still implemented here.
+        // TODO: Restore user-specific unseen notification detection and parameters here
+        // once the related migration/feature work is completed.
         $unseen_notification_select = "FALSE AS has_unseen_gradeable_notification,";
         $unseen_notification_param = [];
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -6075,21 +6075,8 @@ AND gc_id IN (
         $order = self::generateOrderByClause($sort_keys, []);
 
         // Detect potential unseen grading notifications for the given user
-        if ($for_user_id !== null) {
-            $unseen_notification_select = "
-                EXISTS (
-                    SELECT 1 FROM notifications n
-                    WHERE n.gradeable_id = g.g_id
-                        AND n.to_user_id = ?
-                        AND n.component = 'grading'
-                        AND n.seen_at IS NULL
-                    ) AS has_unseen_gradeable_notification,";
-            $unseen_notification_param = [$for_user_id];
-        }
-        else {
-            $unseen_notification_select = "FALSE AS has_unseen_gradeable_notification,";
-            $unseen_notification_param = [];
-        }
+        $unseen_notification_select = "FALSE AS has_unseen_gradeable_notification,";
+        $unseen_notification_param = [];
 
         $query = "
             SELECT


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12774

Opening a gradeable submission page on `main` currently crashes with:

`SQLSTATE[42703]: Undefined column: 7 ERROR: column n.gradeable_id does not exist`

`DatabaseQueries::getGradeableConfigs()` computes `has_unseen_gradeable_notification` using `notifications.gradeable_id`, but the course `notifications` table in my local environment does not contain a `gradeable_id` column. This causes gradeable submission pages to fail before rendering.

This change restores page loading by removing that invalid schema dependency until notification schema support is implemented consistently.

### What is the New Behavior?

Gradeable submission pages no longer crash when loading `getGradeableConfigs()`.

This patch makes `has_unseen_gradeable_notification` fall back to `FALSE` instead of querying `notifications.gradeable_id`.

**Before**
<img width="1470" height="956" alt="Screenshot 2026-04-12 at 15 51 44" src="https://github.com/user-attachments/assets/561d5766-0bc9-4401-9e22-02e6ef205311" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Check out current `main` without this patch.
2. Open a course gradeable submission page.
3. Example: `/courses/s26/sample/gradeable/bulk_upload_test`
4. Observe the database error caused by `n.gradeable_id`.
5. Apply this patch.
6. Reload the same page.
7. Verify the page loads successfully.

### Automated Testing & Documentation

- Reproduced the crash locally on a course gradeable submission page
- Confirmed the failing query referenced `notifications.gradeable_id`
- Confirmed the course DB `notifications` table does not contain a `gradeable_id` column
- Applied this patch locally
- Ran `php -l site/app/libraries/database/DatabaseQueries.php`
- Verified the page loads again after the change

I was not able to run the targeted PHPUnit test from my local shell because `phpunit` was not available in that environment.

No documentation changes are needed for this bugfix.

### Other information

This is a minimal crash fix, not the long-term notification feature solution. It temporarily disables unseen-gradeable notification detection in this query path by falling back to `FALSE AS has_unseen_gradeable_notification`.

This PR does not include migrations.

No known security concerns.