### PR TITLE
[Refactor:Developer] Use cy.should('contain', text)

### DIFF
--- a/site/cypress/e2e/Cypress-Admin/auth_token.spec.js
+++ b/site/cypress/e2e/Cypress-Admin/auth_token.spec.js
@@ -17,7 +17,7 @@ describe('Test cases revolving around authentication tokens', () => {
 
         cy.get('[data-testid="new-auth-token-submit"]').click();
 
-        cy.get('[data-testid="new-token-banner"]').contains('Value: ');
+        cy.get('[data-testid="new-token-banner"]').should('contain', 'Value: ');
 
         let cookie;
 

--- a/site/cypress/e2e/Cypress-Admin/courseMaterials.spec.js
+++ b/site/cypress/e2e/Cypress-Admin/courseMaterials.spec.js
@@ -13,7 +13,7 @@ describe('Test cases revolving around course material uploading and access contr
             cy.get('#submit-materials').click();
         });
 
-        cy.get('.file-viewer').contains('file1.txt');
+        cy.get('.file-viewer').should('contain', 'file1.txt');
 
         const fileTgt = buildUrl(['sample', 'course_material', 'file1.txt']);
 
@@ -39,7 +39,7 @@ describe('Test cases revolving around course material uploading and access contr
             cy.get('#submit-materials').click();
         });
 
-        cy.get('.file-viewer').contains('file1.txt');
+        cy.get('.file-viewer').should('contain', 'file1.txt');
         const fileTgt = buildUrl(['sample', 'course_material', 'option1', 'file1.txt']);
 
         cy.visit(fileTgt);
@@ -121,7 +121,7 @@ describe('Test cases revolving around course material uploading and access contr
         const fileTgt2 = buildUrl(['sample', 'course_material', 'file1.txt']);
         cy.visit(fileTgt2);
 
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
+        cy.get('.content').should('contain', 'Reason: You may not access this file until it is released');
 
         cy.logout();
         cy.login();
@@ -168,7 +168,7 @@ describe('Test cases revolving around course material uploading and access contr
 
         const fileTgt2 = buildUrl(['sample', 'course_material', 'option1', 'file2.txt']);
         cy.visit(fileTgt2);
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
+        cy.get('.content').should('contain', 'Reason: You may not access this file until it is released');
 
         cy.logout();
         cy.login();
@@ -224,7 +224,7 @@ describe('Test cases revolving around course material uploading and access contr
 
         const fileTgt2 = buildUrl(['sample', 'course_material', 'zip', '1_1.txt']);
         cy.visit(fileTgt2);
-        cy.get('.content').contains('Reason: You may not access this file until it is released');
+        cy.get('.content').should('contain', 'Reason: You may not access this file until it is released');
 
         cy.logout();
         cy.login();
@@ -267,7 +267,7 @@ describe('Test cases revolving around course material uploading and access contr
         const fileTgt2 = buildUrl(['sample', 'course_material', 'file1.txt']);
 
         cy.visit(fileTgt2);
-        cy.get('.content').contains('Reason: Your section may not access this file');
+        cy.get('.content').should('contain', 'Reason: Your section may not access this file');
 
         cy.visit('/');
         cy.logout();
@@ -329,7 +329,7 @@ describe('Test cases revolving around course material uploading and access contr
         const fileTgt2 = buildUrl(['sample', 'course_material', 'zip', '1_1.txt']);
         cy.visit(fileTgt2);
 
-        cy.get('.content').contains('Reason: Your section may not access this file');
+        cy.get('.content').should('contain', 'Reason: Your section may not access this file');
         cy.visit('/');
         cy.logout();
 
@@ -392,7 +392,7 @@ describe('Test cases revolving around course material uploading and access contr
         cy.get('#cm-toggle-folders-btn').click();
 
         for (let i = 5; i > 0; i--) {
-            cy.get(`.folder-container:nth-child(4) :nth-child(${6 - i}) > .file-viewer`).contains(`file${i}.txt`);
+            cy.get(`.folder-container:nth-child(4) :nth-child(${6 - i}) > .file-viewer`).should('contain', `file${i}.txt`);
         }
         cy.get('a[id=a]').parent().find('.fa-trash').click();
         cy.get('.btn-danger:visible').click();
@@ -432,7 +432,7 @@ describe('Test cases revolving around course material uploading and access contr
             cy.get('.fa-pencil-alt').eq((2 - i) * 2 + 1).click();
             cy.get('#edit-folder-sort').should('have.value', `${2 - i}`);
             cy.get('#edit-course-materials-folder-form > .popup-box > .popup-window > .form-title > .btn').click();
-            cy.get(`#div_viewer_sd1d${3 - i} > .file-container > .file-viewer`).contains(`file${i}.txt`);
+            cy.get(`#div_viewer_sd1d${3 - i} > .file-container > .file-viewer`).should('contain', `file${i}.txt`);
         }
 
         // Clean up files
@@ -565,7 +565,7 @@ describe('Test cases revolving around course material uploading and access contr
         const fileTgt = buildUrl(['sample', 'course_material', 'a', 'file1.txt']);
 
         cy.visit(fileTgt);
-        cy.get('.content').contains('Reason: Your section may not access this file');
+        cy.get('.content').should('contain', 'Reason: Your section may not access this file');
 
         cy.logout();
         cy.login();

--- a/site/cypress/e2e/Cypress-Feature/forums.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/forums.spec.js
@@ -589,17 +589,17 @@ describe('Should test Search functionality', () => {
     it('Should find posts containing \'Homework 1\'', () => {
         cy.get('[data-testid="search-content-input"]').type('Homework 1');
         cy.get('[data-testid="search-submit"]').click();
-        cy.get('#thread_list').contains('Homework 1 not running');
-        cy.get('#thread_list').contains('Homework 1 print clarification');
-        cy.get('#thread_list').contains('Homework 1 has been posted on the course website.');
+        cy.get('#thread_list').should('contain', 'Homework 1 not running');
+        cy.get('#thread_list').should('contain', 'Homework 1 print clarification');
+        cy.get('#thread_list').should('contain', 'Homework 1 has been posted on the course website.');
         cy.get('#thread_list').contains('Python Tutorials').should('not.exist');
         cy.get('#thread_list').contains('Course syllabus').should('not.exist');
 
         cy.go('back');
-        cy.get('#thread_list').contains('Homework 1 not running');
-        cy.get('#thread_list').contains('Homework 1 print clarification');
-        cy.get('#thread_list').contains('Homework 1 has been posted on the course website.');
-        cy.get('#thread_list').contains('Python Tutorials');
-        cy.get('#thread_list').contains('Course syllabus');
+        cy.get('#thread_list').should('contain', 'Homework 1 not running');
+        cy.get('#thread_list').should('contain', 'Homework 1 print clarification');
+        cy.get('#thread_list').should('contain', 'Homework 1 has been posted on the course website.');
+        cy.get('#thread_list').should('contain', 'Python Tutorials');
+        cy.get('#thread_list').should('contain', 'Course syllabus');
     });
 });

--- a/site/cypress/e2e/Cypress-Feature/late_days_allowed.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/late_days_allowed.spec.js
@@ -6,7 +6,7 @@ describe('Test cases involving the late days allowed page', () => {
         });
 
         it('should not allow access', () => {
-            cy.get('.content').contains('You don\'t have access to this page');
+            cy.get('.content').should('contain', 'You don\'t have access to this page');
         });
     });
 
@@ -21,7 +21,7 @@ describe('Test cases involving the late days allowed page', () => {
             cy.get('#datestamp').should('be.empty');
             cy.get('#late_days').should('be.empty');
             cy.get('#csv_option_overwrite_all').should('be.checked');
-            cy.get('#empty-table').contains('No late days are currently entered');
+            cy.get('#empty-table').should('contain', 'No late days are currently entered');
         });
 
         it('check invalid user ID', () => {
@@ -67,19 +67,19 @@ describe('Test cases involving the late days allowed page', () => {
             cy.get('input[type=submit]').click();
 
             // make sure table has right values
-            cy.get('#late-day-table > tbody > tr > :nth-child(1)').contains('bitdiddle');
-            cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('Ben');
-            cy.get('#late-day-table > tbody > tr > :nth-child(3)').contains('Bitdiddle');
-            cy.get('#late-day-table > tbody > tr > :nth-child(4)').contains('3');
-            cy.get('#late-day-table > tbody > tr > :nth-child(5)').contains('2021-01-01');
+            cy.get('#late-day-table > tbody > tr > :nth-child(1)').should('contain', 'bitdiddle');
+            cy.get('#late-day-table > tbody > tr > :nth-child(2)').should('contain', 'Ben');
+            cy.get('#late-day-table > tbody > tr > :nth-child(3)').should('contain', 'Bitdiddle');
+            cy.get('#late-day-table > tbody > tr > :nth-child(4)').should('contain', '3');
+            cy.get('#late-day-table > tbody > tr > :nth-child(5)').should('contain', '2021-01-01');
 
             // login as bitdiddle and check that they have proper number of late days
             cy.logout();
             cy.login('bitdiddle');
             cy.visit(['sample', 'late_table']);
-            cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('2021-01-01');
-            cy.get('#late-day-table > tbody > tr > :nth-child(8)').contains('+3');
-            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').contains('3');
+            cy.get('#late-day-table > tbody > tr > :nth-child(2)').should('contain', '2021-01-01');
+            cy.get('#late-day-table > tbody > tr > :nth-child(8)').should('contain', '+3');
+            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').should('contain', '3');
 
             // logout and log back in as the instructor
             cy.logout();
@@ -97,19 +97,19 @@ describe('Test cases involving the late days allowed page', () => {
             cy.reload(); // make sure the late day registered
 
             // make sure the table has the updated values
-            cy.get('#late-day-table > tbody > tr > :nth-child(1)').contains('bitdiddle');
-            cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('Ben');
-            cy.get('#late-day-table > tbody > tr > :nth-child(3)').contains('Bitdiddle');
-            cy.get('#late-day-table > tbody > tr > :nth-child(4)').contains('5');
-            cy.get('#late-day-table > tbody > tr > :nth-child(5)').contains('2021-01-01');
+            cy.get('#late-day-table > tbody > tr > :nth-child(1)').should('contain', 'bitdiddle');
+            cy.get('#late-day-table > tbody > tr > :nth-child(2)').should('contain', 'Ben');
+            cy.get('#late-day-table > tbody > tr > :nth-child(3)').should('contain', 'Bitdiddle');
+            cy.get('#late-day-table > tbody > tr > :nth-child(4)').should('contain', '5');
+            cy.get('#late-day-table > tbody > tr > :nth-child(5)').should('contain', '2021-01-01');
 
             // logout and log back in as bitdiddle to make sure the number of late days has been updated correctly
             cy.logout();
             cy.login('bitdiddle');
             cy.visit(['sample', 'late_table']);
-            cy.get('#late-day-table > tbody > tr > :nth-child(2)').contains('2021-01-01');
-            cy.get('#late-day-table > tbody > tr > :nth-child(8)').contains('+5');
-            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').contains('5');
+            cy.get('#late-day-table > tbody > tr > :nth-child(2)').should('contain', '2021-01-01');
+            cy.get('#late-day-table > tbody > tr > :nth-child(8)').should('contain', '+5');
+            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').should('contain', '5');
 
             // logout and log back in as the instructor
             cy.logout();
@@ -121,14 +121,14 @@ describe('Test cases involving the late days allowed page', () => {
             cy.reload(); // make sure the late day removal was registered
 
             // assert that the table is now empty
-            cy.get('#empty-table').contains('No late days are currently entered');
+            cy.get('#empty-table').should('contain', 'No late days are currently entered');
 
             // logout and log back in as bitdiddle to make sure there are no remaining late days
             cy.logout();
             cy.login('bitdiddle');
             cy.visit(['sample', 'late_table']);
             cy.reload(); // just a quick pause to make sure the page has loaded fully
-            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').contains('0');
+            cy.get('#late-day-table > tbody > tr').last(':nth-child(8)').should('contain', '0');
         });
     });
 });

--- a/site/cypress/e2e/Cypress-Feature/late_days_cache.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/late_days_cache.spec.js
@@ -203,7 +203,7 @@ describe('Test cases involving late day cache updates', () => {
                 cy.get('#late-days').type(2, { force: true });
                 cy.get('#extensions-form').find('a').as('ext-form-link');
 
-                cy.get('@ext-form-link').contains('Submit');
+                cy.get('@ext-form-link').should('contain', 'Submit');
                 cy.get('@ext-form-link').should('exist');
                 cy.get('@ext-form-link').click();
                 cy.wait('@extensions-update');

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -94,12 +94,12 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#future-table').should('be.visible');
 
         // verify that existing polls exist and are in the expected state
-        cy.get('#older-table').contains('Poll 1');
+        cy.get('#older-table').should('contain', 'Poll 1');
         cy.get('#poll_1_visible').should('be.checked');
         cy.get('#poll_1_view_results').should('not.be.checked');
         cy.get('#poll_1_responses').invoke('text').then(parseInt).should('be.gt', 0);
 
-        cy.get('#older-table').contains('Poll 2');
+        cy.get('#older-table').should('contain', 'Poll 2');
         cy.get('#poll_2_visible').should('be.checked');
         cy.get('#poll_2_view_results').should('not.be.checked');
         cy.get('#poll_2_responses').invoke('text').then(parseInt).should('be.gt', 0);
@@ -111,7 +111,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('#poll_3_view_results').should('be.checked');
         cy.get('#poll_3_responses').invoke('text').then(parseInt).should('be.eq', 0);
 
-        cy.get('#future-table').contains('Poll 4');
+        cy.get('#future-table').should('contain', 'Poll 4');
         cy.get('#poll_4_responses').invoke('text').then(parseInt).should('be.eq', 0);
     });
 
@@ -121,15 +121,15 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
 
         // verify that existing polls exist and are in the expected state
-        cy.get('#older-table').contains('Poll 1');
+        cy.get('#older-table').should('contain', 'Poll 1');
         cy.contains('Poll 1').siblings(':nth-child(3)').children().children().should('have.class', 'btn-primary');
-        cy.contains('Poll 1').siblings(':nth-child(3)').contains('View Poll');
+        cy.contains('Poll 1').siblings(':nth-child(3)').should('contain', 'View Poll');
 
-        cy.get('#older-table').contains('Poll 2');
+        cy.get('#older-table').should('contain', 'Poll 2');
         cy.contains('Poll 2').siblings(':nth-child(3)').children().children().should('have.class', 'btn-primary');
-        cy.contains('Poll 2').siblings(':nth-child(3)').contains('View Poll');
+        cy.contains('Poll 2').siblings(':nth-child(3)').should('contain', 'View Poll');
 
-        cy.contains('Poll 3').siblings(':nth-child(2)').contains('No Response');
+        cy.contains('Poll 3').siblings(':nth-child(2)').should('contain', 'No Response');
     });
 
     it('Should verify all polls result pages', () => {
@@ -146,55 +146,55 @@ describe('Test cases revolving around polls functionality', () => {
         // go to poll 1 result page
         cy.contains('Poll 1').siblings().last().click();
         // make sure all the page elements are there
-        cy.get('.content > h1').contains('Poll 1');
+        cy.get('.content > h1').should('contain', 'Poll 1');
         cy.get('[data-testid="timer"]').should('contain', 'Poll Ended');
-        cy.get('.markdown').contains('What animals swim in the sea?');
-        cy.get('#chartContainer').contains('Poll 1');
-        cy.get('#chartContainer').contains('Dolphin');
-        cy.get('#chartContainer').contains('Dove');
-        cy.get('#chartContainer').contains('Shark');
-        cy.get('#chartContainer').contains('Frog');
-        cy.get('#chartContainer').contains('Snail');
+        cy.get('.markdown').should('contain', 'What animals swim in the sea?');
+        cy.get('#chartContainer').should('contain', 'Poll 1');
+        cy.get('#chartContainer').should('contain', 'Dolphin');
+        cy.get('#chartContainer').should('contain', 'Dove');
+        cy.get('#chartContainer').should('contain', 'Shark');
+        cy.get('#chartContainer').should('contain', 'Frog');
+        cy.get('#chartContainer').should('contain', 'Snail');
         cy.go('back');
 
         // go to poll 2 result page
         cy.contains('Poll 2').siblings().last().click();
         // make sure all the page elements are there
-        cy.get('.content > h1').contains('Poll 2');
+        cy.get('.content > h1').should('contain', 'Poll 2');
         cy.get('[data-testid="timer"]').should('contain', 'Poll Ended');
-        cy.get('.markdown').contains('What color is the sky?');
-        cy.get('#chartContainer').contains('Poll 2');
-        cy.get('#chartContainer').contains('Green');
-        cy.get('#chartContainer').contains('Blue');
-        cy.get('#chartContainer').contains('White');
-        cy.get('#chartContainer').contains('Red');
+        cy.get('.markdown').should('contain', 'What color is the sky?');
+        cy.get('#chartContainer').should('contain', 'Poll 2');
+        cy.get('#chartContainer').should('contain', 'Green');
+        cy.get('#chartContainer').should('contain', 'Blue');
+        cy.get('#chartContainer').should('contain', 'White');
+        cy.get('#chartContainer').should('contain', 'Red');
         cy.go('back');
 
         // go to poll 3 result page
         cy.contains('Poll 3').siblings().last().click();
         // make sure all the page elements are there
-        cy.get('.content > h1').contains('Poll 3');
+        cy.get('.content > h1').should('contain', 'Poll 3');
         cy.get('[data-testid="timer"]').should('not.exist');
-        cy.get('.markdown').contains('What is your favorite food?');
-        cy.get('#chartContainer').contains('Poll 3');
-        cy.get('#chartContainer').contains('Pizza');
-        cy.get('#chartContainer').contains('Hamburger');
-        cy.get('#chartContainer').contains('Ice cream');
-        cy.get('#chartContainer').contains('Candy');
-        cy.get('#chartContainer').contains('Other');
+        cy.get('.markdown').should('contain', 'What is your favorite food?');
+        cy.get('#chartContainer').should('contain', 'Poll 3');
+        cy.get('#chartContainer').should('contain', 'Pizza');
+        cy.get('#chartContainer').should('contain', 'Hamburger');
+        cy.get('#chartContainer').should('contain', 'Ice cream');
+        cy.get('#chartContainer').should('contain', 'Candy');
+        cy.get('#chartContainer').should('contain', 'Other');
         cy.go('back');
 
         // go to poll 4 result page
         cy.contains('Poll 4').siblings().last().click();
         // make sure all the page elements are there
-        cy.get('.content > h1').contains('Poll 4');
-        cy.get('.markdown').contains('Which of the following statements are true? Select all that apply.');
-        cy.get('#chartContainer').contains('Poll 4');
-        cy.get('#chartContainer').contains('2 + 2 = 4');
-        cy.get('#chartContainer').contains('3 + 2 = 7');
-        cy.get('#chartContainer').contains('2 * 3 = 6');
-        cy.get('#chartContainer').contains('8 / 2 = 3');
-        cy.get('#chartContainer').contains('1 * 3 = 4');
+        cy.get('.content > h1').should('contain', 'Poll 4');
+        cy.get('.markdown').should('contain', 'Which of the following statements are true? Select all that apply.');
+        cy.get('#chartContainer').should('contain', 'Poll 4');
+        cy.get('#chartContainer').should('contain', '2 + 2 = 4');
+        cy.get('#chartContainer').should('contain', '3 + 2 = 7');
+        cy.get('#chartContainer').should('contain', '2 * 3 = 6');
+        cy.get('#chartContainer').should('contain', '8 / 2 = 3');
+        cy.get('#chartContainer').should('contain', '1 * 3 = 4');
     });
 
     it('Should verify making, editing, deleting poll works as expected', () => {
@@ -269,7 +269,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.logout();
         cy.login('student');
         cy.visit(['sample', 'polls']);
-        cy.contains('Poll Cypress Test').siblings(':nth-child(3)').contains('Closed');
+        cy.contains('Poll Cypress Test').siblings(':nth-child(3)').should('contain', 'Closed');
         cy.contains('Poll Cypress Test').parent().find('a').invoke('attr', 'href').then((href) => {
             cy.visit(href);
             cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'Poll is not available');
@@ -288,21 +288,21 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         visitPoll('Poll Cypress Test', 'View Poll');
-        cy.get('h1').contains('Poll Cypress Test');
+        cy.get('h1').should('contain', 'Poll Cypress Test');
         cy.get('img').should('be.visible');
-        cy.get('h2').contains('Possible responses:');
+        cy.get('h2').should('contain', 'Possible responses:');
         cy.get('.markdown').should('contain', 'Question goes here...?');
         cy.get('.markdown').should('not.contain', '#');
         // go through options, verify text and status of buttons
-        cy.get('.poll-content').contains('td', 'No response');
-        cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(2)').contains('No response');
+        cy.get('.poll-content').should('contain', 'td', 'No response');
+        cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(2)').should('contain', 'No response');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('be.disabled');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('be.checked');
-        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').contains('Answer 1');
+        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').should('contain', 'Answer 1');
         cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(1) > input').should('be.disabled');
-        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').contains('Answer 2');
+        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').should('contain', 'Answer 2');
         cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(1) > input').should('be.disabled');
-        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').contains('Answer 3');
+        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').should('contain', 'Answer 3');
         cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(1) > input').should('be.disabled');
         // verify the optional display buttons and histogram don't exist for student
         cy.get('#toggle-histogram-button').should('not.exist');
@@ -351,17 +351,17 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('[data-testid="timer"]').should('be.visible');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('not.be.disabled');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('be.checked');
-        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').contains('Answer 1');
+        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').should('contain', 'Answer 1');
         cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(1) > input').should('not.be.disabled');
-        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').contains('Answer 2');
+        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').should('contain', 'Answer 2');
         cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(1) > input').should('not.be.disabled');
-        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').contains('Answer 3');
+        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').should('contain', 'Answer 3');
         cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(1) > input').should('not.be.disabled');
         // switch answer to Answer 2
         cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(1) > input').check();
         cy.get('button[type=submit]').click();
         cy.url().should('include', 'sample/polls');
-        cy.contains('Poll Cypress Test').siblings(':nth-child(2)').contains('Answer 2');
+        cy.contains('Poll Cypress Test').siblings(':nth-child(2)').should('contain', 'Answer 2');
 
         // try switching the answer and verify it got saved
         visitPoll('Poll Cypress Test', 'Answer', true);
@@ -369,7 +369,7 @@ describe('Test cases revolving around polls functionality', () => {
         cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(1) > input').should('not.be.checked');
         cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(1) > input').check(); // Answer 3
         cy.get('button[type=submit]').click();
-        cy.contains('Poll Cypress Test').siblings(':nth-child(2)').contains('Answer 3');
+        cy.contains('Poll Cypress Test').siblings(':nth-child(2)').should('contain', 'Answer 3');
 
         // log into instructor, edit the poll
         cy.logout();
@@ -409,8 +409,8 @@ describe('Test cases revolving around polls functionality', () => {
             cy.wrap($el).type('Answer 0');
         });
         cy.get('#responses').children(':nth-child(3)').children(':nth-child(5)').click();
-        cy.get('#responses').children(':nth-child(2)').children(':nth-child(4)').contains('Answer 3');
-        cy.get('#responses').children(':nth-child(3)').children(':nth-child(4)').contains('Answer 2');
+        cy.get('#responses').children(':nth-child(2)').children(':nth-child(4)').should('contain', 'Answer 3');
+        cy.get('#responses').children(':nth-child(3)').children(':nth-child(4)').should('contain', 'Answer 2');
         cy.get('button[type=submit]').click();
 
         // log into student and verify the edits were made
@@ -418,13 +418,13 @@ describe('Test cases revolving around polls functionality', () => {
         cy.login('student');
         cy.visit(['sample', 'polls']);
         visitPoll('Poll Cypress Test', 'Answer', true);
-        cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(2)').contains('No response');
+        cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(2)').should('contain', 'No response');
         cy.get('.poll-content > tbody > tr:nth-child(1) > td:nth-child(1) > input').should('not.be.checked');
-        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').contains('Answer 0');
+        cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(2)').should('contain', 'Answer 0');
         cy.get('.poll-content > tbody > tr:nth-child(2) > td:nth-child(1) > input').should('not.be.checked');
-        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').contains('Answer 3');
+        cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(2)').should('contain', 'Answer 3');
         cy.get('.poll-content > tbody > tr:nth-child(3) > td:nth-child(1) > input').should('be.checked');
-        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').contains('Answer 2');
+        cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(2)').should('contain', 'Answer 2');
         cy.get('.poll-content > tbody > tr:nth-child(4) > td:nth-child(1) > input').should('not.be.checked');
         // verify we can't see histogram or answer
         cy.get('#toggle-info-button').should('not.exist');

--- a/site/cypress/e2e/Cypress-Gradeable/bulkupload.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/bulkupload.spec.js
@@ -32,36 +32,36 @@ describe('Test cases revolving around bulk uploading', () => {
             // Bulk upload
             cy.get('[data-testid="select-files"]').selectFile('cypress/fixtures/bulk_upload.pdf', { force: true });
             cy.get('[data-testid="submit-gradeable"]').click();
-            cy.get('[data-testid="assign-box"]').contains('2 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '2 files ready to assign', { timeout: 10000 });
             // reload to load the new files
             cy.reload();
             cy.get('[data-testid="bulk-delete-all"]').click();
-            cy.get('[data-testid="assign-box"]').contains('0 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '0 files ready to assign', { timeout: 10000 });
 
             // Bulk upload with QR Code
             cy.get('[data-testid="split-by-qr-code"]').check();
             cy.get('[data-testid="select-files"]').selectFile('cypress/fixtures/bulk_upload_qr.pdf', { force: true });
             cy.get('[data-testid="submit-gradeable"]').click();
-            cy.get('[data-testid="assign-box"]').contains('2 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '2 files ready to assign', { timeout: 10000 });
             cy.reload();
             cy.get('[data-testid="bulk-delete-all"]').click();
-            cy.get('[data-testid="assign-box"]').contains('0 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '0 files ready to assign', { timeout: 10000 });
 
             // Bulk upload with QR code, detect and assign a test to studentID
             cy.get('[data-testid="select-files"]').selectFile('cypress/fixtures/bulk_upload_qr.pdf', { force: true });
             cy.get('[data-testid="submit-gradeable"]').click();
-            cy.get('[data-testid="assign-box"]').contains('2 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '2 files ready to assign', { timeout: 10000 });
             cy.reload();
             cy.get('[data-testid="bulk-user-id-1"]').should('have.value', 'adamsg');
             // assign adamsg their test
             cy.get('[data-testid="bulk-submit-1"]').click();
             cy.get('[data-testid="bulk-delete-all"]').click();
-            cy.get('[data-testid="assign-box"]').contains('0 files ready to assign', { timeout: 10000 });
+            cy.get('[data-testid="assign-box"]').should('contain', '0 files ready to assign', { timeout: 10000 });
 
             // confirm that adamsg has a test
             cy.visit(['sample', 'gradeable', 'bulk_upload_test', 'grading', 'details']);
             cy.get('[data-testid="view-sections"]').click();
-            cy.get('[data-testid="grade-table"]').contains('adamsg').parent().get('[data-testid="grade-button"]').contains('Grade');
+            cy.get('[data-testid="grade-table"]').contains('adamsg').parent().get('[data-testid="grade-button"]').should('contain', 'Grade');
         });
     });
 });

--- a/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
@@ -16,7 +16,7 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             cy.waitPageChange(() => {
                 cy.get('#submit').click();
             });
-            cy.get('#submitted-files > div').contains('file1.txt');
+            cy.get('#submitted-files > div').should('contain', 'file1.txt');
             cy.get('#submitted-files > div').contains('Download all files:').should('not.exist');
 
             cy.get('[fname = "file1.txt"] > td').first().contains('file1.txt').next('.file-trash').click();
@@ -29,9 +29,9 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             });
 
             // Checks submitted files
-            cy.get('#submitted-files > div').contains('span', 'file1.txt');
-            cy.get('#submitted-files > div').contains('span', 'file2.txt');
-            cy.get('#submitted-files > div').contains('Download all files:');
+            cy.get('#submitted-files > div').should('contain', 'span', 'file1.txt');
+            cy.get('#submitted-files > div').should('contain', 'span', 'file2.txt');
+            cy.get('#submitted-files > div').should('contain', 'Download all files:');
             // Commented out to pass cypress in CI -- FIXME
             // cy.get('[aria-label="Download file1.txt"]').click();
             // cy.readFile('cypress/downloads/file1.txt').should('eq','a\n');
@@ -49,7 +49,7 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             });
             if (user !== 'instructor2') {
                 cy.visit(['testing', 'gradeable', 'locked_homework']);
-                cy.get('[data-testid="popup-message"]').contains('You have not unlocked this gradeable yet');
+                cy.get('[data-testid="popup-message"]').should('contain', 'You have not unlocked this gradeable yet');
             }
             cy.logout();
         });

--- a/site/cypress/e2e/Cypress-System/login.spec.js
+++ b/site/cypress/e2e/Cypress-System/login.spec.js
@@ -63,9 +63,9 @@ describe('Test cases revolving around the logging in functionality of the site',
             cy.visit('authentication/login');
             cy.url().should('eq', `${Cypress.config('baseUrl')}/authentication/login`);
             loginViaUI('pearsr');
-            cy.get('#courses > div > div > h1').contains('My Courses');
+            cy.get('#courses > div > div > h1').should('contain', 'My Courses');
             cy.visit(['sample']);
-            cy.get('.content').contains('You don\'t have access to this course.');
+            cy.get('.content').should('contain', 'You don\'t have access to this course.');
         });
 
         it('logout button should successfully logout and end up at login screen', () => {

--- a/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
@@ -61,7 +61,7 @@ describe('Test cases for checking the clear version conflicts button in the TA g
             cy.get('[data-testid="version-warning"]').should('exist');
             cy.get('@test-component').children().eq(0).children().eq(0).click();
 
-            cy.get('[data-testid="save-tools-save"]').contains('Save and resolve version conflict');
+            cy.get('[data-testid="save-tools-save"]').should('contain', 'Save and resolve version conflict');
             cy.get('[data-testid="save-tools-save"]').click();
 
             cy.get('[data-testid="version-warning"]', { timeout: 10000 }).should('not.exist');

--- a/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/test_rubric_access.spec.js
@@ -5,7 +5,7 @@ describe('Rubric Access Test', () => {
         cy.get('.content').should('contain', 'You don\'t have access to this page.');
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
         cy.get('#error-0').should('contain', 'You do not have permission to grade Grading Homework');
-        cy.get('.alert-error').contains('You do not have permission to grade Grading Homework');
+        cy.get('.alert-error').should('contain', 'You do not have permission to grade Grading Homework');
         cy.logout();
     });
     it('test rubric delete file attachment ta and instructor', () => {

--- a/site/cypress/e2e/Cypress-UI/docker_ui.spec.js
+++ b/site/cypress/e2e/Cypress-UI/docker_ui.spec.js
@@ -117,7 +117,7 @@ describe('Docker UI Test', () => {
 
         // Check empty tag list, should have `et-cetera'
         cy.get('#capabilities-list')
-            .contains('et-cetera');
+            .should('contain', 'et-cetera');
 
         cy.intercept('POST', '**/admin/add_image').as('addImage');
 
@@ -319,7 +319,7 @@ describe('Docker UI Test', () => {
 
         // images should be visible
         cy.get('[data-testid="image-row"]').should('exist');
-        cy.get('[data-testid="image-row"]').contains('submitty/autograding-default');
+        cy.get('[data-testid="image-row"]').should('contain', 'submitty/autograding-default');
 
         // Add image to capability section should not exist
         cy.get('[data-testid="add-image-to-capability"]').should('not.exist');


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In Cypress, it is better to use the explicit assertion `.should('contain', text)`;

### What is the New Behavior?
Most of the .contains() that don't chain now use the assertion.

### Automated Testing & Documentation
This has no effect on the tests, it is just best practice, and a style we should enforce.