### PR TITLE
[Bugfix:TAGrading] Fix false peer grading version conflict

### DIFF
--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -1471,7 +1471,8 @@ function getGradedComponentFromDOM(component_id: number): ComponentGradeInfo {
     const dataDOMElement = domElement.find('.graded-component-data');
     let gradedVersion = dataDOMElement.attr('data-graded_version')!;
     if (gradedVersion === '') {
-        gradedVersion = getDisplayVersion().toString();
+        const displayVersion = getDisplayVersion();
+        gradedVersion = isNaN(displayVersion) ? '0' : displayVersion.toString();
     }
     return {
         score: score,
@@ -1875,7 +1876,10 @@ function updateVerifyAllButton() {
  * @returns {boolean}
  */
 function getComponentVersionConflict(graded_component: { graded_version: number } | undefined) {
-    return graded_component !== undefined && graded_component.graded_version !== getDisplayVersion();
+    if (graded_component === undefined) return false;
+    const displayVersion = getDisplayVersion();
+    if (isNaN(graded_component.graded_version) || isNaN(displayVersion)) return false;
+    return graded_component.graded_version !== displayVersion;
 }
 
 /**

--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -1876,9 +1876,13 @@ function updateVerifyAllButton() {
  * @returns {boolean}
  */
 function getComponentVersionConflict(graded_component: { graded_version: number } | undefined) {
-    if (graded_component === undefined) return false;
+    if (graded_component === undefined) {
+        return false;
+    }
     const displayVersion = getDisplayVersion();
-    if (isNaN(graded_component.graded_version) || isNaN(displayVersion)) return false;
+    if (isNaN(graded_component.graded_version) || isNaN(displayVersion)) {
+        return false;
+    }
     return graded_component.graded_version !== displayVersion;
 }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #10772 

When a peer grader clicks in and out of a rubric component, a false
"Version Conflict" banner appears showing "version NaN" even when no
real conflict exists.

### What is the New Behavior?
The version conflict banner no longer appears falsely during peer
grading. It will only appear when a genuine version mismatch exists.

Before: Clicking on the component again and again shows the false "Version Conflict" 
<img width="1235" height="289" alt="Screenshot from 2026-04-12 14-31-14" src="https://github.com/user-attachments/assets/6119c65f-8e56-406c-b4ee-010950d9cc14" />

After: Clicking on the component again and again it doesn't show the false 'Version Conflict"
<img width="1235" height="289" alt="image" src="https://github.com/user-attachments/assets/96bc407b-b14f-41f2-9f54-a94788f73866" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Log into Submitty as a student who is assigned as a student
<img width="663" height="444" alt="image" src="https://github.com/user-attachments/assets/c55a9263-8246-4791-8f0d-7275a9570a92" />

2. Click on the sample (section-1)
<img width="755" height="320" alt="image" src="https://github.com/user-attachments/assets/df9d7c9b-3216-470e-a6d5-26731e856f9b" />

3. Navigate to a peer grading gradeable and click "Grade" for Closed Peer Team Homework
<img width="1577" height="134" alt="Screenshot from 2026-04-12 16-19-23" src="https://github.com/user-attachments/assets/4f322082-87cc-4879-8346-396ada3971e0" />

4. Click on the any grade version 1
<img width="1542" height="208" alt="image" src="https://github.com/user-attachments/assets/c3eac689-9179-49d7-b294-6d5356961821" />
5.  Click into a rubric component to open it
<img width="1444" height="436" alt="image" src="https://github.com/user-attachments/assets/a1e8bcb8-9b9b-42b6-a3c3-183146b37f89" />

6. Click out of the component, then click back in — repeat 2-3 times

8. Confirm that no "Version Conflict" banner appears
<img width="1235" height="289" alt="Screenshot from 2026-04-12 14-31-14" src="https://github.com/user-attachments/assets/6119c65f-8e56-406c-b4ee-010950d9cc14" />

### Automated Testing & Documentation
No automated tests

### Other information
Not a breaking change. No migrations required. No security concerns.
