### PR TITLE
[Bugfix:TAGrading] Simple Grading Staff Highlight

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -229,10 +229,11 @@
         {% else %}
             data-student="simple-grade-active"
         {% endif %}
-        {% if not grade.getSubmitter().isTeam() and grade.getSubmitter().getUser().accessGrading() %}
-            class="highlighted-row"
-        {% endif %}
-    >
+        {% if not grade.getSubmitter().isTeam() 
+    and grade.getSubmitter().getUser() 
+    and grade.getSubmitter().getUser().accessGrading() %}
+    class="highlighted-row"
+{% endif %}
         <td class=""></td>
         <td class="">{{ grade.getSubmitter().getUser().getRegistrationSection() }}
             {% if grade.getSubmitter().getUser().getRegistrationSubsection() is not empty %}


### PR DESCRIPTION
#Why is this Change Important & Necessary?
Fixes #12584  
Course staff were not being highlighted in the simple grading interface.

# What is the New Behavior?
Course staff rows are now correctly highlighted in simple grading.

#What steps should a reviewer take to reproduce or test the bug or new feature?
1. Go to simple grading page
2. Observe course staff rows
3. They should now be highlighted correctly

# Automated Testing & Documentation
No new tests added (UI fix)

# Other information
This is not a breaking change.