### PR TITLE
[Bugfix:System] fix twig cache directory

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -154,11 +154,11 @@ fi
 readarray -t result_array <<< "${result}"
 
 # clear old twig cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/twig" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/twig"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/twig" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/twig"
 fi
 # create twig cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/twig
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/twig
 
 # clear old routes cache
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
@@ -271,6 +271,9 @@ php "${SUBMITTY_INSTALL_DIR}/sbin/load_lang.php" "${SUBMITTY_REPOSITORY}/../Loca
 # Update permissions & ownership for cache directory
 chmod -R 751 ${SUBMITTY_INSTALL_DIR}/site/cache
 chown -R ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_INSTALL_DIR}/site/cache
+
+chmod -R 751 ${SUBMITTY_DATA_DIR}/cache
+chown -R ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_DATA_DIR}/cache
 
 if [[ "${CI}" != true && "${BROWSCAP}" = true ]]; then
     echo -e "Checking for and fetching latest browscap.ini if needed"

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -105,8 +105,13 @@ class Output {
 
     public function loadTwig($full_load = true) {
         $template_root = FileUtils::joinPaths(dirname(__DIR__), 'templates');
-        $cache_path = FileUtils::joinPaths(dirname(dirname(__DIR__)), 'cache', 'twig');
+
+        // cache must be in a directory that is not hardened by php fpm 'ProtectSystem=full' property
+        $cache_path = FileUtils::joinPaths('/', 'var', 'local', 'submitty', 'cache', 'twig');
+
         $debug = $full_load && $this->core->getConfig()?->isDebug();
+        // set this to false to force caching even on development machine
+        //$debug = false;
 
         $this->twig_loader = new \Twig\Loader\FilesystemLoader($template_root);
         $this->twig = new \Twig\Environment($this->twig_loader, [


### PR DESCRIPTION
### Why is this Change Important & Necessary?

The default for php fpm configuration changed recently on a production server causing new writes to the 
twig cache to fail.  If the twig cache was cleared (which happens on software update), every page load would crash. The previous location of the twig cache in `/usr/local/submitty/site/cache/twig` was blocked because the file `/lib/systemd/system/php8.2-fpm.service` contains the line `ProtectSystem=full` which means that `/usr` and `/boot` are read-only.

### What is the New Behavior?

The twig cache has been moved to `/var/local/submitty/cache/twig`.

### What steps should a reviewer take to reproduce or test the bug or new feature?

On a vagrant development machine, debug mode is on by default and twig is not cached.  To enable caching of twig files, you can set `$debug = false;` in the `loadTwig` function in `site/app/libraries/Output.php`.   After editing the file run `submitty_install_site`.  If caching is enabled, files should be added to the specified cache directory on new page loads.  The directory can be manually cleared to enable testing.

### Automated Testing & Documentation

Why wasn't this caught with automated testing?  Is all of our testing in debug mode?  Why wasn't it caught by the developers?  Because vagrant is in debug mode by default.  This is a downside of being in debug mode all the time.

### Other information

I'm worried that the other caches in /usr/local/submitty/site/cache/ are also impacted.  

Is /var/local/submitty/cache a good place to put these files?  Is there a better location?