### PR TITLE
[Testing:InstructorUI] Repair Sidebar Spec Failure

### DIFF
--- a/sample_files/site_theme/override.css
+++ b/sample_files/site_theme/override.css
@@ -1,6 +1,6 @@
 /* Whole page background */
 body {
-    background-image: url(http://www.cs.rpi.edu/~cutler/classes/visualization/S18/images/vinca_minor_mirrored.jpg);
+    background-image: url(https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png);
 }
 
 /* Make the center site have a transparent white bg instead of the blue gradient */

--- a/site/cypress/e2e/Cypress-UI/sidebar.spec.js
+++ b/site/cypress/e2e/Cypress-UI/sidebar.spec.js
@@ -144,7 +144,7 @@ describe('Test sidebars', () => {
             cy.login(user);
             cy.visit(['sample']);
             extendedBaseSidebar();
-            cy.get('body').should('have.css', 'background-image').and('include', 'http://www.cs.rpi.edu/~cutler/classes/visualization/S18/images/vinca_minor_mirrored.jpg');
+            cy.get('body').should('have.css', 'background-image').and('include', 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png');
             cy.get('#submitty-body').should('have.css', 'background-color', 'rgba(240, 240, 240, 0.85)');
         });
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
sidebar.spec.js, part of the UI Cypress test, was inconsistently failing. It seemed to be caused by failure to load the following image in time: http://www.cs.rpi.edu/~cutler/classes/visualization/S18/images/vinca_minor_mirrored.jpg.


### What is the New Behavior?
While the test passes consistently locally, it only fails remotely. This change replaces the current image with the google logo (https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png), which should be more easily accessible than an image on the rpi network. **This might not 100% fix the test, just make it less flaky**

### What steps should a reviewer take to reproduce or test the bug or new feature?
Let the test suite run remotely on github and see if sidebar.spec.js fails.

### Automated Testing & Documentation
No testing needed to test feature