### PR TITLE
[Bugfix:Submission] No File Rubric submit all user groups

### DIFF
--- a/site/app/controllers/student/SubmissionController.php
+++ b/site/app/controllers/student/SubmissionController.php
@@ -403,7 +403,7 @@ class SubmissionController extends AbstractController {
         $success_count = 0;
 
         foreach ($students as $student) {
-            if ($student->getGroup() !== User::GROUP_STUDENT || $student->getRegistrationSection() === null) {
+            if ($student->getRegistrationSection() === null) {
                 continue;
             }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12810 
Before, only users in the Student group would receive submissions if the No File Rubric Grading feature was used. Now, if a user is a TA and registered for the course, this feature will make a submission for them. 

### What is the New Behavior?
Any user who is not a student but is in a non-NULL registration section will now receive a submission with the No File Rubric Grading feature. 
<img width="1669" height="882" alt="Screenshot 2026-04-27 at 15-34-32 ta no file Grading - Sample" src="https://github.com/user-attachments/assets/ff7f9ac5-de6e-459b-ac8b-a4a33afe1d83" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create a bulk upload gradeable
2. As instructor, navigate to the 'bulk upload' tab and select 'No File Rubric Grading' as the submission mode. 
3. After submitting, verify that a TA that is in a valid registration section has received a submission by checking the grading menu.
4. Any users in the NULL section will still not receive submissions. 

### Automated Testing & Documentation

### Other information

