### PR TITLE
[UI/UX:Submission] Collapse File List

### DIFF
--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -29,17 +29,29 @@
     {% if downloadable_file_count > 0 %}
         <div class="submitted-files-header">
             <h4>Submitted Files</h4>
-            {% if downloadable_file_count > 20 %}
-                <span id="submission-files-toggle" onclick="toggleSubmittedFiles()">
-                    <i id="submission-files-toggle-icon" class="fas fa-chevron-down"></i>
-                    <span id="submission-files-toggle-text">Expand All Files</span>
+            <button
+                id="submission-files-toggle"
+                class="btn btn-default"
+                onclick="toggleSubmittedFiles()"
+                type="button"
+            >
+                <i 
+                    id="submission-files-toggle-icon"
+                    class="fas {% if downloadable_file_count > 10 %}fa-chevron-down{% else %}fa-chevron-up{% endif %}"
+                ></i>
+                <span id="submission-files-toggle-text">
+                    {% if downloadable_file_count > 10 %}
+                        Show All Files
+                    {% else %}
+                        Hide All Files
+                    {% endif %}
                 </span>
-            {% endif %}
+            </button>
         </div>
     {% endif %}
     <div class="row">
         {% if downloadable_file_count > 0 %}
-            <div class="box col-md-6{% if downloadable_file_count > 20 %} submitted-files-collapsed{% endif %}" id="submitted-files">
+            <div class="box col-md-6{% if downloadable_file_count > 10 %} submitted-files-collapsed{% endif %}" id="submitted-files">
             {% for file in files %}
                 {% if (is_notebook and (file.relative_name|split('/'))|length > 1) or (not is_notebook) %}
                     <div class="flex-row">
@@ -100,7 +112,7 @@
             {% endif %}
         </div>
         {% endif %}
-        {% if downloadable_file_count > 20 %}
+        {% if downloadable_file_count > 10 %}
             <div class="box col-md-12 submission-details" id="submission-details">
         {% elseif downloadable_file_count > 0 %}
             <div class="box col-md-6 submission-details" id="submission-details">

--- a/site/app/templates/submission/homework/CurrentVersionResults.twig
+++ b/site/app/templates/submission/homework/CurrentVersionResults.twig
@@ -27,11 +27,19 @@
 {# Submitted files #}
 {% if student_download or is_vcs or core.getUser().accessGrading() %}
     {% if downloadable_file_count > 0 %}
-        <h4>Submitted Files</h4>
+        <div class="submitted-files-header">
+            <h4>Submitted Files</h4>
+            {% if downloadable_file_count > 20 %}
+                <span id="submission-files-toggle" onclick="toggleSubmittedFiles()">
+                    <i id="submission-files-toggle-icon" class="fas fa-chevron-down"></i>
+                    <span id="submission-files-toggle-text">Expand All Files</span>
+                </span>
+            {% endif %}
+        </div>
     {% endif %}
     <div class="row">
         {% if downloadable_file_count > 0 %}
-            <div class="box col-md-6" id="submitted-files">
+            <div class="box col-md-6{% if downloadable_file_count > 20 %} submitted-files-collapsed{% endif %}" id="submitted-files">
             {% for file in files %}
                 {% if (is_notebook and (file.relative_name|split('/'))|length > 1) or (not is_notebook) %}
                     <div class="flex-row">
@@ -82,20 +90,22 @@
                 <br />
                 <div class="flex-row">
                     <span>Download all files:</span>
-                     <button class = 'btn btn-primary' 
+                     <button class = 'btn btn-primary'
                         onclick='downloadSubmissionZip("{{ gradeable_id }}", "{{ submitter_id }}", "{{ display_version }}", "submission")'
                         tabindex="0"
                         aria-label="Download"
                         > Download all files
-                        <i class="fas fa-download" title="Download zip of all files"></i></button> 
+                        <i class="fas fa-download" title="Download zip of all files"></i></button>
                 </div>
             {% endif %}
         </div>
         {% endif %}
-        {% if downloadable_file_count > 0 %}
-            <div class="box col-md-6 submission-details">
+        {% if downloadable_file_count > 20 %}
+            <div class="box col-md-12 submission-details" id="submission-details">
+        {% elseif downloadable_file_count > 0 %}
+            <div class="box col-md-6 submission-details" id="submission-details">
         {% else %}
-            <div class="box col-md-12 submission-details">
+            <div class="box col-md-12 submission-details" id="submission-details">
         {% endif %}
             {% if first_access_time is defined and first_access_time is not null and first_access_time is not empty %}
                 <span class="flex-row">

--- a/site/public/css/submitbox.css
+++ b/site/public/css/submitbox.css
@@ -64,6 +64,24 @@
     word-break: break-all;
 }
 
+.submitted-files-collapsed {
+    display: none;
+}
+
+.submitted-files-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.submitted-files-header h4 {
+    margin: 0;
+}
+
+#submission-files-toggle {
+    cursor: pointer;
+}
+
 #version-cont {
     display: flex;
     flex-wrap: wrap;

--- a/site/public/css/submitbox.css
+++ b/site/public/css/submitbox.css
@@ -72,14 +72,16 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    margin-top: 8px;
+}
+
+#submission-files-toggle {
+    padding: 3px 8px;
+    line-height: 1;
 }
 
 .submitted-files-header h4 {
     margin: 0;
-}
-
-#submission-files-toggle {
-    cursor: pointer;
 }
 
 #version-cont {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -831,19 +831,21 @@ function toggleSubmittedFiles() {
     const toggleText = document.getElementById('submission-files-toggle-text');
     const toggleIcon = document.getElementById('submission-files-toggle-icon');
     const submissionDetails = document.getElementById('submission-details');
+
+    toggleDiv('submitted-files');
+
     if ($('#submitted-files').is(':hidden')) {
-        toggleText.textContent = 'Collapse All Files';
-        toggleIcon.className = 'fas fa-chevron-up';
-        submissionDetails.classList.remove('col-md-12');
-        submissionDetails.classList.add('col-md-6');
-    }
-    else {
-        toggleText.textContent = 'Expand All Files';
+        toggleText.textContent = 'Show All Files';
         toggleIcon.className = 'fas fa-chevron-down';
         submissionDetails.classList.remove('col-md-6');
         submissionDetails.classList.add('col-md-12');
     }
-    toggleDiv('submitted-files');
+    else {
+        toggleText.textContent = 'Hide All Files';
+        toggleIcon.className = 'fas fa-chevron-up';
+        submissionDetails.classList.remove('col-md-12');
+        submissionDetails.classList.add('col-md-6');
+    }
 }
 
 function checkRefreshPage(url, anon_id = '') {

--- a/site/public/js/server.js
+++ b/site/public/js/server.js
@@ -827,6 +827,25 @@ function toggleDiv(id) {
     return true;
 }
 
+function toggleSubmittedFiles() {
+    const toggleText = document.getElementById('submission-files-toggle-text');
+    const toggleIcon = document.getElementById('submission-files-toggle-icon');
+    const submissionDetails = document.getElementById('submission-details');
+    if ($('#submitted-files').is(':hidden')) {
+        toggleText.textContent = 'Collapse All Files';
+        toggleIcon.className = 'fas fa-chevron-up';
+        submissionDetails.classList.remove('col-md-12');
+        submissionDetails.classList.add('col-md-6');
+    }
+    else {
+        toggleText.textContent = 'Expand All Files';
+        toggleIcon.className = 'fas fa-chevron-down';
+        submissionDetails.classList.remove('col-md-6');
+        submissionDetails.classList.add('col-md-12');
+    }
+    toggleDiv('submitted-files');
+}
+
 function checkRefreshPage(url, anon_id = '') {
     setTimeout(() => {
         check_server(url, anon_id);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes Issue #10387 
Currently, if a student submits more than 20 files, the submitted files section can take up most of the page. This forces students to scroll through a long file list before reaching their autograding results and submission details.

### What is the New Behavior?
If a submission contains more than 20 downloadable files, the submitted files section is collapsed by default. Users can expand or collapse the file list using the toggle next to the Submitted Files header.

Before: 
<img width="835" height="472" alt="image" src="https://github.com/user-attachments/assets/25b61817-2f05-46fb-a018-aeb5082b754e" />

After:
<img width="1704" height="240" alt="image" src="https://github.com/user-attachments/assets/dda07296-c41f-4644-86b0-8688d3391d58" />

### What steps should a reviewer take to reproduce or test the bug or new feature?

In the main branch:
1. Log in as a student
2. Submit an assignment with 20+ files (you may need to submit a zip, depending on the assignment type)
3. Observe that all submitted files are displayed immediately.

In the PR branch:
1. Log in as a student
2. Submit an assignment with 20+ files (you may need to submit a zip, depending on the assignment type)
3. Test the expand files option along with the collapse files option

### Automated Testing & Documentation
N/A

### Other information
N/A