### PR TITLE
[Bugfix:InstructorUI] Recentering Grading Panel Navbar

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -60,7 +60,7 @@ aside {
 }
 
 .navigation-box {
-    margin: 0 0 0 32px;
+    margin: 0 auto;
     display: flex;
     width: max-content;
     max-width: 100%;
@@ -553,6 +553,9 @@ progress::-webkit-progress-value {
 }
 
 #grading-panel-student-name {
+    position: absolute;
+    top: 0;
+    left: 0;
     overflow-y: auto;
     border-right: 1px solid var(--standard-light-medium-gray);
     padding: 5px 10px 5px 5px;

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -364,8 +364,7 @@ $(() => {
     });
 
     // manually trigger resize at init so layout matches window dimensions at first page open
-   window.dispatchEvent(new Event('resize'));
-
+    window.dispatchEvent(new Event('resize'));
 
     // Grading panel toggle buttons
     $('.grade-panel button').click(function () {

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -358,6 +358,8 @@ $(() => {
 
         const overlap_margin = 15;
         const overlapping = (panel_buttons_bbox.left - name_div_bbox.right) < overlap_margin;
+        console.log(`overlap amount between student name and buttons: ${(panel_buttons_bbox.left - name_div_bbox.right)}`);
+        console.log(`overlapping? ${overlapping} (overlap margin = ${overlap_margin})`);
         if (overlapping || taLayoutDet.isFullLeftColumnMode) {
             $('#grading-panel-student-name').hide();
         }

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -329,10 +329,6 @@ function openAutoGrading(num: string) {
 $(() => {
     Object.assign(taLayoutDet, getSavedTaLayoutDetails());
 
-    // Check initially if its the mobile screen view or not
-    changeMobileView();
-    initializeTaLayout();
-
     window.addEventListener('resize', () => {
         const wasMobileView = isMobileView;
         changeMobileView();
@@ -362,6 +358,9 @@ $(() => {
             $('#grading-panel-student-name').hide();
         }
     });
+
+    // manually trigger resize at init so layout matches window dimensions at first page open
+    window.dispatchEvent(new Event('resize'));
 
     // Grading panel toggle buttons
     $('.grade-panel button').click(function () {

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -363,6 +363,10 @@ $(() => {
         }
     });
 
+    // manually trigger resize at init so layout matches window dimensions at first page open
+   window.dispatchEvent(new Event('resize'));
+
+
     // Grading panel toggle buttons
     $('.grade-panel button').click(function () {
         const btnCont = $(this).parent();

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -329,6 +329,10 @@ function openAutoGrading(num: string) {
 $(() => {
     Object.assign(taLayoutDet, getSavedTaLayoutDetails());
 
+    // Check initially if its the mobile screen view or not
+    changeMobileView();
+    initializeTaLayout();
+
     window.addEventListener('resize', () => {
         const wasMobileView = isMobileView;
         changeMobileView();
@@ -358,9 +362,6 @@ $(() => {
             $('#grading-panel-student-name').hide();
         }
     });
-
-    // manually trigger resize at init so layout matches window dimensions at first page open
-    window.dispatchEvent(new Event('resize'));
 
     // Grading panel toggle buttons
     $('.grade-panel button').click(function () {

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -358,8 +358,6 @@ $(() => {
 
         const overlap_margin = 15;
         const overlapping = (panel_buttons_bbox.left - name_div_bbox.right) < overlap_margin;
-        console.log(`overlap amount between student name and buttons: ${(panel_buttons_bbox.left - name_div_bbox.right)}`);
-        console.log(`overlapping? ${overlapping} (overlap margin = ${overlap_margin})`);
         if (overlapping || taLayoutDet.isFullLeftColumnMode) {
             $('#grading-panel-student-name').hide();
         }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The grading panel's navbar used to be centered (in Spring 2026 and probably before). However, the CSS for this element has recently been changed and it is now left-aligned along with the name of the student who made the submission in the top-left. This pushes the navbar to different parts of the screen depending on the length of the student's name.

### What is the New Behavior?
The grading navbar is now centered, as it was before, and the student's name in the top left was reverted to having position:absolute. Also, I have added that a resize event will be manually triggered when the page is first initialized, so you don't have to resize the page manually to trigger the functions which properly create the layout.

Before vs After:

<img width="949" height="89" alt="Screenshot 2026-06-15 145523" src="https://github.com/user-attachments/assets/6cac7c24-9384-4c61-b2e9-15f87ad9c1df" />
<img width="959" height="86" alt="Screenshot 2026-06-15 155924" src="https://github.com/user-attachments/assets/9eee0aad-a863-4cf4-a6d8-33295b5c80d4" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
- go to the grading page in main and note that the navbar is left-aligned
- go to the grading page in this branch and see that it's now centered
- collapse the left column or enter full-screen mode for the next 2 steps
- change the width of the browser window to confirm that the navbar stays in center; also, the student's name should disappear to make room for the navbar at smaller widths
- reload the page while your browser has a small width to confirm that the student's name is not visible when the page loads

### Automated Testing & Documentation
No new tests added

Changes tested on Chrome, Firefox, and Edge browsers
