### PR TITLE
[Bugfix:InstructorUI] Histogram bucket fix

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/StatusBase.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusBase.twig
@@ -23,17 +23,16 @@
     }
 
     function fillBuckets(range, increment, betterBuckets, xValue, yValue, xBuckets, mode, modeCount, max, min) {
-        // number of buckets
         let numBuckets;
         if (increment === 1) {
-            numBuckets = Math.round(range / increment) + 1; // one bucket per value, max inclusive
+            numBuckets = Math.round(range / increment) + 1;
         } else {
             numBuckets = Math.max(1, Math.ceil(range / increment));
         }
 
         const counts = new Array(numBuckets).fill(0);
 
-        // labels (kept identical to the original formatting)
+        // labels
         for (let b = 0; b < numBuckets; b++) {
             const lo = +parseFloat(min + b * increment).toPrecision(4);
             const hi = +parseFloat(min + (b + 1) * increment).toPrecision(4);
@@ -44,15 +43,14 @@
             }
         }
 
-        // assign each score to exactly one bucket — conserves the total
+        // assign each score to exactly one bucket
         for (let s = 0; s < xValue.length; s++) {
             let idx = Math.floor((xValue[s] - min) / increment);
             if (idx < 0) idx = 0;
-            if (idx >= numBuckets) idx = numBuckets - 1; // also catches score === max
+            if (idx >= numBuckets) idx = numBuckets - 1;
             counts[idx]++;
         }
 
-        // counts -> yValue, and compute mode from the actual bucket
         mode = xBuckets[0];
         modeCount = -1;
         for (let b = 0; b < numBuckets; b++) {

--- a/site/app/templates/grading/electronic/ta_status/StatusBase.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusBase.twig
@@ -22,48 +22,45 @@
         return data;
     }
 
-    function fillBuckets(range,increment,betterBuckets,xValue,yValue,xBuckets,mode,modeCount,max,min){
-        let loop = Math.ceil(range/increment);
-        if(increment === 1){
-            loop += 1
+    function fillBuckets(range, increment, betterBuckets, xValue, yValue, xBuckets, mode, modeCount, max, min) {
+        // number of buckets
+        let numBuckets;
+        if (increment === 1) {
+            numBuckets = Math.round(range / increment) + 1; // one bucket per value, max inclusive
+        } else {
+            numBuckets = Math.max(1, Math.ceil(range / increment));
         }
-        let tracking = min;
-        for(i = 0;i<loop;i++){
-            betterBuckets.set(tracking,0);
-            tracking = +parseFloat(tracking+increment).toPrecision(4);
-            if(i===(loop-1)){
-                if(increment === 1){
-                    xBuckets.push(String(max));
-                }else{
-                    xBuckets.push(+parseFloat(tracking-increment).toPrecision(4)+" to <="+max);
-                }
-            }else{
-               xBuckets.push(+parseFloat(tracking-increment).toPrecision(4)+" to <"+tracking);
+
+        const counts = new Array(numBuckets).fill(0);
+
+        // labels (kept identical to the original formatting)
+        for (let b = 0; b < numBuckets; b++) {
+            const lo = +parseFloat(min + b * increment).toPrecision(4);
+            const hi = +parseFloat(min + (b + 1) * increment).toPrecision(4);
+            if (b === numBuckets - 1) {
+                xBuckets.push(increment === 1 ? String(max) : (lo + " to <=" + max));
+            } else {
+                xBuckets.push(lo + " to <" + hi);
             }
         }
-        var maxMin = tracking-increment;
-        var ct = 0;
-        for(i = 0;i<xValue.length;i++){
-           ct++;
-           for(var [key,value] of betterBuckets){
-                if(key===maxMin){
-                    if(xValue[i]>=key&&xValue[i]<=max){
-                       betterBuckets.set(key,value+1);
-                   }
-                }
-               else{
-                    if(xValue[i]>=key && xValue[i]<(key+increment)){
-                        betterBuckets.set(key,value+1);
-                    }
-                }
-           }
+
+        // assign each score to exactly one bucket — conserves the total
+        for (let s = 0; s < xValue.length; s++) {
+            let idx = Math.floor((xValue[s] - min) / increment);
+            if (idx < 0) idx = 0;
+            if (idx >= numBuckets) idx = numBuckets - 1; // also catches score === max
+            counts[idx]++;
         }
-        for(var[key,value]of betterBuckets){
-            if(value>modeCount){
-                modeCount=value;
-                mode = key+" to <"+(key+increment);
+
+        // counts -> yValue, and compute mode from the actual bucket
+        mode = xBuckets[0];
+        modeCount = -1;
+        for (let b = 0; b < numBuckets; b++) {
+            yValue.push(counts[b]);
+            if (counts[b] > modeCount) {
+                modeCount = counts[b];
+                mode = xBuckets[b];
             }
-            yValue.push(value);
         }
         return mode;
     }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [Issue#12410](https://github.com/Submitty/Submitty/issues/12410)

### What is the New Behavior?
Prior, when using the histogram buckets, entries would commonly be lost due to how the previous increment sorting worked. The way the increments are determined and compared against was updated so that entries will no longer be lost.
For screenshots of the prior behavior, refer to to the linked issue above. 
The new behavior is displayed here:
<img width="2246" height="964" alt="image" src="https://github.com/user-attachments/assets/0a179d77-f281-4b2e-b931-a41852e16bf9" />
Notice how the total number of entries is 60.
<img width="2240" height="968" alt="image" src="https://github.com/user-attachments/assets/48ac0a21-aaee-4306-bdf9-b9204a42aa19" />
Changing the bucket to include all entries in one column, the number of entries should stay the same. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Run `submitty_install_site`
2. Log in as instructor
3. Go to any gradeable with a decent amount of submissions, the `C System Calls` and `C++ Hidden Tests` work best as they have manual and autograding results with many sample submissions.
4. Click the grade or regrade button
5. Click `Statistics and Charts`
6. Within any of the histogram tabs test different bucket sizes and verify no entries are lost.

### Automated Testing & Documentation
This feature is not tested by E2E testing.
