### PR TITLE
[Bugfix:Autograding] comment out repair services

### DIFF
--- a/.setup/submitty_crontab
+++ b/.setup/submitty_crontab
@@ -17,6 +17,8 @@
 # Update OS Info and Service Health every hour
 0 * * * * submitty_daemon   /usr/local/submitty/sbin/update_worker_sysinfo.sh UpdateSystemInfo
 # Run the repair_services.sh script every hour
-0 * * * * submitty_daemon   sudo /usr/local/submitty/sbin/repair_services.sh
+# FIXME: repair services is buggy
+# See https://github.com/Submitty/Submitty/issues/12787
+#0 * * * * submitty_daemon   sudo /usr/local/submitty/sbin/repair_services.sh
 # Run the send_notification.py script every hour
 0 * * * * submitty_daemon   python3 /usr/local/submitty/sbin/send_notification.py


### PR DESCRIPTION
### Why is this Change Important & Necessary?

See Issue #12787

The repair services script is broken on heavily used production server.  We have had it commented out for many months -- pushing this to Github is long overdue (I was hoping to debug it quickly but have not done so yet).
