### PR TITLE
[Bugfix:System] Attempt to fix zombie dockers

### DIFF
--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -841,7 +841,6 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
         try:
             container.create(execution_script, arguments, False)
             container.start(logfile)
-            container.process.wait()
         except Exception:
             self.log_message(
                 'ERROR generating random input using docker. '
@@ -849,7 +848,7 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             )
             self.log_stack_trace(traceback.format_exc())
         finally:
-            container.cleanup_container()
+            container.cleanup_container(logfile)
 
         return container.return_code
 

--- a/autograder/autograder/execution_environments/container_network.py
+++ b/autograder/autograder/execution_environments/container_network.py
@@ -8,10 +8,15 @@ from pwd import getpwnam
 from timeit import default_timer as timer
 import shutil
 import docker
+import requests
 
 from submitty_utils import dateutils
 from . import secure_execution_environment, rlimit_utils
 from .. import autograding_utils
+
+# Maximum seconds to wait for a container to exit before force-killing it.
+# Containers should be killed by their own rlimits before this fires.
+CONTAINER_CLEANUP_TIMEOUT = 300
 
 
 class Container():
@@ -195,8 +200,19 @@ class Container():
         """ Remove this container. """
         cleanup_start = timer()
         if not self.is_server:
-            status = self.container.wait()
-            self.return_code = status['StatusCode']
+            try:
+                status = self.container.wait(timeout=CONTAINER_CLEANUP_TIMEOUT)
+                self.return_code = status['StatusCode']
+            except requests.exceptions.ReadTimeout:
+                self.log_function(
+                    f'WARNING: Container {self.full_name} did not exit within '
+                    f'{CONTAINER_CLEANUP_TIMEOUT}s, force killing'
+                )
+                try:
+                    self.container.kill()
+                except docker.errors.APIError:
+                    pass  # Container may have already exited between timeout and kill
+                self.return_code = -1
 
         logs = self.container.logs(stdout=True, stderr=False).decode('utf-8')
         print(f'Log entry for {self.name}:\n', file=logfile)
@@ -882,6 +898,8 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             self.log_stack_trace(traceback.format_exc())
             return -1
 
+        return_code = 0
+        router = None
         try:
             router = self.get_router(containers)
             # First start the router a second before any other container,
@@ -931,13 +949,13 @@ class ContainerNetwork(secure_execution_environment.SecureExecutionEnvironment):
             )
             self.log_stack_trace(traceback.format_exc())
 
-        # A zero return code means execution went smoothly
-        return_code = 0
         # Check the return codes of the standard (non server/router) containers
         # to see if they finished properly. Note that this return code is yielded by
         # main runner/validator/compiler. We return the first non-zero return code we encounter.
-        for container in self.get_standard_containers(containers):
-            if container.return_code != 0:
-                return_code = container.return_code
-                break
+        # Skip the check if startup already failed so that error is not masked.
+        if return_code == 0:
+            for container in self.get_standard_containers(containers):
+                if container.return_code is not None and container.return_code != 0:
+                    return_code = container.return_code
+                    break
         return return_code


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Under high submission load, Docker grading containers can hang and never exit. Because
`container.wait()` had no timeout, a single stuck container would permanently block that
worker slot. Over time, all worker slots become blocked, Docker runs out of resources,
and the system requires a full manual `docker restart` to recover.

A secondary bug caused startup errors in `execute_helper` to be silently masked:
`return_code` was set to `-1` when container startup failed, but then unconditionally
overwritten with `0` before the final return, making all errors appear as success.

### What is the New Behavior?

- `container.wait()` now times out after 300 seconds. If a container has not exited by
  then, it is force-killed via `container.kill()` and the testcase is recorded as failed
  (`return_code = -1`). The 300-second limit is a safety net — containers are expected
  to be killed by their own rlimits long before this triggers.
- `router` and `return_code` are now initialized before the container startup `try`
  block, preventing a potential `NameError` if `get_router()` raises and ensuring the
  error code is not lost.
- The final return-code check is guarded so that a `-1` set during startup failure is
  never overwritten by the container exit-code loop. A `None` check was also added to
  avoid treating un-started containers as failures.

### What steps should a reviewer take to reproduce or test the bug or new feature?

**Reproducing the original bug:**
1. Configure a gradeable with a Docker execution environment.
2. Submit a student program that does not terminate (e.g., `while(true);`) and ensure
   the rlimit for that gradeable is disabled or very long.
3. Observe that the autograding worker for that `untrusted_user` slot hangs permanently
   on `container.wait()` and never picks up subsequent jobs.

**Verifying the fix:**
1. Apply this patch and repeat the above.
2. After 300 seconds, the worker should log:
   `WARNING: Container ... did not exit within 300s, force killing`
3. The container should be removed and the worker should proceed to the next job.
4. For normal-terminating submissions, grading behavior is unchanged.

**Verifying the return_code fix:**
1. Configure a gradeable with an image that does not exist on the worker machine.
2. Without this fix, `grade_item.py` would receive `return_code = 0` despite the
   container failing to create.
3. With this fix, a non-zero `return_code` is correctly propagated.

### Automated Testing & Documentation

A new test covering the timeout/force-kill path (e.g., a mock
container that never exits) would be valuable but does not exist yet. I am not sure how 
to effectively set that up and test it.

### Other information

- The next change would be to make the `CONTAINER_CLEANUP_TIMEOUT = 300` constant defined in the Submitty config as a default, and per gradeable overrides in their respective config.json