### PR TITLE
[Bugfix:InstructorUI] Create Course Validation

### DIFF
--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -296,8 +296,21 @@ class HomePageController extends AbstractController {
             );
         }
 
+        $course_title = trim($_POST['course_title']);
+        // course title can only contain lowercase letters, digits, and the underscore character
+        // also check for "" (if only whitespace is input, it all gets trimmed)
+        if (preg_match('/[^a-z0-9_]/', $course_title) || $course_title === "") {
+            $error = "The course code must contain only lowercase letters (a-z), digits (0-9), and the underscore character.";
+            $this->core->addErrorMessage($error);
+            return new MultiResponse(
+                JsonResponse::getFailResponse($error),
+                null,
+                new RedirectResponse($this->core->buildUrl(['home', 'courses', 'new']))
+            );
+        }
+        $course_title = strtolower($course_title);
+
         $semester = trim($_POST['course_semester']);
-        $course_title = trim(strtolower($_POST['course_title']));
         $head_instructor = $_POST['head_instructor'];
 
         if ($user->getAccessLevel() === User::LEVEL_FACULTY && $head_instructor !== $user->getId()) {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #12934 

### What is the New Behavior?
If a user tries to make a new course and inputs a course code containing characters other than lowercase letters, numbers, or underscores, they will be redirected to the New Course page and be given a helpful error. This validation is implemented server-side. Previously, there was no validation for the course code field.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On main, sign in as instructor.
2. Go to the New Course page.
3. Ensure the term is valid and select any filesystem group.
4. Enter a valid course code (containing only lowercase letters, numbers, and underscores) and click Create New Course.
5. You will see the popup below, and after a few seconds and a reload, the new course appears under My Courses.

<img width="385" height="83" alt="Screenshot 2026-06-19 152318" src="https://github.com/user-attachments/assets/8254bd1b-a223-4cd3-897d-fe6d89e53293" />

6. Repeat steps 2 and 3, then try to enter a course code that does not follow the requirements given for that field 
(e.g. "!", "   ", "A", "te st").
7. You will see the same message pop up as in step 5, but the course is never made.

Now go to this PR's branch and repeat the above procedure. After entering an invalid course code and trying to create a new course, instead of seeing the green popup, you will be redirected to the New Course page and will see this red popup:

<img width="395" height="73" alt="Screenshot 2026-06-24 105327" src="https://github.com/user-attachments/assets/bdfae72e-45d7-42b3-a434-965dc0e3f123" />

### Automated Testing & Documentation
Introduced in issue #12951