### PR TITLE
[Bugfix:Notifications] Fix Broken Course Link

### DIFF
--- a/site/vue/src/components/Notification.vue
+++ b/site/vue/src/components/Notification.vue
@@ -106,7 +106,7 @@ function markSeen(course: string, id: number) {
             <span
               class="course-notification-link"
               title="Go to notifications"
-              @click.stop="goToCourseNotifications(notification.course)"
+              @click.stop.prevent="goToCourseNotifications(notification.course)"
             >
               {{ notification.course_name ? notification.course_name : notification.course }}
             </span>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
A small feature on the home page notifications panel is the course button, which should redirect the user to that course's notification page. Currently, it redirects the user to the origin of the notification just like the rest of the button.
<img width="1097" height="470" alt="image" src="https://github.com/user-attachments/assets/d7eb8eea-042a-47d1-839b-67b932e33272" />

### What is the New Behavior?
Clicking the course button now redirects to that course's notification page.

### What steps should a reviewer take to reproduce or test the bug or new feature?
On main: Click the course button. Redirect to notification origin.
Feature branch. Click the course button, Redirect to that course's notification page.

### Automated Testing & Documentation
#12430 is in progress and will test this feature.

### Other information
This is not a breaking change.
