### PR TITLE
[Bugfix:InstructorUI] Fix markdown in notebook builder

### DIFF
--- a/site/public/css/notebook-builder.css
+++ b/site/public/css/notebook-builder.css
@@ -18,7 +18,6 @@
     justify-content: space-between;
 }
 
-
 .widget-main {
     padding: 10px;
     margin-right: 10px;

--- a/site/public/css/notebook-builder.css
+++ b/site/public/css/notebook-builder.css
@@ -18,6 +18,7 @@
     justify-content: space-between;
 }
 
+
 .widget-main {
     padding: 10px;
     margin-right: 10px;
@@ -70,6 +71,11 @@
     width: 100%;
     margin-right: 10px;
     min-height: 75px;
+}
+
+.markdown-widget .markdown-area-wrapper {
+    flex: 1;
+    min-width: 0;
 }
 
 /**

--- a/site/public/js/notebook_builder/widgets/markdown-widget.js
+++ b/site/public/js/notebook_builder/widgets/markdown-widget.js
@@ -30,6 +30,7 @@ class MarkdownWidget extends Widget {
         interactive_area.appendChild(label);
 
         const markdownArea = document.createElement('div');
+        markdownArea.classList.add('markdown-area-wrapper');
         interactive_area.appendChild(markdownArea);
         window.submitty.render(markdownArea, 'component', 'MarkdownArea', {
             markdownAreaId: `notebook-builder-markdown-${NUM_MARKDOWN}`,


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes Issue [#12932](https://github.com/Submitty/Submitty/issues/12932)

### What is the New Behavior?
Prior, the markdown box in the notebook component would appear as follows:
<img width="2244" height="520" alt="image" src="https://github.com/user-attachments/assets/6fe2b02f-f772-410e-90d8-a1144c7c3928" />
It now appears as it should:
<img width="2320" height="664" alt="image" src="https://github.com/user-attachments/assets/ff3025f0-1cb1-485f-a669-c2fc1d792757" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create a new gradeable
2. Fill in the title, URL, and ID for the gradeable
3. Click students will submit one or more files by direct upload to the Submitty website
4. Click that some of this assignment will be manually graded
5. Click no for the rest of the options
6. Go to the submissions/autograding tab
7. Click start new under the notebook builder section
8. Add a markdown component
9. See new behavior 

### Automated Testing & Documentation
This feature is not covered by any tests (to my knowledge).