### PR TITLE
[Testing:Developer] update & fix submitty_test js/css lint

### DIFF
--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -22,7 +22,6 @@ run_npm_scripts_in_tmp_dir() {
 
     echo "Copying site/ to /tmp/submitty_test to bypass permissions..."
 
-    # copy site/ to a folder in /tmp
     TMP_FOLDER="/tmp/submitty_test"
 
     mkdir -p "$TMP_FOLDER"
@@ -57,7 +56,7 @@ run_npm_scripts_in_tmp_dir() {
         rsync -a --exclude='node_modules' . "$OLDPWD/"
     fi
 
-    # exit and clean up the temporary directory
+    # exit /tmp/submitty_test
     popd > /dev/null || {
         echo "ERROR: failed to exit /tmp/submitty_test"
         exit 1

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -17,12 +17,22 @@ run_php_cs() {
 
 run_js_es() {
     npm install
-    npm run eslint
+    node node_modules/.bin/eslint .
+}
+
+run_js_es_fix() {
+    npm install
+    node node_modules/.bin/eslint . --fix
 }
 
 run_css_style() {
     npm install
-    npm run css-stylelint
+    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}"
+}
+
+run_css_style_fix() {
+    npm install
+    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}"
 }
 
 run_php_unit() {
@@ -50,8 +60,12 @@ elif [ "$1" == "php-unit" ]; then
     run_php_unit "$@"
 elif [ "$1" == "js-lint" ]; then
     run_js_es
+elif [ "$1" == "js-lint --fix" ]; then
+    run_js_es_fix
 elif [ "$1" == "css-lint" ]; then
     run_css_style
+elif [ "$1" == "css-lint --fix" ]; then
+    run_css_style_fix
 else
     echo "Unknown test type: $1
         use phpstan, phpcs, php-lint, php-unit, js-lint, css-lint

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -20,21 +20,23 @@ run_npm_scripts_in_tmp_dir() {
     local script="$1"
     local option="$2"
 
-    echo "Copying node_modules to /tmp to bypass permissions..."
+    echo "Copying site/ to /tmp/submitty_test to bypass permissions..."
 
-    # Create a random temporary folder for node_modules
-    TMP_FOLDER=$(mktemp -d /tmp/submitty_test_XXXXXX)
+    # copy site/ to a folder in /tmp
+    TMP_FOLDER="/tmp/submitty_test"
+
+    mkdir -p "$TMP_FOLDER"
 
     if [ ! -d "$TMP_FOLDER" ]; then
-        echo "ERROR: The temporary folder could not be generated."
+        echo "ERROR: The /tmp/submitty_test folder could not be generated."
         exit 1
     fi
 
-    rsync -a --exclude='node_modules' . "$TMP_FOLDER/"
+    rsync -a --delete --exclude='node_modules' . "$TMP_FOLDER/"
 
     # change to tmp folder
     pushd "$TMP_FOLDER" > /dev/null || {
-        echo "Failed to change to the temporary folder."
+        echo "Failed to change to /tmp/submitty_test"
         exit 1
     }
 
@@ -57,10 +59,9 @@ run_npm_scripts_in_tmp_dir() {
 
     # exit and clean up the temporary directory
     popd > /dev/null || {
-        echo "ERROR: failed to exit the temporary directory."
+        echo "ERROR: failed to exit /tmp/submitty_test"
         exit 1
     }
-    rm -rf "$TMP_FOLDER"
 
     return $result
 

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -17,22 +17,12 @@ run_php_cs() {
 
 run_js_es() {
     npm install
-    node node_modules/.bin/eslint .
-}
-
-run_js_es_fix() {
-    npm install
-    node node_modules/.bin/eslint . --fix
+    node node_modules/.bin/eslint . "${@:2}"
 }
 
 run_css_style() {
     npm install
-    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}"
-}
-
-run_css_style_fix() {
-    npm install
-    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}"
+    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}" "${@:2}"
 }
 
 run_php_unit() {
@@ -59,13 +49,9 @@ elif [ "$1" == "php-lint" ]; then
 elif [ "$1" == "php-unit" ]; then
     run_php_unit "$@"
 elif [ "$1" == "js-lint" ]; then
-    run_js_es
-elif [ "$1" == "js-lint --fix" ]; then
-    run_js_es_fix
+    run_js_es "$@"
 elif [ "$1" == "css-lint" ]; then
-    run_css_style
-elif [ "$1" == "css-lint --fix" ]; then
-    run_css_style_fix
+    run_css_style "$@"
 else
     echo "Unknown test type: $1
         use phpstan, phpcs, php-lint, php-unit, js-lint, css-lint

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -15,14 +15,63 @@ run_php_cs() {
     COMPOSER_ALLOW_SUPERUSER=1 composer run-script lint 2>/dev/null
 }
 
-run_js_es() {
+run_npm_scripts_in_tmp_dir() {
+
+    local script="$1"
+    local option="$2"
+
+    echo "Copying node_modules to /tmp to bypass permissions..."
+
+    # Create a random temporary folder for node_modules
+    TMP_FOLDER=$(mktemp -d /tmp/submitty_test_XXXXXX)
+
+    if [ ! -d "$TMP_FOLDER" ]; then
+        echo "ERROR: The temporary folder could not be generated."
+        exit 1
+    fi
+
+    rsync -a --exclude='node_modules' . "$TMP_FOLDER/"
+
+    # change to tmp folder
+    pushd "$TMP_FOLDER" > /dev/null || {
+        echo "Failed to change to the temporary folder."
+        exit 1
+    }
+
+    # set up npm
     npm install
-    node node_modules/.bin/eslint . "${@:2}"
+    chmod -R +x node_modules/.bin/
+
+    if [ "$option" = "--fix" ]; then
+        npm run "${script}:fix"
+    else
+        npm run "$script"
+    fi
+
+    local result=$?
+
+    if [ "$option" = "--fix" ]; then
+        echo "Syncing fixed files back to the shared mount..."
+        rsync -a --exclude='node_modules' . "$OLDPWD/"
+    fi
+
+    # exit and clean up the temporary directory
+    popd > /dev/null || {
+        echo "ERROR: failed to exit the temporary directory."
+        exit 1
+    }
+    rm -rf "$TMP_FOLDER"
+
+    return $result
+
+}
+
+run_js_es() {
+    run_npm_scripts_in_tmp_dir "eslint" "$2"
 }
 
 run_css_style() {
-    npm install
-    node node_modules/stylelint/bin/stylelint.mjs "**/*.{css,vue}" "${@:2}"
+    run_npm_scripts_in_tmp_dir "css-stylelint" "$2"
 }
 
 run_php_unit() {


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #12958 
Before, the submitty_test script used npm run to execute the js and css linting packages. However, this didn't work because the permissions in the directory submitty_test accesses did not allow npm to execute the modules. 

### What is the New Behavior?
You can now properly use the submitty_test script on js-lint, css-lint, js-lint --fix, and css-lint --fix modes. EDIT: the fix was to move to a different directory where the permissions could be set appropriately and run the tests there.

One thing that was added in this PR was the functionality of the --fix command on both js and css linting. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. verify that the linters do not work on main and say access denied
- vagrant up & vagrant ssh
- `submitty_test js-lint` should say sh: 1: eslint: permission denied
- `submitty_test css-lint` should say sh: 1: stylelint: permission denied
2. run submitty_install on the branch and repeat the test
- note, it will be helpful to insert some typos into relevant files to fully test. 
- `submitty_test js-lint` should work
- `submitty_test css-lint` should work
- `submitty_test js-lint --fix` should fix the fixable errors
- `submitty_test css-lint --fix` should fix the fixable errors

### Automated Testing & Documentation
This feature does not need to be tested by automated testing and should only affect the developer tool in the VM.
The documentation for the usage of js-lint and css-lint is outdated and inconsistent and will need to be updated.

### Other information
Not a breaking change.
