### PR TITLE
[Testing:Notifications] Fix grade_inquiries.spec.js

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
@@ -72,14 +72,17 @@ describe('Test cases revolving around grade inquiries', () => {
             });
 
             // need to clear local storage to refresh grader's responsibility page
+            cy.logout();
+            cy.clearCookies();
             cy.clearLocalStorage();
         });
 
         // student view
         cy.login('beahaf');
         cy.visit(['sample', 'gradeable', gradeableId]);
-        cy.get('[data-testid="grade-inquiry-container"]').should('contain.text', 'Grade inquiries are due by 9998-01-01 @ 12:00 AM EST');
-        verifyWebSocketStatus();
+        cy.get('[data-testid="grade-inquiry-container"]').should('contain.text', 'Grade inquiries are due by 9998-01-01 @ 12:00 AM EST').then(() => {
+            verifyWebSocketStatus();
+        });
     });
     it('should test cases regarding abnormal grade inquiry dates', () => {
         cy.login();


### PR DESCRIPTION
### Why is this Change Important & Necessary?
grade_inquiries.spec.js was failing because of a websocket verification failure. This PR fixes that.

### What is the New Behavior?
Before, a websocket verification within the test was occuring before cypress properly loaded a page. This was because cypress was queueing the page visit, but then executing the verification before the page was loaded. Now, the verification is in a .then block that runs once the page is confirmed to be loaded.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Just run grade_inquiries.spec.js via cypress locally.

### Automated Testing & Documentation
No tests needed.

### Other information
Not a breaking change
No migrations
No security concerns
