### PR TITLE
[Bugfix:InstructorUI] Removed feature flag for Bulk Late Days

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -333,13 +333,11 @@ class GlobalController extends AbstractController {
                 "id" => "nav-sidebar-extensions",
                 "icon" => "fa-calendar-plus"
             ]);
-            if ($this->core->getConfig()->checkFeatureFlagEnabled('late_day_cache_display')) {
-                $sidebar_buttons[] = new NavButton($this->core, [
-                    "href" => $this->core->buildCourseUrl(['bulk_late_days']),
-                    "title" => "Bulk Late Days",
-                    "icon" => "fa-calendar-alt"
-                ]);
-            }
+            $sidebar_buttons[] = new NavButton($this->core, [
+                "href" => $this->core->buildCourseUrl(['bulk_late_days']),
+                "title" => "Bulk Late Days",
+                "icon" => "fa-calendar-alt"
+            ]);
             $sidebar_buttons[] = new NavButton($this->core, [
                 "href" => $this->core->buildCourseUrl(['grade_override']),
                 "title" => "Grade Override",


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Currently, Bulk Late Days page is not available on production.

### What is the New Behavior?
Now, Bulk Late Days is accessible on production.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Verify  that Bulk Late Days appears in the left navbar for Submitty.

### Automated Testing & Documentation

### Other information
This is not a breaking change.
