### PR TITLE
[Bugfix:System] Restore TCLAPP

### DIFF
--- a/.setup/install_system.sh
+++ b/.setup/install_system.sh
@@ -353,6 +353,25 @@ sudo chown "${DAEMON_USER}:${DAEMON_USER}" "$gitconfig_path"
 usermod -a -G docker "${DAEMON_USER}"
 
 #################################################################
+# TCLAPP SETUP
+#################
+pushd /tmp > /dev/null
+
+echo "Getting TCLAPP"
+wget https://sourceforge.net/projects/tclap/files/tclap-1.2.2.tar.gz -o /dev/null > /dev/null 2>&1
+tar -xpzf tclap-1.2.2.tar.gz
+rm /tmp/tclap-1.2.2.tar.gz
+cd tclap-1.2.2/
+sed -i 's/SUBDIRS = include examples docs tests msc config/SUBDIRS = include docs msc config/' Makefile.in
+bash configure
+make
+make install
+cd /tmp
+rm -rf /tmp/tclap-1.2.2
+
+popd > /dev/null
+
+#################################################################
 # APACHE SETUP
 #################
 


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
https://github.com/Submitty/Submitty/pull/12819 had removed TCLAPP which is actually used in some parts of Submitty.

Our vagrant up job was silently failing on gradeable builds. See https://github.com/Submitty/Submitty/actions/runs/25894567631/job/76104819616

### What is the New Behavior?
TCLAPP is now back in Submitty.

See https://github.com/Submitty/Submitty/actions/runs/25948519781/job/76281590042 for a working vagrant up on this branch.
