### PR TITLE
[Bugfix:Developer] Add developer CSS ignore files

### DIFF
--- a/site/.stylelintrc.json
+++ b/site/.stylelintrc.json
@@ -13,6 +13,7 @@
   },
   "ignoreFiles": [
     "vendor/**",
+    "cypress/**",
     "tests/report/**",
     "public/css/jquery-ui.min.css",
     "public/css/reset.css",
@@ -24,7 +25,8 @@
     "public/css/pdf/toolbar_embedded.css",
     "public/css/pdf/pdf_embedded.css",
     "public/css/select2-override.css",
-    "public/css/highlightjs/*"
+    "public/css/highlightjs/*",
+    "public/mjs/vue/submitty-vue.css"
   ],
   "overrides": [
     {


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->
For the sake of visibility for running `npm run css-stylelint`, there are certain files that are generated by the client/developer that should not be linted. This is not an issue for the CI as it doesnt build the app, it only runs the commands, therefore not generating any developer files

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->
Added cypress directory and submitty-vue.css to the ignore file

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->
TODO: We should probably add a *separate* linter for vue css files
#12807 
