### PR TITLE
[Feature:Submission] Add a confirmation pop-up for do not grade this assignment

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionBox.twig
+++ b/site/app/templates/submission/homework/CurrentVersionBox.twig
@@ -25,7 +25,7 @@
                 {# If viewing the active version, show cancel button, otherwise so button to switch active #}
                 {% if display_version > 0 %}
                     {% if display_version == active_version %}
-                        <form method="post" action="{{ cancel_url }}">
+                        <form method="post" action="{{ cancel_url }}" onsubmit='return confirm("Are you sure you want to mark this assignment as Do Not Grade?")'>
                             <input type='hidden' name="csrf_token" value="{{ csrf_token }}" />
                             <input type="submit" id="do_not_grade" class="btn btn-default" value="Do Not Grade This Assignment">
                         </form>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #12777 
This change prevents accidental clicks on the "Do Not Grade This Assignment" button in the submission version selection page. Previously, it was too easy to unintentionally mark an assignment as "Do Not Grade," which could disrupt grading workflows and cause confusion for both students and instructors.


### What is the New Behavior?
- When a user clicks the "Do Not Grade This Assignment" button, a confirmation dialog now appears.
- The user must confirm their action before the assignment is marked as "Do Not Grade."
- This reduces the risk of accidental clicks and improves the user experience.

**Before:**  
Clicking "Do Not Grade This Assignment" immediately performed the action with no confirmation.

**After:**  
Clicking the button prompts a browser confirmation dialog. The action only proceeds if the user confirms.


https://github.com/user-attachments/assets/e1611259-3087-4c7f-a764-c0774faee33c


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Go to the submission version selection page for any gradeable.
2. Click the "Do Not Grade This Assignment" button.
3. Verify that a confirmation dialog appears.
4. Confirming proceeds with the action and cancelling aborts it.

### Automated Testing & Documentation
- This is a UI change and is not covered by automated unit or end-to-end tests.
- No documentation changes are required.

### Other information
- This is not a breaking change.
- No database migrations are required.
- There are no security concerns introduced by this change.