### PR TITLE
[Bugfix:TAGrading] Remove panel selector modal drag

### DIFF
--- a/site/ts/panel-selector-modal-init.ts
+++ b/site/ts/panel-selector-modal-init.ts
@@ -1,7 +1,4 @@
 $(() => {
-    // Draggable Popup box
-    $('#panels-selector-modal').draggable();
-
     // Single Panel mode
     const singlePanelCanvas: HTMLCanvasElement | null = document.querySelector('#layout-option-1 #single-panel');
     const singlePanelCanvasCTX = singlePanelCanvas?.getContext('2d');


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12839

The Panel Selector modal was draggable with no boundary 
constraints. This caused two bugs:
1. Dragging and releasing the modal anywhere caused it to 
   vanish immediately due to click event bubbling
2. Dragging outside the viewport made the modal inaccessible 
   and it would reopen at the same off-screen position

There is no functional reason for the modal to be draggable.

### What is the New Behavior?

The Panel Selector modal is no longer draggable. It opens 
in its default centered position every time.

##Before - Screenshot

Could be dragged off the center

<img width="1512" height="859" alt="Screenshot 2026-05-11 at 11 34 10 AM" src="https://github.com/user-attachments/assets/21511a02-042c-4f47-b833-72c2c5f32fb0" />

##After - Screenshot

Panel selector is fixed at the center

<img width="1512" height="859" alt="Screenshot 2026-05-11 at 11 33 45 AM" src="https://github.com/user-attachments/assets/c4875287-d23e-42c9-93af-67927aef0a90" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Go to the grading interface as any grading role
2. Click the panel mode button
3. Verify the modal opens in center position
4. Verify the modal cannot be dragged

### Automated Testing & Documentation

No automated tests added. The existing Cypress tests for 
the panel switcher cover the modal functionality.

### Other information

No breaking changes. No migrations required.