### PR TITLE
[Bugfix:TAGrading] Student Name Resize

### DIFF
--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -333,6 +333,7 @@ $(() => {
     changeMobileView();
     initializeTaLayout();
 
+    // switch between standard and mobile layout on resize
     window.addEventListener('resize', () => {
         const wasMobileView = isMobileView;
         changeMobileView();
@@ -342,6 +343,7 @@ $(() => {
         }
     });
 
+    // resize/hide the student's name in the top-left corner on resize
     window.addEventListener('resize', () => {
         if ($('#silent-edit-id').length === 0) {
             return;
@@ -359,7 +361,7 @@ $(() => {
         const overlap_margin = 15;
         const overlapping = (panel_buttons_bbox.left - name_div_bbox.right) < overlap_margin;
         if (overlapping || taLayoutDet.isFullLeftColumnMode) {
-            $('#grading-panel-student-name').hide();
+            name_div.hide();
         }
     });
 

--- a/site/ts/ta-grading-panels-init.ts
+++ b/site/ts/ta-grading-panels-init.ts
@@ -345,9 +345,6 @@ $(() => {
 
     // resize/hide the student's name in the top-left corner on resize
     window.addEventListener('resize', () => {
-        if ($('#silent-edit-id').length === 0) {
-            return;
-        }
         const name_div = $('#grading-panel-student-name');
         const panel_div = $('.panels-container');
         // have to calculate the height since the item is positioned absolutely


### PR DESCRIPTION
### Why is this Change Important & Necessary?
While on the grading page, the student's name in the top-left corner resizes dynamically and disappears when it overlaps with the buttons in the top panel. However, this resizing is prevented if the gradeable has the Silent Regrade button. This is unwanted and unnecessary behavior, and this PR removes it.

### What is the New Behavior?
The Silent Regrade button now has no effect on how the student's name is displayed on the grading page.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On main, create a new gradeable with student submissions that has Silent Regrade disabled (the easiest way I have found to do this is to keep manual grading disabled).
2. See that the student's name in the top-left is not sized properly. This is clear when the white line to the right of the student's name does not span the top panel, because that element's height was not dynamically set.
3. Notice also that when you reduce the width of your window, the student's name does not disappear, even after the student's name starts overlapping with the buttons.

Issues described in 2 and 3 respectively:
<img width="181" height="74" alt="Screenshot 2026-06-23 163658" src="https://github.com/user-attachments/assets/e7eeb608-b704-44bd-9a98-7928c7803341" />
<img width="214" height="77" alt="Screenshot 2026-06-23 164250" src="https://github.com/user-attachments/assets/bcda2932-befd-4adc-91b1-d73ce1375fa9" />

4. Now go to this PR and repeat steps 2 and 3. Neither issue should be present any longer.

<img width="197" height="71" alt="Screenshot 2026-06-23 164946" src="https://github.com/user-attachments/assets/4a517ac2-abf2-41eb-bcd1-e8d9029ee5aa" />
<img width="171" height="74" alt="Screenshot 2026-06-23 164951" src="https://github.com/user-attachments/assets/6dd3467f-d061-44dc-af9b-870678fd34e3" />

### Automated Testing & Documentation
N/A