### PR TITLE
[Bugfix:Developer] Fix bump_repo permissions

### DIFF
--- a/.github/workflows/bump_repo.yml
+++ b/.github/workflows/bump_repo.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: 3.11


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The `bump_repo` job [failed](https://github.com/Submitty/Submitty/actions/runs/25199059152/job/73886032219) recently, which I believe is a conflict between credentials stored by the `actions/checkout` action and the `Submitty/peter-evans-create-pull-request` action.  

### What is the New Behavior?
Explicitly configuring the `actions/checkout` action to not store credentials should resolve this issue next time the `bump_repo` job is run.