### PR TITLE
[Bugfix:Testing] grade_inquiries spec race condition

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
@@ -71,6 +71,8 @@ describe('Test cases revolving around grade inquiries', () => {
                 verifyWebSocketStatus();
             });
 
+            cy.visit('/');
+
             // need to clear local storage to refresh grader's responsibility page
             cy.logout();
             cy.clearCookies();
@@ -110,3 +112,4 @@ describe('Test cases revolving around grade inquiries', () => {
         setGradeInquiriesForGradeable(gradeableId, originalGradeInquiryDate);
     });
 });
+

--- a/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/grade_inquiries.spec.js
@@ -71,6 +71,7 @@ describe('Test cases revolving around grade inquiries', () => {
                 verifyWebSocketStatus();
             });
 
+            // redirect page in order to avoid race condition
             cy.visit('/');
 
             // need to clear local storage to refresh grader's responsibility page
@@ -112,4 +113,3 @@ describe('Test cases revolving around grade inquiries', () => {
         setGradeInquiriesForGradeable(gradeableId, originalGradeInquiryDate);
     });
 });
-

--- a/site/public/js/testcase-output.js
+++ b/site/public/js/testcase-output.js
@@ -241,4 +241,3 @@ function loadAllTestCaseOutput(div_name, expand_all, num_test_cases, gradeable_i
 
     CheckStatesOfAllTestCases(num_test_cases, expand_all);
 }
-

--- a/site/public/js/testcase-output.js
+++ b/site/public/js/testcase-output.js
@@ -1,13 +1,13 @@
 // Map to store the XMLHttpRequest object returned by getJSON when getting the
 // output to display in loadTestCaseOutput()
 // Key: div_name ("testcase_" + index)   Value: XMLHttpRequest object
-const loading_test_cases_xml_http_requests = new Map();
+window.loading_test_cases_xml_http_requests = window.loading_test_cases_xml_http_requests || new Map();
 
 // String containing the name of the div for expand all toggle
-const expand_all_toggle_div_name = '#tc_expand_all';
+window.expand_all_toggle_div_name = window.expand_all_toggle_div_name || '#tc_expand_all';
 
 // String containing the name of the div for collapse all toggle
-const collapse_all_toggle_div_name = '#tc_collapse_all';
+window.collapse_all_toggle_div_name = window.collapse_all_toggle_div_name || '#tc_collapse_all';
 
 /**
  * Collapses test case output. If all test cases have been collapsed,
@@ -48,14 +48,14 @@ function CollapseTestCaseOutput(div_name, index, num_test_cases, loadingTools, c
  */
 function EnableExpandAllOrCollapseAllToggles(enable_expand_all) {
     if (enable_expand_all) {
-        $(expand_all_toggle_div_name).css('cursor', 'pointer');
-        const expand_all_loading_tools = $(expand_all_toggle_div_name).find('.loading-tools');
+        $(window.expand_all_toggle_div_name).css('cursor', 'pointer');
+        const expand_all_loading_tools = $(window.expand_all_toggle_div_name).find('.loading-tools');
         expand_all_loading_tools.find('.loading-tools-show').css('color', 'var(--standard-deep-blue)');
         expand_all_loading_tools.find('.loading-tools-show').css('textDecoration', 'underline');
     }
     else {
-        $(collapse_all_toggle_div_name).css('cursor', 'pointer');
-        const collapse_all_loading_tools = $(collapse_all_toggle_div_name).find('.loading-tools');
+        $(window.collapse_all_toggle_div_name).css('cursor', 'pointer');
+        const collapse_all_loading_tools = $(window.collapse_all_toggle_div_name).find('.loading-tools');
         collapse_all_loading_tools.find('.loading-tools-hide').css('color', 'var(--standard-deep-blue)');
         collapse_all_loading_tools.find('.loading-tools-hide').css('textDecoration', 'underline');
     }
@@ -93,15 +93,15 @@ function CheckStatesOfAllTestCases(num_test_cases, are_test_cases_expanded) {
     if (test_cases_have_same_state) {
         if (are_test_cases_expanded) {
             EnableExpandAllOrCollapseAllToggles(false);
-            $(expand_all_toggle_div_name).css('cursor', 'default');
-            const expand_all_loading_tools = $(expand_all_toggle_div_name).find('.loading-tools');
+            $(window.expand_all_toggle_div_name).css('cursor', 'default');
+            const expand_all_loading_tools = $(window.expand_all_toggle_div_name).find('.loading-tools');
             expand_all_loading_tools.find('.loading-tools-show').css('color', 'var(--standard-medium-dark-gray)');
             expand_all_loading_tools.find('.loading-tools-show').css('textDecoration', 'none');
         }
         else {
             EnableExpandAllOrCollapseAllToggles(true);
-            $(collapse_all_toggle_div_name).css('cursor', 'default');
-            const collapse_all_loading_tools = $(collapse_all_toggle_div_name).find('.loading-tools');
+            $(window.collapse_all_toggle_div_name).css('cursor', 'default');
+            const collapse_all_loading_tools = $(window.collapse_all_toggle_div_name).find('.loading-tools');
             collapse_all_loading_tools.find('.loading-tools-hide').css('color', 'var(--standard-medium-dark-gray)');
             collapse_all_loading_tools.find('.loading-tools-hide').css('textDecoration', 'none');
         }
@@ -134,13 +134,13 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
     const loadingTools = $(`#tc_${index}`).find('.loading-tools');
 
     // Checks if output for this div is being loaded
-    if (loading_test_cases_xml_http_requests.has(orig_div_name)) {
+    if (window.loading_test_cases_xml_http_requests.has(orig_div_name)) {
         // Checks if xhr is defined and has not succeeded yet
         // If so, abort loading
-        const xhr = loading_test_cases_xml_http_requests.get(orig_div_name);
+        const xhr = window.loading_test_cases_xml_http_requests.get(orig_div_name);
         if (xhr && xhr.readyState !== 4) {
             xhr.abort();
-            loading_test_cases_xml_http_requests.delete(orig_div_name);
+            window.loading_test_cases_xml_http_requests.delete(orig_div_name);
         }
     }
 
@@ -163,7 +163,7 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
             CheckStatesOfAllTestCases(num_test_cases, true);
         }
 
-        loading_test_cases_xml_http_requests.set(orig_div_name, $.getJSON({
+        window.loading_test_cases_xml_http_requests.set(orig_div_name, $.getJSON({
             url: url,
             async: true,
             success: function (response) {
@@ -171,7 +171,7 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
                     alert(`Error getting file diff: ${response.message}`);
                     return;
                 }
-                loading_test_cases_xml_http_requests.delete(orig_div_name);
+                window.loading_test_cases_xml_http_requests.delete(orig_div_name);
 
                 $(div_name).empty();
                 // eslint-disable-next-line no-restricted-syntax
@@ -186,15 +186,15 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
                 enableKeyToClick();
             },
             error: function (e) {
-                // Check if error was occurred by candelling a test case
-                if (loading_test_cases_xml_http_requests.has(orig_div_name) && loading_test_cases_xml_http_requests.get(orig_div_name).readyState === 0) {
-                    loading_test_cases_xml_http_requests.delete(orig_div_name);
+                // Check if error was occurred by cancelling a test case
+                if (window.loading_test_cases_xml_http_requests.has(orig_div_name) && window.loading_test_cases_xml_http_requests.get(orig_div_name).readyState === 0) {
+                    window.loading_test_cases_xml_http_requests.delete(orig_div_name);
                     CollapseTestCaseOutput(orig_div_name, index, num_test_cases, loadingTools, check_all_test_cases_states);
                 }
                 else {
                     // Display error message once
-                    loading_test_cases_xml_http_requests.delete(orig_div_name);
-                    if (loading_test_cases_xml_http_requests.size === 0) {
+                    window.loading_test_cases_xml_http_requests.delete(orig_div_name);
+                    if (window.loading_test_cases_xml_http_requests.size === 0) {
                         alert('Could not load diff, please refresh the page and try again.');
                         console.log(e);
                         // eslint-disable-next-line no-undef

--- a/site/public/js/testcase-output.js
+++ b/site/public/js/testcase-output.js
@@ -1,13 +1,13 @@
 // Map to store the XMLHttpRequest object returned by getJSON when getting the
 // output to display in loadTestCaseOutput()
 // Key: div_name ("testcase_" + index)   Value: XMLHttpRequest object
-window.loading_test_cases_xml_http_requests = window.loading_test_cases_xml_http_requests || new Map();
+const loading_test_cases_xml_http_requests = new Map();
 
 // String containing the name of the div for expand all toggle
-window.expand_all_toggle_div_name = window.expand_all_toggle_div_name || '#tc_expand_all';
+const expand_all_toggle_div_name = '#tc_expand_all';
 
 // String containing the name of the div for collapse all toggle
-window.collapse_all_toggle_div_name = window.collapse_all_toggle_div_name || '#tc_collapse_all';
+const collapse_all_toggle_div_name = '#tc_collapse_all';
 
 /**
  * Collapses test case output. If all test cases have been collapsed,
@@ -48,14 +48,14 @@ function CollapseTestCaseOutput(div_name, index, num_test_cases, loadingTools, c
  */
 function EnableExpandAllOrCollapseAllToggles(enable_expand_all) {
     if (enable_expand_all) {
-        $(window.expand_all_toggle_div_name).css('cursor', 'pointer');
-        const expand_all_loading_tools = $(window.expand_all_toggle_div_name).find('.loading-tools');
+        $(expand_all_toggle_div_name).css('cursor', 'pointer');
+        const expand_all_loading_tools = $(expand_all_toggle_div_name).find('.loading-tools');
         expand_all_loading_tools.find('.loading-tools-show').css('color', 'var(--standard-deep-blue)');
         expand_all_loading_tools.find('.loading-tools-show').css('textDecoration', 'underline');
     }
     else {
-        $(window.collapse_all_toggle_div_name).css('cursor', 'pointer');
-        const collapse_all_loading_tools = $(window.collapse_all_toggle_div_name).find('.loading-tools');
+        $(collapse_all_toggle_div_name).css('cursor', 'pointer');
+        const collapse_all_loading_tools = $(collapse_all_toggle_div_name).find('.loading-tools');
         collapse_all_loading_tools.find('.loading-tools-hide').css('color', 'var(--standard-deep-blue)');
         collapse_all_loading_tools.find('.loading-tools-hide').css('textDecoration', 'underline');
     }
@@ -93,15 +93,15 @@ function CheckStatesOfAllTestCases(num_test_cases, are_test_cases_expanded) {
     if (test_cases_have_same_state) {
         if (are_test_cases_expanded) {
             EnableExpandAllOrCollapseAllToggles(false);
-            $(window.expand_all_toggle_div_name).css('cursor', 'default');
-            const expand_all_loading_tools = $(window.expand_all_toggle_div_name).find('.loading-tools');
+            $(expand_all_toggle_div_name).css('cursor', 'default');
+            const expand_all_loading_tools = $(expand_all_toggle_div_name).find('.loading-tools');
             expand_all_loading_tools.find('.loading-tools-show').css('color', 'var(--standard-medium-dark-gray)');
             expand_all_loading_tools.find('.loading-tools-show').css('textDecoration', 'none');
         }
         else {
             EnableExpandAllOrCollapseAllToggles(true);
-            $(window.collapse_all_toggle_div_name).css('cursor', 'default');
-            const collapse_all_loading_tools = $(window.collapse_all_toggle_div_name).find('.loading-tools');
+            $(collapse_all_toggle_div_name).css('cursor', 'default');
+            const collapse_all_loading_tools = $(collapse_all_toggle_div_name).find('.loading-tools');
             collapse_all_loading_tools.find('.loading-tools-hide').css('color', 'var(--standard-medium-dark-gray)');
             collapse_all_loading_tools.find('.loading-tools-hide').css('textDecoration', 'none');
         }
@@ -134,13 +134,13 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
     const loadingTools = $(`#tc_${index}`).find('.loading-tools');
 
     // Checks if output for this div is being loaded
-    if (window.loading_test_cases_xml_http_requests.has(orig_div_name)) {
+    if (loading_test_cases_xml_http_requests.has(orig_div_name)) {
         // Checks if xhr is defined and has not succeeded yet
         // If so, abort loading
-        const xhr = window.loading_test_cases_xml_http_requests.get(orig_div_name);
+        const xhr = loading_test_cases_xml_http_requests.get(orig_div_name);
         if (xhr && xhr.readyState !== 4) {
             xhr.abort();
-            window.loading_test_cases_xml_http_requests.delete(orig_div_name);
+            loading_test_cases_xml_http_requests.delete(orig_div_name);
         }
     }
 
@@ -163,7 +163,7 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
             CheckStatesOfAllTestCases(num_test_cases, true);
         }
 
-        window.loading_test_cases_xml_http_requests.set(orig_div_name, $.getJSON({
+        loading_test_cases_xml_http_requests.set(orig_div_name, $.getJSON({
             url: url,
             async: true,
             success: function (response) {
@@ -171,7 +171,7 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
                     alert(`Error getting file diff: ${response.message}`);
                     return;
                 }
-                window.loading_test_cases_xml_http_requests.delete(orig_div_name);
+                loading_test_cases_xml_http_requests.delete(orig_div_name);
 
                 $(div_name).empty();
                 // eslint-disable-next-line no-restricted-syntax
@@ -186,15 +186,15 @@ function loadTestCaseOutput(div_name, gradeable_id, who_id, index, num_test_case
                 enableKeyToClick();
             },
             error: function (e) {
-                // Check if error was occurred by cancelling a test case
-                if (window.loading_test_cases_xml_http_requests.has(orig_div_name) && window.loading_test_cases_xml_http_requests.get(orig_div_name).readyState === 0) {
-                    window.loading_test_cases_xml_http_requests.delete(orig_div_name);
+                // Check if error was occurred by candelling a test case
+                if (loading_test_cases_xml_http_requests.has(orig_div_name) && loading_test_cases_xml_http_requests.get(orig_div_name).readyState === 0) {
+                    loading_test_cases_xml_http_requests.delete(orig_div_name);
                     CollapseTestCaseOutput(orig_div_name, index, num_test_cases, loadingTools, check_all_test_cases_states);
                 }
                 else {
                     // Display error message once
-                    window.loading_test_cases_xml_http_requests.delete(orig_div_name);
-                    if (window.loading_test_cases_xml_http_requests.size === 0) {
+                    loading_test_cases_xml_http_requests.delete(orig_div_name);
+                    if (loading_test_cases_xml_http_requests.size === 0) {
                         alert('Could not load diff, please refresh the page and try again.');
                         console.log(e);
                         // eslint-disable-next-line no-undef
@@ -241,3 +241,4 @@ function loadAllTestCaseOutput(div_name, expand_all, num_test_cases, gradeable_i
 
     CheckStatesOfAllTestCases(num_test_cases, expand_all);
 }
+


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The grade inquiries spec was failing when calling the function `verifyWebSocketStatus()` because, for some reason, it attempted to edit/redefine a const variable in the testcase-output.js file. Specifically, loading_test_cases_xml_http_requests. I believe this was down to a race condition in the end of this part of the test.

### What is the New Behavior?
The grade_inquires spec should now pass. The test simply navigates away from the page once it is finished testing 'Test cases revolving around grade inquiries'.

### What steps should a reviewer take to reproduce or test the bug or new feature?
On main:
1. run grade_inquries.spec.js locally and observe this:
<img width="859" height="975" alt="image" src="https://github.com/user-attachments/assets/4860d044-9b4e-4f00-bcb3-96fc9d404b68" />


On the branch:
1. Verify regular usage of cypress works as intended.
2. Especially, run grade_inquiries.spec.js and observe that it works.

### Automated Testing & Documentation


### Other information
If there is some other bug with grade_inquiries or the grade_inquiries spec that is causing this, I was unable to determine what it was.
