### PR TITLE
[Testing:Developer] Allow gradeable upload test to be re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,12 +899,18 @@ jobs:
         with:
           name: Cypress-${{matrix.containers}}-Screenshots
           path: ${{env.SUBMITTY_REPOSITORY}}/site/cypress/screenshots
+
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: Cypress-${{matrix.containers}}-Videos
           path: ${{env.SUBMITTY_REPOSITORY}}/site/cypress/videos
 
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: Cypress-${{matrix.containers}}-Downloads
+          path: ${{env.SUBMITTY_REPOSITORY}}/site/cypress/downloads
 
   Integration:
     name: Integration

--- a/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
@@ -1,9 +1,43 @@
 import { getCurrentSemester } from '../../support/utils';
 import { getApiKey } from '../../support/utils';
 import { gradeable_json, rubric, bad_rubric } from '../../support/api_testing_json';
+const testfile1 = 'cypress/fixtures/json_ui.json';
+
 describe('Tests cases revolving around gradeable access and submission', () => {
+    before(() => {
+        cy.login();
+        cy.visit(['sample']);
+        cy.get('body').then(($body) => {
+            // Reset the state on BEFORE actions, so reruns are possible.
+            if ($body.find('[data-testid="api_testing"] [title="Delete Gradeable"]').length > 0) {
+                    cy.get('[data-testid="api_testing"] [title="Delete Gradeable"]').click();
+                    cy.get('[data-testid="confirm-delete-gradeable').click();
+            }
+            if ($body.find('[data-testid="hw-1"] [title="Delete Gradeable"]').length > 0) {
+                    cy.get('[data-testid="hw-1"] [title="Delete Gradeable"]').click();
+                    cy.get('[data-testid="confirm-delete-gradeable').click();
+            }
+        });
+    });
     it('Should upload file, submit, view gradeable', () => {
-        // // API
+        cy.visit(['sample', 'gradeable']);
+
+        // Makes sure the clear button is not disabled by adding a file
+        cy.get('[data-testid="upload-gradeable-btn"]').click();
+        cy.get('[data-testid="popup-window"]').should('be.visible');
+        cy.get('[data-testid="popup-window"]').should('contain.text', 'Upload JSON for Gradeable');
+        cy.get('[data-testid="upload"]').selectFile(testfile1, { action: 'drag-drop' });
+        cy.get('[data-testid="submit"]').click();
+        cy.get('[data-testid="upload-gradeable-btn"]', { timeout: 10000 }).should('not.exist');
+        cy.get('body').should('contain.text', 'Edit Gradeable');
+        cy.get('[data-testid="ta-view-start-date"]').should('have.value', '2024-01-11 23:59:59');
+        cy.get('[data-testid="team_lock_date"]').should('have.value', '2024-01-15 23:59:59');
+        cy.get('[data-testid="submission-open-date"]').should('have.value', '2024-01-15 23:59:59');
+        cy.get('[data-testid="submission-due-date"]').should('have.value', '2024-02-15 23:59:59');
+        cy.get('[data-testid="release_date"]').should('have.value', '2024-03-15 23:59:59');
+        cy.get('[data-testid="has_release_date_no"]').should('not.be.checked');
+        cy.get('[data-testid="has_release_date_yes"]').should('be.checked');
+
         getApiKey('instructor', 'instructor').then((key) => {
             cy.request({
                 method: 'POST',
@@ -35,26 +69,6 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             expect(test_json.rubric).to.eql(rubric);
             expect(test_json.dates.has_release_date).to.eql(false);
         });
-
-        const testfile1 = 'cypress/fixtures/json_ui.json';
-
-        cy.visit(['sample', 'gradeable']);
-
-        // Makes sure the clear button is not disabled by adding a file
-        cy.get('[data-testid="upload-gradeable-btn"]').click();
-        cy.get('[data-testid="popup-window"]').should('be.visible');
-        cy.get('[data-testid="popup-window"]').should('contain.text', 'Upload JSON for Gradeable');
-        cy.get('[data-testid="upload"]').selectFile(testfile1, { action: 'drag-drop' });
-        cy.get('[data-testid="submit"]').click();
-        cy.get('[data-testid="upload-gradeable-btn"]', { timeout: 10000 }).should('not.exist');
-        cy.get('body').should('contain.text', 'Edit Gradeable');
-        cy.get('[data-testid="ta-view-start-date"]').should('have.value', '2024-01-11 23:59:59');
-        cy.get('[data-testid="team_lock_date"]').should('have.value', '2024-01-15 23:59:59');
-        cy.get('[data-testid="submission-open-date"]').should('have.value', '2024-01-15 23:59:59');
-        cy.get('[data-testid="submission-due-date"]').should('have.value', '2024-02-15 23:59:59');
-        cy.get('[data-testid="release_date"]').should('have.value', '2024-03-15 23:59:59');
-        cy.get('[data-testid="has_release_date_no"]').should('not.be.checked');
-        cy.get('[data-testid="has_release_date_yes"]').should('be.checked');
     });
 
     it('Should get error JSON responses', () => {

--- a/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable_upload.spec.js
@@ -10,12 +10,12 @@ describe('Tests cases revolving around gradeable access and submission', () => {
         cy.get('body').then(($body) => {
             // Reset the state on BEFORE actions, so reruns are possible.
             if ($body.find('[data-testid="api_testing"] [title="Delete Gradeable"]').length > 0) {
-                    cy.get('[data-testid="api_testing"] [title="Delete Gradeable"]').click();
-                    cy.get('[data-testid="confirm-delete-gradeable').click();
+                cy.get('[data-testid="api_testing"] [title="Delete Gradeable"]').click();
+                cy.get('[data-testid="confirm-delete-gradeable').click();
             }
             if ($body.find('[data-testid="hw-1"] [title="Delete Gradeable"]').length > 0) {
-                    cy.get('[data-testid="hw-1"] [title="Delete Gradeable"]').click();
-                    cy.get('[data-testid="confirm-delete-gradeable').click();
+                cy.get('[data-testid="hw-1"] [title="Delete Gradeable"]').click();
+                cy.get('[data-testid="confirm-delete-gradeable').click();
             }
         });
     });


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The gradeable upload tests is currently lot able to be re-run because it creates gradeables, but does not delete them. 

### What is the New Behavior?
The test sets the state it is looking for Before tests are run, this allows for mid-test cancelling and retrying. It also allows for CI to retry the test and not give false "All changes saved" errors 

### What steps should a reviewer take to reproduce or test the bug or new feature?
Run the gradeable_upload Cypress test twice. It should run and pass both times.

### Other information
We should make all tests that create gradeables do this, or something similar. 