### PR TITLE
[Bugfix:Forum] Truncate post content in delete/restore notifications

### DIFF
--- a/site/app/controllers/forum/ForumController.php
+++ b/site/app/controllers/forum/ForumController.php
@@ -843,8 +843,14 @@ class ForumController extends AbstractController {
                 }
                 // We want to reload same thread again, in both case (thread/post undelete)
                 $metadata = json_encode(['url' => $this->core->buildCourseUrl(['forum', 'threads', $thread_id]) . '#' . (string) $post_id, 'thread_id' => $thread_id, 'post_id' => $post_id]);
-                $subject = "Restored: " . $post->getContent();
-                $content = "In " . $full_course_name . "\n\nThe following post was Restored.\n\nThread: " . $thread->getTitle() . "\n\n" . $post->getContent();
+                $preview_short = $this->previewText($post->getContent(), 100);
+                $preview_long = $this->previewText($post->getContent(), 300);
+                $subject = "Restored: " . $preview_short;
+                $content = "In " . $full_course_name .
+                        "\n\nThe following post was Restored.\n\nThread: " .
+                        $thread->getTitle() .
+                        "\n\n" .
+                        $preview_long;
                 $event = ['component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post->getAuthor()->getId(), 'preference' => 'all_modifications_forum'];
             }
         }
@@ -855,8 +861,10 @@ class ForumController extends AbstractController {
                 $type = "thread";
             }
             $metadata = json_encode([]);
-            $subject = "Deleted: " . $post->getContent();
-            $content = "In " . $full_course_name . "\n\nThread: " . $thread->getTitle() . "\n\nPost:\n" . $post->getContent() . " was deleted.";
+            $preview_short = $this->previewText($post->getContent(), 100);
+            $preview_long = $this->previewText($post->getContent(), 300);
+            $subject = "Deleted: " . $preview_short;
+            $content = "In " . $full_course_name . "\n\nThread: " . $thread->getTitle() . "\n\nPost:\n" . $preview_long . " was deleted.";
             $event = [ 'component' => 'forum', 'metadata' => $metadata, 'content' => $content, 'subject' => $subject, 'recipient' => $post->getAuthor()->getId(), 'preference' => 'all_modifications_forum'];
             $this->core->getQueries()->removeNotificationsPost($post_id);
             $this->sendSocketMessage(array_merge(


### PR DESCRIPTION
Fixes #12553

## Problem
When a forum post is deleted or restored, the notification subject 
and body used the full post content via $post->getContent(), causing 
extremely large notifications and emails for long posts.

## Fix
Used the existing previewText() helper to truncate post content in 
both delete and restore notifications:
- Subject line: truncated to 100 characters
- Body: truncated to 300 characters

This matches the existing pattern used in PR #12277.

## Changes
- ForumController.php: Applied previewText() to delete notification
- ForumController.php: Applied previewText() to restore notification

## Testing
- Tested with long forum posts (500+ characters)
- Delete notification shows truncated preview ✅
- Restore notification shows truncated preview ✅