### PR TITLE
[Bugfix:System] Preserve signup fields

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -352,13 +352,16 @@ EMAIL;
             $this->core->addErrorMessage('Users cannot create their own account, Please have your system administrator add you.');
             return new RedirectResponse($this->core->buildUrl(['authentication', 'login']));
         }
+        $form_values = $_SESSION['create_account_form_values'] ?? [];
+        unset($_SESSION['create_account_form_values']);
         return new WebResponse(
             'Authentication',
             'signupForm',
             [
                 'accepted_emails' => $this->core->getConfig()->getAcceptedEmails(),
                 'user_id_requirements' => $this->core->getConfig()->getUserIdRequirements(),
-                'password_requirements' => $this->core->getConfig()->getPasswordRequirements()
+                'password_requirements' => $this->core->getConfig()->getPasswordRequirements(),
+                'form_values' => $form_values
             ]
         );
     }
@@ -461,32 +464,33 @@ EMAIL;
         $confirm_password = $_POST['confirm_password'];
         $given_name = $_POST['given_name'];
         $family_name = $_POST['family_name'];
+        $form_values = [
+            'email' => $email,
+            'user_id' => $user_id,
+            'given_name' => $given_name,
+            'family_name' => $family_name
+        ];
         $user_exists = $this->core-> getQueries()->getUserIdEmailExists($email, $user_id);
         $unverified_users = UnverifiedUserController::getUnverifiedUsers($this->core, $email, $user_id);
 
         if ($user_exists || count($unverified_users) !== 0) {
-            $this->core->addErrorMessage('User ID or email is already attached with an account.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm('User ID or email is already attached with an account.', $form_values);
         }
 
         if ($password !== $confirm_password) {
-            $this->core->addErrorMessage('Passwords did not match.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm('Passwords did not match.', $form_values);
         }
 
         if (!Utils::isValidPassword($password, $this->core->getConfig()->getPasswordRequirements())) {
-            $this->core->addErrorMessage('Password does not meet the requirements.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm('Password does not meet the requirements.', $form_values);
         }
 
         if (!Utils::isAcceptedEmail($this->core->getConfig()->getAcceptedEmails(), $email)) {
-            $this->core->addErrorMessage('This email is not accepted.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm('This email is not accepted.', $form_values);
         }
 
         if (!Utils::isAcceptedUserId($this->core->getConfig()->getUserIdRequirements(), $user_id, $given_name, $family_name, $email)) {
-            $this->core->addErrorMessage('This user id does not meet the requirements.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm('This user id does not meet the requirements.', $form_values);
         }
         $verification_values = Utils::generateVerificationCode($this->core, $this->core->getConfig()->isDebug());
 
@@ -509,8 +513,16 @@ EMAIL;
         }
         catch (\Exception $e) {
             Logger::error($e);
-            $this->core->addErrorMessage($e->getMessage() . ' Failed to create the account.');
-            return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
+            return $this->redirectToSignupForm($e->getMessage() . ' Failed to create the account.', $form_values);
         }
+    }
+
+    /**
+     * @param array{email: string, user_id: string, given_name: string, family_name: string} $form_values
+     */
+    private function redirectToSignupForm(string $message, array $form_values): RedirectResponse {
+        $this->core->addErrorMessage($message);
+        $_SESSION['create_account_form_values'] = $form_values;
+        return new RedirectResponse($this->core->buildUrl(['authentication', 'create_account']));
     }
 }

--- a/site/app/templates/CreateNewAccount.twig
+++ b/site/app/templates/CreateNewAccount.twig
@@ -23,7 +23,7 @@
                     {% endfor %}
                 </ul>
             </div>
-            <input type="text" name="email" required data-testid="email" />
+            <input type="text" name="email" value="{{ form_values['email'] ?? '' }}" required data-testid="email" />
         </div>
         <div class="display-box">
             <p style="display:block">User ID <button class="requirements-button" type="button" onclick="showRequirements(this.id)" id="userid">Show Requirements</button></p>  
@@ -55,15 +55,15 @@
                 {% endif %}
                 </ul>
             </div>
-                <input type="text" name="user_id" data-testid="user-id" required />
+                <input type="text" name="user_id" value="{{ form_values['user_id'] ?? '' }}" data-testid="user-id" required />
         </div>
         <div class="display-box">
             Given Name
-            <input type="text" name="given_name" data-testid="given-name" required />
+            <input type="text" name="given_name" value="{{ form_values['given_name'] ?? '' }}" data-testid="given-name" required />
         </div>
         <div class="display-box">
             Family Name
-            <input type="text" name="family_name" data-testid="family-name" required />
+            <input type="text" name="family_name" value="{{ form_values['family_name'] ?? '' }}" data-testid="family-name" required />
         </div>
         <div class="display-box">
             <p style="display:block">Password <button class="requirements-button" type="button" onclick="showRequirements(this.id)" id="password">Show Requirements</button></p>

--- a/site/app/views/AuthenticationView.php
+++ b/site/app/views/AuthenticationView.php
@@ -67,7 +67,8 @@ class AuthenticationView extends AbstractView {
         return $this->core->getOutput()->renderTwigTemplate("CreateNewAccount.twig", [
             "signup_url" => $this->core->buildUrl(['authentication', 'self_add_user']),
             "signup_content" => $signup_content,
-            "requirements" => $content
+            "requirements" => $content,
+            "form_values" => $content['form_values'] ?? []
         ]);
     }
 

--- a/site/cypress/e2e/Cypress-System/self_account_creation.spec.js
+++ b/site/cypress/e2e/Cypress-System/self_account_creation.spec.js
@@ -7,11 +7,17 @@ const incorrect_verification_code = '99999999';
 const valid_verification_code = '00000000';
 
 function inputData(email = valid_email, user_id = valid_user_id, password = valid_password, confirm_password = valid_password) {
+    cy.get('[data-testid="email"]').clear();
     cy.get('[data-testid="email"]').type(email);
+    cy.get('[data-testid="user-id"]').clear();
     cy.get('[data-testid="user-id"]').type(user_id);
+    cy.get('[data-testid="given-name"]').clear();
     cy.get('[data-testid="given-name"]').type(valid_given_name);
+    cy.get('[data-testid="family-name"]').clear();
     cy.get('[data-testid="family-name"]').type(valid_family_name);
+    cy.get('[data-testid="password"]').clear();
     cy.get('[data-testid="password"]').type(password);
+    cy.get('[data-testid="confirm-password"]').clear();
     cy.get('[data-testid="confirm-password"]').type(confirm_password);
 }
 
@@ -41,6 +47,12 @@ describe('Self account creation tests', () => {
         inputData('test.email.bad@bad.com', 'new_user_id');
         cy.get('[data-testid="sign-up-button"]').click();
         cy.get('[data-testid="popup-message"]').should('contain.text', 'This email is not accepted.');
+        cy.get('[data-testid="email"]').should('have.value', 'test.email.bad@bad.com');
+        cy.get('[data-testid="user-id"]').should('have.value', 'new_user_id');
+        cy.get('[data-testid="given-name"]').should('have.value', valid_given_name);
+        cy.get('[data-testid="family-name"]').should('have.value', valid_family_name);
+        cy.get('[data-testid="password"]').should('have.value', '');
+        cy.get('[data-testid="confirm-password"]').should('have.value', '');
         cy.get('[data-testid="remove-message-popup"').click(); // unremoved popups eventually clog the screen
         // Id too short
         inputData(undefined, 'short');


### PR DESCRIPTION
### What is the current behavior?

When server-side validation rejects the self-account creation form, the redirect back to the signup page clears every field. This includes failures that cannot be prevented by client-side validation, such as duplicate user IDs or email addresses.

### What is the new behavior?

The controller stores only the submitted email, user ID, given name, and family name for the redirect request. The signup form consumes those values once and repopulates the corresponding fields.

Password and confirmation values are intentionally never stored or repopulated.

This keeps server-side validation authoritative and covers every existing validation/error redirect rather than only rules that can be duplicated in JavaScript.

### Testing

- `git diff --check`
- `node --check site/cypress/e2e/Cypress-System/self_account_creation.spec.js`

Closes #12490