### PR TITLE
[Bugfix:Submission] Consistent KB Capitalization

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -14,7 +14,7 @@
                 {% if (is_notebook and (file.relative_name|split('/'))|length > 1) or (not is_notebook) %}
                     <div class="flex-row">
                         <span>
-                            {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}kb)
+                            {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}KB)
                         </span>
                         {# view and download icons if student is permitted to access files #}
                         {% if student_download %}
@@ -38,7 +38,7 @@
                     {% if (is_notebook and (file.relative_name|split('/'))|length > 1) or (not is_notebook) %}
                         <div class="flex-row">
                             <span>
-                                {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}kb)
+                                {{ file.relative_name }} ({{ (file.size / 1024) | number_format(2) | default(-1) }}KB)
                             </span>
                             {# view and download icons if student is permitted to access files #}
                             {% if student_download %}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12794 

### What is the New Behavior?
Before, the submitted files box listed sizes in "kb":

<img width="1131" height="685" alt="Screenshot_20260417_141422" src="https://github.com/user-attachments/assets/72ada6c9-390c-4a78-a89b-8396bea21fd9" />

After, the submitted files box lists sizes in "KB":

<img width="1164" height="693" alt="Screenshot_20260417_142223" src="https://github.com/user-attachments/assets/0d783875-e954-4bd4-8f7c-3854f99bcb59" />


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Submit any size file for any gradable.
2. See that the listed size is capitalized.

### Automated Testing & Documentation
N/A

### Other information
N/A
