### PR TITLE
[Bugfix:Developer] Fix Broken CI

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -208,6 +208,11 @@ runs:
         sudo service apache2 restart
       shell: bash
 
+    - name: Fix Doctrine Cache Permissions
+      run: |
+        chown -R submitty_php:submitty_php /usr/local/submitty/site/cache/doctrine-proxy
+        chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
+
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -212,6 +212,7 @@ runs:
       run: |
         chown -R submitty_php:submitty_php /usr/local/submitty/site/cache/doctrine-proxy
         chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
+      shell: bash
 
     - name: Run git tests
       if: contains(inputs.courses, 'sample')

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -204,8 +204,8 @@ runs:
         sudo a2ensite submitty
         sudo bash -c 'echo "export PATH=$PATH" >> /etc/apache2/envvars'
         sudo apache2ctl -t
-        sudo service php${PHP_VER}-fpm restart
-        sudo service apache2 restart
+        sudo servicectl php${PHP_VER}-fpm restart
+        sudo servicectl apache2 restart
       shell: bash
 
     - name: Fix Doctrine Cache Permissions
@@ -214,6 +214,12 @@ runs:
         sudo chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
       shell: bash
 
+    - name: Show permissions
+      run: | 
+        ls -la /usr/local/submitty/site/cache
+        ls -la /usr/local/submitty
+        cat /etc/php/8.2/fpm/php-fpm.conf
+      shell: bash
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -210,8 +210,8 @@ runs:
 
     - name: Fix Doctrine Cache Permissions
       run: |
-        chown -R submitty_php:submitty_php /usr/local/submitty/site/cache/doctrine-proxy
-        chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
+        sudo chown -R submitty_php:submitty_php /usr/local/submitty/site/cache/doctrine-proxy
+        sudo chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
       shell: bash
 
     - name: Run git tests

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -180,6 +180,11 @@ runs:
         sudo service nginx restart
       shell: bash
 
+    - name: Add www-data to submitty_php
+      run: |
+        sudo usermod -aG submitty_php www-data
+      shell: bash
+
     - name: Set up apache
       run: |
         sudo apt-get install apache2

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -209,8 +209,8 @@ runs:
         sudo a2ensite submitty
         sudo bash -c 'echo "export PATH=$PATH" >> /etc/apache2/envvars'
         sudo apache2ctl -t
-        sudo servicectl php${PHP_VER}-fpm restart
-        sudo servicectl apache2 restart
+        sudo service php${PHP_VER}-fpm restart
+        sudo service apache2 restart
       shell: bash
 
     - name: Fix Doctrine Cache Permissions

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -180,11 +180,6 @@ runs:
         sudo service nginx restart
       shell: bash
 
-    - name: Add www-data to submitty_php
-      run: |
-        sudo usermod -aG submitty_php www-data
-      shell: bash
-
     - name: Set up apache
       run: |
         sudo apt-get install apache2
@@ -213,18 +208,6 @@ runs:
         sudo service apache2 restart
       shell: bash
 
-    - name: Fix Doctrine Cache Permissions
-      run: |
-        sudo chown -R submitty_php:submitty_php /usr/local/submitty/site/cache/doctrine-proxy
-        sudo chmod -R 777 /usr/local/submitty/site/cache/doctrine-proxy
-      shell: bash
-
-    - name: Show permissions
-      run: | 
-        ls -la /usr/local/submitty/site/cache
-        ls -la /usr/local/submitty
-        cat /etc/php/8.2/fpm/php-fpm.conf
-      shell: bash
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |

--- a/site/app/libraries/Core.php
+++ b/site/app/libraries/Core.php
@@ -181,7 +181,9 @@ class Core {
             FileUtils::joinPaths(dirname(__DIR__, 2), 'cache', 'doctrine-proxy'),
             $cache
         );
-
+        if ($this->config->isDebug()) {
+            $config->setAutoGenerateProxyClasses(\Doctrine\ORM\Proxy\ProxyFactory::AUTOGENERATE_EVAL);
+        }
         return new EntityManager($database->getConnection(), $config);
     }
 

--- a/site/app/templates/notebook/Notebook.twig
+++ b/site/app/templates/notebook/Notebook.twig
@@ -17,7 +17,7 @@
             <button class="btn btn-danger" onclick="dontShowPopupSubmit()">Don't Ask Me Again</button>
         </div>
     {% endif %}      
-    {% if notebook_size_exceeded %}
+    {% if notebook_size_exceeded|default(false) %}
         <div class="alert alert-danger d-flex align-items-center mb-3" role="alert">
             <i class="fas fa-exclamation-triangle me-2"></i>
             <div>
@@ -26,16 +26,16 @@
                 Please download the notebook to view its contents.
             </div>
         </div>
-    {% elseif notebook_skipped_content > 0 or notebook_skipped_output > 0 %}
+    {% elseif notebook_skipped_content|default(0) > 0 or notebook_skipped_output|default(0) > 0 %}
         <div class="alert alert-warning d-flex align-items-center mb-3" role="alert">
             <i class="fas fa-exclamation-circle me-2"></i>
             <div>
                 <strong>Notebook rendered with skipped content.</strong>
                 Some content was skipped due to size limits.
-                {% if notebook_skipped_content > 0 %}
+                {% if notebook_skipped_content|default(0) > 0 %}
                     Skipped {{ notebook_skipped_content }} attachment(s).
                 {% endif %}
-                {% if notebook_skipped_output > 0 %}
+                {% if notebook_skipped_output|default(0) > 0 %}
                     Skipped {{ notebook_skipped_output }} output(s).
                 {% endif %}
                 Please download the notebook to view full content.


### PR DESCRIPTION
### Why is this Change Important & Necessary?
CI is currently failing, due to a number of issues. Primarily, for some reason, doctrine is trying (and failing) to generate proxies on "hydration", however they should be pre-generated in CI. I don't know what caused it (assuming an unpinned dependency), as I was able to replicate it ONCE by running `submitty_install` and `submitty_install_site` over and over, but when I destroy'd and re-upped, I was not able to replicate it after.

### What is the New Behavior?
The doctrine issue is solved by telling the config that if it is debug (which CI is, and production should never be), then assume the proxies are already generated. 

This also fixes a notebook builder twig issue.

### What steps should a reviewer take to reproduce or test the bug or new feature?
See that CI is now passing for a majority of the issues.

