### PR TITLE
[Feature:Autograding] Remove DrMemory

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -332,39 +332,6 @@ else
 fi
 
 
-#################################################################
-# DRMEMORY SETUP
-#################
-
-# Dr Memory is a tool for detecting memory errors in C++ programs (similar to Valgrind)
-
-# FIXME: Use of this tool should eventually be moved to containerized
-# autograding and not installed on the native primary and worker
-# machines by default
-
-# FIXME: DrMemory is initially installed in install_system.sh
-# It is re-installed here (on every Submitty software update) in case of version updates.
-
-pushd /tmp > /dev/null
-
-echo "Updating DrMemory..."
-
-rm -rf /tmp/DrMemory*
-wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEMORY_TAG}/DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz -o /dev/null > /dev/null 2>&1
-tar -xpzf DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz
-rsync --delete -a /tmp/DrMemory-Linux-${DRMEMORY_VERSION}/ ${SUBMITTY_INSTALL_DIR}/drmemory
-rm -rf /tmp/DrMemory*
-
-chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/drmemory
-chmod -R 755 ${SUBMITTY_INSTALL_DIR}/drmemory
-
-
-
-echo "...DrMemory ${DRMEMORY_TAG} update complete."
-
-popd > /dev/null
-
-
 ########################################################################################################################
 ########################################################################################################################
 # COPY VARIOUS SCRIPTS USED BY INSTRUCTORS AND SYS ADMINS FOR COURSE ADMINISTRATION

--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -17,7 +17,3 @@ export Localization_Version=v23.08.02
 export JUNIT_VERSION=4.12
 export HAMCREST_VERSION=1.3
 export JACOCO_VERSION=0.8.0
-
-# DR. MEMORY
-export DRMEMORY_TAG=release_2.6.0
-export DRMEMORY_VERSION=2.6.0

--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -400,33 +400,6 @@ fi
 
 
 #################################################################
-# DRMEMORY SETUP
-#################
-
-# Dr Memory is a tool for detecting memory errors in C++ programs (similar to Valgrind)
-
-# FIXME: Use of this tool should eventually be moved to containerized
-# autograding and not installed on the native primary and worker
-# machines by default
-
-# FIXME: DrMemory is also re-installed in INSTALL_SUBMITTY_HELPER.sh
-
-pushd /tmp > /dev/null
-
-echo "Getting DrMemory..."
-
-rm -rf /tmp/DrMemory*
-wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEMORY_TAG}/DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz -o /dev/null > /dev/null 2>&1
-tar -xpzf DrMemory-Linux-${DRMEMORY_VERSION}.tar.gz
-rsync --delete -a /tmp/DrMemory-Linux-${DRMEMORY_VERSION}/ ${SUBMITTY_INSTALL_DIR}/drmemory
-rm -rf /tmp/DrMemory*
-
-chown -R root:${COURSE_BUILDERS_GROUP} ${SUBMITTY_INSTALL_DIR}/drmemory
-chmod -R 755 ${SUBMITTY_INSTALL_DIR}/drmemory
-
-popd > /dev/null
-
-#################################################################
 # TCLAPP SETUP
 #################
 pushd /tmp > /dev/null

--- a/.setup/testing/autograder.sh
+++ b/.setup/testing/autograder.sh
@@ -47,18 +47,6 @@ mkdir -p ${SUBMITTY_INSTALL_DIR}/src
 cp -r grading/ ${SUBMITTY_INSTALL_DIR}/src/
 
 # --------------------------------------
-echo "Getting DrMemory..."
-mkdir -p ${SUBMITTY_INSTALL_DIR}/DrMemory
-pushd /tmp
-DRMEM_TAG=release_2.0.1
-DRMEM_VER=2.0.1-2
-wget_retry wget https://github.com/DynamoRIO/drmemory/releases/download/${DRMEM_TAG}/DrMemory-Linux-${DRMEM_VER}.tar.gz
-tar -xpzf DrMemory-Linux-${DRMEM_VER}.tar.gz -C ${SUBMITTY_INSTALL_DIR}/DrMemory
-ln -s ${SUBMITTY_INSTALL_DIR}/DrMemory/DrMemory-Linux-${DRMEM_VER} ${SUBMITTY_INSTALL_DIR}/drmemory
-rm DrMemory-Linux-${DRMEM_VER}.tar.gz
-popd
-
-# --------------------------------------
 pushd /tmp
 
 echo "Getting TCLAPP"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
DrMemory is no longer needed because all RPI classes which use it have switched to containerized workflows.

### What is the New Behavior?
This PR removes DrMemory from the default system installation.