### PR TITLE
[Bugfix:System] Create Account Test Randomization Fix

### DIFF
--- a/site/cypress/e2e/Cypress-System/self_account_creation.spec.js
+++ b/site/cypress/e2e/Cypress-System/self_account_creation.spec.js
@@ -1,6 +1,6 @@
 const valid_given_name = 'GivenName';
-const valid_user_id = 'good_id';
-const valid_email = 'valid.email@gmail.com';
+let valid_user_id = 'good_id';
+let valid_email = 'valid.email@gmail.com';
 const valid_password = 'Password123!';
 const valid_family_name = 'FamilyName';
 const incorrect_verification_code = '99999999';
@@ -17,6 +17,11 @@ function inputData(email = valid_email, user_id = valid_user_id, password = vali
 
 describe('Self account creation tests', () => {
     it('Test all paths of account creation', () => {
+        // create new randomized alphanumeric user id and email to limit interference of
+        // current database contents on test (especially if this test is run multiple times)
+        valid_user_id = Math.random().toString(36).substring(2, 8);
+        valid_email = `${Math.random().toString(36).substring(2, 8)}@gmail.com`;
+
         cy.visit();
         cy.get('[data-testid="new-account-button"]').click();
         // Not accepted email extension


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Relates to [#12455](https://github.com/Submitty/Submitty/pull/12455)

### What is the New Behavior?
The self_create_account Cypress test now randomizes the user id and email used when trying to create a new account during testing, so that the database contents of the testing VM don't affect this test. Originally, this test would break whenever it was run more than once locally or in CI, because the new user that the first attempt at the test made affects how the next attempts run.

### What steps should a reviewer take to reproduce or test the bug or new feature?
enable DatabaseAuthentication and create_user_account to test the features added, https://submitty.org/sysadmin/configuration/self_account_creation
run the self_create_account Cypress test locally multiple times.
You will see the "User ID or email already attached to an account" display where it shouldn't be.

<img width="743" height="511" alt="Screenshot 2026-06-08 170523" src="https://github.com/user-attachments/assets/d58f4d67-cc9e-477b-9d22-4f23b6695b6f" />

### Other information
This PR is a portion of the changes I have committed to [#12455](https://github.com/Submitty/Submitty/pull/12455), but this bugfix is important for working on other database-related PRs.
