### PR TITLE
[Bugfix:Testing] fix ci errors from old php dependencies

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -187,7 +187,15 @@ runs:
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
+
+        # configure apt for php8.2-fpm install
+        
+        sudo apt-get update
+        sudo apt-get install software-properties-common
+        sudo add-apt-repository ppa:ondrej/php
+        sudo apt-get update
         sudo apt-get install php${PHP_VER}-fpm
+
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -210,6 +210,16 @@ runs:
         sudo service apache2 restart
       shell: bash
 
+    - name: print debugging
+     run: |
+       echo "==== PHP-FPM STATUS ===="
+       sudo systemctl status php8.2-fpm --no-pager || true
+       echo "==== PHP-FPM LOGS ===="
+       sudo cat /var/log/php8.2-fpm.log || true
+       echo "==== APACHE ERROR LOGS ===="
+       sudo tail -n 100 /var/log/apache2/error.log || true
+     shell: bash
+
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -210,21 +210,22 @@ runs:
         sudo service apache2 restart
       shell: bash
 
-    - name: print debugging
-      run: |
-       echo "==== PHP-FPM STATUS ===="
-       sudo systemctl status php8.2-fpm --no-pager || true
-       echo "==== PHP-FPM LOGS ===="
-       sudo cat /var/log/php8.2-fpm.log || true
-       echo "==== APACHE ERROR LOGS ===="
-       sudo tail -n 100 /var/log/apache2/error.log || true
-      shell: bash
-
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |
         cd $SUBMITTY_REPOSITORY
         SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
-        bash tests/git_test.sh
+        if ! bash tests/git_test.sh; then
+          echo "===================================================="
+          echo "GIT TEST FAILED. PRINT DEBUGGING"
+          echo "===================================================="
+          echo "--- APACHE ERROR LOG ---"
+          sudo tail -n 100 /var/log/apache2/error.log
+          echo "--- APACHE ACCESS LOG ---"
+          sudo tail -n 100 /var/log/apache2/access.log
+          echo "--- SUBMITTY AUTH / PAM LOGS ---"
+          [ -f /var/log/auth.log ] && sudo tail -n 50 /var/log/auth.log
+          exit 1
+        fi
       shell: bash

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -54,6 +54,7 @@ runs:
       with:
         php-version: ${{ env.PHP_VER }}
         extensions: imagick, ldap
+        tools: php-fpm
 
     - name: Set Timezone
       run: |
@@ -187,7 +188,6 @@ runs:
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
-        sudo apt-get install php${PHP_VER}-fpm
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -211,14 +211,14 @@ runs:
       shell: bash
 
     - name: print debugging
-     run: |
+      run: |
        echo "==== PHP-FPM STATUS ===="
        sudo systemctl status php8.2-fpm --no-pager || true
        echo "==== PHP-FPM LOGS ===="
        sudo cat /var/log/php8.2-fpm.log || true
        echo "==== APACHE ERROR LOGS ===="
        sudo tail -n 100 /var/log/apache2/error.log || true
-     shell: bash
+      shell: bash
 
     - name: Run git tests
       if: contains(inputs.courses, 'sample')

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -50,6 +50,12 @@ runs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+    
+    - name: Uninstall PHP 8.1 before setup
+      run: |
+        sudo apt-get --dry-run purge 'php8.1*'
+      shell: bash
+
     - uses: shivammathur/setup-php@2.37.0
       with:
         php-version: ${{ env.PHP_VER }}
@@ -226,6 +232,4 @@ runs:
         sudo systemctl status php8.2-fpm --no-pager || true
         echo "=== Apache Error Log ==="
         sudo tail -n 50 /var/log/apache2/error.log || true
-        echo "=== Apache Access Log ==="
-        sudo tail -n 50 /var/log/apache2/access.log || true
       shell: bash

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -51,10 +51,10 @@ runs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Uninstall PHP 8.1 before setup
+    - name: Disable php8.1-fpm before setup
       run: |
-        sudo apt-get purge -qqy 'php8.1*'
-        sudo apt-get autoremove -qqy
+        sudo systemctl stop php8.1-fpm
+        sudo systemctl disable php8.1-fpm
       shell: bash
 
     - uses: shivammathur/setup-php@2.37.0

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -226,4 +226,6 @@ runs:
         sudo systemctl status php8.2-fpm --no-pager || true
         echo "=== Apache Error Log ==="
         sudo tail -n 50 /var/log/apache2/error.log || true
+        echo "=== Apache Access Log ==="
+        sudo tail -n 50 /var/log/apache2/access.log || true
       shell: bash

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -54,7 +54,6 @@ runs:
       with:
         php-version: ${{ env.PHP_VER }}
         extensions: imagick, ldap
-        tools: php-fpm
 
     - name: Set Timezone
       run: |
@@ -188,6 +187,7 @@ runs:
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
+        sudo apt-get install php${PHP_VER}-fpm
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -217,11 +217,6 @@ runs:
         sudo service apache2 restart
       shell: bash
 
-    - name: fix git config perms for all Submitty users
-      run: |
-        sudo git config --system --add safe.directory '*'
-      shell: bash
-
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |
@@ -236,6 +231,10 @@ runs:
       run: |
         echo "=== PHP-FPM Service Status ==="
         sudo systemctl status php8.2-fpm --no-pager || true
+        echo "=== Submitty Apache Vhost Log ==="
+        sudo tail -n 100 /var/log/apache2/submitty.log || true
         echo "=== Apache Error Log ==="
         sudo tail -n 50 /var/log/apache2/error.log || true
+        echo "=== Manual curl against site ==="
+        curl -v http://localhost/ 2>&1 || true
       shell: bash

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -50,7 +50,7 @@ runs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-    
+
     - name: Uninstall PHP 8.1 before setup
       run: |
         sudo apt-get --dry-run purge 'php8.1*'

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -187,15 +187,12 @@ runs:
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
-
         # configure apt for php8.2-fpm install
-        
         sudo apt-get update
         sudo apt-get install software-properties-common
         sudo add-apt-repository ppa:ondrej/php
         sudo apt-get update
         sudo apt-get install php${PHP_VER}-fpm
-
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -187,12 +187,6 @@ runs:
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
-        # configure apt for php8.2-fpm install
-        sudo apt-get update
-        sudo apt-get install software-properties-common
-        sudo add-apt-repository ppa:ondrej/php
-        sudo apt-get update
-        sudo apt-get install php${PHP_VER}-fpm
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -53,7 +53,8 @@ runs:
 
     - name: Uninstall PHP 8.1 before setup
       run: |
-        sudo apt-get --dry-run purge 'php8.1*'
+        sudo apt-get purge -qqy 'php8.1*'
+        sudo apt-get autoremove -qqy
       shell: bash
 
     - uses: shivammathur/setup-php@2.37.0

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -182,11 +182,14 @@ runs:
 
     - name: Set up apache
       run: |
+        sudo add-apt-repository ppa:ondrej/php
+        sudo apt update
         sudo apt-get install apache2
         sudo apt-get install apache2-suexec-custom
         sudo apt-get install libapache2-mod-authnz-external
         sudo apt-get install libapache2-mod-authz-unixgroup
         sudo apt-get install libapache2-mod-wsgi-py3
+        sudo apt-get install php${PHP_VER}-fpm
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -216,16 +216,14 @@ runs:
         cd $SUBMITTY_REPOSITORY
         SEMESTER=$(python3 -c 'from datetime import datetime; today = datetime.today(); semester = ("s" if today.month < 7 else "f") + str(today.year)[-2:]; print(semester)')
         sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
-        if ! bash tests/git_test.sh; then
-          echo "===================================================="
-          echo "GIT TEST FAILED. PRINT DEBUGGING"
-          echo "===================================================="
-          echo "--- APACHE ERROR LOG ---"
-          sudo tail -n 100 /var/log/apache2/error.log
-          echo "--- APACHE ACCESS LOG ---"
-          sudo tail -n 100 /var/log/apache2/access.log
-          echo "--- SUBMITTY AUTH / PAM LOGS ---"
-          [ -f /var/log/auth.log ] && sudo tail -n 50 /var/log/auth.log
-          exit 1
-        fi
+        bash tests/git_test.sh
+      shell: bash
+
+    - name: print debugging again
+      if: failure()
+      run: |
+        echo "=== PHP-FPM Service Status ==="
+        sudo systemctl status php8.2-fpm --no-pager || true
+        echo "=== Apache Error Log ==="
+        sudo tail -n 50 /var/log/apache2/error.log || true
       shell: bash

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -217,6 +217,11 @@ runs:
         sudo service apache2 restart
       shell: bash
 
+    - name: fix git config perms for all Submitty users
+      run: |
+        sudo git config --system --add safe.directory '*'
+      shell: bash
+
     - name: Run git tests
       if: contains(inputs.courses, 'sample')
       run: |

--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -225,16 +225,3 @@ runs:
         sudo python3 /usr/local/submitty/bin/generate_repos.py ${SEMESTER} sample open_homework
         bash tests/git_test.sh
       shell: bash
-
-    - name: print debugging again
-      if: failure()
-      run: |
-        echo "=== PHP-FPM Service Status ==="
-        sudo systemctl status php8.2-fpm --no-pager || true
-        echo "=== Submitty Apache Vhost Log ==="
-        sudo tail -n 100 /var/log/apache2/submitty.log || true
-        echo "=== Apache Error Log ==="
-        sudo tail -n 50 /var/log/apache2/error.log || true
-        echo "=== Manual curl against site ==="
-        curl -v http://localhost/ 2>&1 || true
-      shell: bash

--- a/site/composer.json
+++ b/site/composer.json
@@ -34,7 +34,7 @@
     "symfony/cache": "6.4.7",
     "symfony/config": "6.4.4",
     "symfony/http-foundation": "6.4.14",
-    "symfony/routing": "6.1.11",
+    "symfony/routing": "6.4.13",
     "textalk/websocket": "1.6.3",
     "twig/markdown-extra": "^3.24",
     "twig/twig": "3.24.0"

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "914967fccdfc537b40e3bc7c6fd1bd22",
+    "content-hash": "6029ddef78fecd6795b74f674429ba00",
     "packages": [
         {
             "name": "brick/math",
@@ -5115,41 +5115,36 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.1.11",
+            "version": "v6.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "dd8556e52717bd8559fdac8e9090388be1e2eba7"
+                "reference": "640a74250d13f9c30d5ca045b6aaaabcc8215278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/dd8556e52717bd8559fdac8e9090388be1e2eba7",
-                "reference": "dd8556e52717bd8559fdac8e9090388be1e2eba7",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/640a74250d13f9c30d5ca045b6aaaabcc8215278",
+                "reference": "640a74250d13f9c30d5ca045b6aaaabcc8215278",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "doctrine/annotations": "<1.12",
-                "symfony/config": "<5.4",
+                "symfony/config": "<6.2",
                 "symfony/dependency-injection": "<5.4",
                 "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12|^2",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
-                "symfony/http-foundation": "^5.4|^6.0",
-                "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/config": "For using the all-in-one router or any loader",
-                "symfony/expression-language": "For using expression matching",
-                "symfony/http-foundation": "For using a Symfony Request object",
-                "symfony/yaml": "For using the YAML loader"
+                "symfony/config": "^6.2|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -5183,7 +5178,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.1.11"
+                "source": "https://github.com/symfony/routing/tree/v6.4.13"
             },
             "funding": [
                 {
@@ -5199,7 +5194,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:55+00:00"
+            "time": "2024-10-01T08:30:56+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8961,5 +8956,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
all of cypress is failing when trying to use apt-get to install php8.2-fpm

### What is the New Behavior?
This issue is weird, because AFAIK shivammathur/setup-php@2.37.0 is called in this file to setup php, and that action installs and uses ppa:ondrej/php as a dependency. I'm not sure why it broke if that is the case.
Currently to fix, I am just removing the install call and seeing what will happen.

Edit: Removing php8.1 does not seem to fix the git clone access issue but does cause some problems with packages for php, at least the way I did it.
Edit: I have an idea on how to fix the git perms issue, will push if these checks fail.

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation


### Other information

