### PR TITLE
[Bugfix:Developer] trust hashicorp for vagrant install

### DIFF
--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -17,8 +17,9 @@ jobs:
           fetch-depth: 0
       - name: Install vagrant
         run: |
+          brew tap hashicorp/tap
           brew trust --formula hashicorp/tap/vagrant
-          brew install vagrant
+          brew install hashicorp/tap/hashicorp-vagrant
 
       - name: install virtual box 7.0.20
         run: |

--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -16,7 +16,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install vagrant
-        run: brew install vagrant
+        run: |
+          brew trust hashicorp/tap
+          brew install vagrant
 
       - name: install virtual box 7.0.20
         run: |

--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Install vagrant
         run: |
-          brew trust hashicorp/tap
+          brew trust --formula hashicorp/tap/vagrant
           brew install vagrant
 
       - name: install virtual box 7.0.20


### PR DESCRIPTION
### Why is this Change Important & Necessary?
the install of vagrant was failing on the prepackage cloud vm runner due to 'Error: Refusing to load formula hashicorp/tap/vagrant from untrusted tap hashicorp/tap'.

### What is the New Behavior?
https://developer.hashicorp.com/vagrant/install 
vagrant is installed per the hashicorp documentation for the install of vagrant on macos using homebrew.
Additionally, the tap is set to be trusted so the install is always run.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Observe the most recent run of the Prepackage Cloud VM Action on this branch. 

### Automated Testing & Documentation


### Other information
pr created to test the github action
