### PR TITLE
Relocate cache directories to data directory for compatibility

### DIFF
--- a/.setup/install_submitty/install_site.sh
+++ b/.setup/install_submitty/install_site.sh
@@ -161,39 +161,46 @@ fi
 mkdir -p ${SUBMITTY_DATA_DIR}/cache/twig
 
 # clear old routes cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/routes" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/routes"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/routes" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/routes"
 fi
 # create routes cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/routes
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/routes
 
 # clear old doctrine cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/doctrine" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/doctrine"
 fi
 # create doctrine cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/doctrine
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/doctrine
 
 # clear old access control cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/access_control" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/access_control"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/access_control" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/access_control"
 fi
 # create access control cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/access_control
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/access_control
 
 # clear old doctrine proxy classes
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/doctrine-proxy" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/doctrine-proxy"
 fi
 # create doctrine proxy classes directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/doctrine-proxy
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/doctrine-proxy
 
 # clear old lang cache
-if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache/lang" ]; then
-    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache/lang"
+if [ -d "${SUBMITTY_DATA_DIR}/cache/lang" ]; then
+    rm -rf "${SUBMITTY_DATA_DIR}/cache/lang"
 fi
 # create lang cache directory
-mkdir -p ${SUBMITTY_INSTALL_DIR}/site/cache/lang
+mkdir -p ${SUBMITTY_DATA_DIR}/cache/lang
+
+# remove any existing site/cache directory or symlink
+if [ -d "${SUBMITTY_INSTALL_DIR}/site/cache" ] || [ -L "${SUBMITTY_INSTALL_DIR}/site/cache" ]; then
+    rm -rf "${SUBMITTY_INSTALL_DIR}/site/cache"
+fi
+# create site/cache symlink
+ln -s "${SUBMITTY_DATA_DIR}/cache" "${SUBMITTY_INSTALL_DIR}/site/cache"
 
 if [ -d "${SUBMITTY_INSTALL_DIR}/site/public/mjs" ]; then
     rm -r "${SUBMITTY_INSTALL_DIR}/site/public/mjs"
@@ -266,14 +273,12 @@ fi
 php "${SUBMITTY_INSTALL_DIR}/sbin/doctrine.php" "orm:generate-proxies"
 
 # load lang files
-php "${SUBMITTY_INSTALL_DIR}/sbin/load_lang.php" "${SUBMITTY_REPOSITORY}/../Localization/lang" "${SUBMITTY_INSTALL_DIR}/site/cache/lang"
+php "${SUBMITTY_INSTALL_DIR}/sbin/load_lang.php" "${SUBMITTY_REPOSITORY}/../Localization/lang" "${SUBMITTY_DATA_DIR}/cache/lang"
 
 # Update permissions & ownership for cache directory
-chmod -R 751 ${SUBMITTY_INSTALL_DIR}/site/cache
-chown -R ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_INSTALL_DIR}/site/cache
-
 chmod -R 751 ${SUBMITTY_DATA_DIR}/cache
 chown -R ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_DATA_DIR}/cache
+chown -h ${PHP_USER}:${PHP_GROUP} ${SUBMITTY_INSTALL_DIR}/site/cache
 
 if [[ "${CI}" != true && "${BROWSCAP}" = true ]]; then
     echo -e "Checking for and fetching latest browscap.ini if needed"
@@ -446,7 +451,7 @@ chmod 551 ${SUBMITTY_INSTALL_DIR}/site/public/mjs
 set_mjs_permission ${SUBMITTY_INSTALL_DIR}/site/public/mjs
 
 # cache needs to be writable
-find ${SUBMITTY_INSTALL_DIR}/site/cache -type d -exec chmod u+w {} \;
+find ${SUBMITTY_DATA_DIR}/cache -type d -exec chmod u+w {} \;
 
 # reload PHP-FPM before we re-enable website, but only if PHP-FPM is actually being used
 # as expected (Travis for example will fail here otherwise).

--- a/site/app/libraries/Output.php
+++ b/site/app/libraries/Output.php
@@ -107,7 +107,7 @@ class Output {
         $template_root = FileUtils::joinPaths(dirname(__DIR__), 'templates');
 
         // cache must be in a directory that is not hardened by php fpm 'ProtectSystem=full' property
-        $cache_path = FileUtils::joinPaths('/', 'var', 'local', 'submitty', 'cache', 'twig');
+        $cache_path = FileUtils::joinPaths($this->core->getConfig()->getSubmittyPath(), 'cache', 'twig');
 
         $debug = $full_load && $this->core->getConfig()?->isDebug();
         // set this to false to force caching even on development machine


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12869. 

Recent systemd updates enforcing `ProtectSystem=full` caused writes to `/usr/local/submitty/site/cache` to fail. While PR #12867 fixed the catastrophic crash associated with the `twig` cache, several other caches (`access_control`, `doctrine`, `doctrine-proxy`, `lang`, and `routes`) were left in the read-only directory and were failing silently, degrading performance. 

### What is the New Behavior?
- Moves `access_control`, `doctrine`, `doctrine-proxy`, `lang`, and `routes` caches into `${SUBMITTY_DATA_DIR}/cache/`.
- Replaces `${SUBMITTY_INSTALL_DIR}/site/cache` with a symlink pointing to `${SUBMITTY_DATA_DIR}/cache`. This preserves backwards compatibility so that the PHP application can still cleanly access the caches without requiring mass code refactoring.
- Removes the hardcoded absolute path for the twig cache in `Output.php` (introduced in #12867) and replaces it with the dynamic configuration path (`$this->core->getConfig()->getSubmittyPath()`).
- Deletes the old `site/cache` directory automatically upon running `install_site.sh` to ensure a smooth transition for existing installations.

### Automated Testing & Documentation
This is an infrastructure-level filesystem change, so existing CI tests will verify that the symlink provides the required backwards compatibility for the PHP code to function as normal. 

### Other information
This PR includes migration logic inside `install_site.sh` to automatically delete the legacy `site/cache` directory if it exists, ensuring that existing servers migrate smoothly. It is not a breaking change.