### PR TITLE
[Bugfix:Testing] Fix specs that hardcode term

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/files_panel.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/files_panel.spec.js
@@ -1,3 +1,5 @@
+import { getCurrentSemester } from '/cypress/support/utils.js';
+
 function assertSubmissionsBrowserClosed() {
     cy.get('#div_viewer_sd1').should('not.be.visible');
 }
@@ -271,7 +273,7 @@ describe('Test cases involving auto opening single file submissions', () => {
         assertSingleImageSubmissionOpen();
 
         // wait for PDF to fully load in, or an error will occur when it's interrupted by logout
-        cy.intercept('/courses/s26/sample/gradeable/grading_homework_pdf/encode_pdf').as('pdf');
+        cy.intercept(`/courses/${getCurrentSemester()}/sample/gradeable/grading_homework_pdf/encode_pdf').as('pdf`);
         cy.wait('@pdf');
     });
 

--- a/site/cypress/e2e/Cypress-Feature/files_panel.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/files_panel.spec.js
@@ -273,7 +273,7 @@ describe('Test cases involving auto opening single file submissions', () => {
         assertSingleImageSubmissionOpen();
 
         // wait for PDF to fully load in, or an error will occur when it's interrupted by logout
-        cy.intercept(`/courses/${getCurrentSemester()}/sample/gradeable/grading_homework_pdf/encode_pdf').as('pdf`);
+        cy.intercept(`/courses/${getCurrentSemester()}/sample/gradeable/grading_homework_pdf/encode_pdf`).as('pdf');
         cy.wait('@pdf');
     });
 

--- a/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
@@ -1,4 +1,4 @@
-import { getCurrentSemester } from 'site/cypress/support/utils.js'
+import { getCurrentSemester } from '/cypress/support/utils.js'
 
 describe('Limited Access Grader Submission View Restriction', () => {
     it('Should redirect limited access grader trying to view submission before grade start date', () => {

--- a/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
@@ -1,4 +1,4 @@
-import { getCurrentSemester } from '/cypress/support/utils.js'
+import { getCurrentSemester } from '/cypress/support/utils.js';
 
 describe('Limited Access Grader Submission View Restriction', () => {
     it('Should redirect limited access grader trying to view submission before grade start date', () => {

--- a/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
@@ -21,7 +21,7 @@ describe('Limited Access Grader Submission View Restriction', () => {
             }
         });
         cy.contains('td', 'boehmd').siblings('td').find('a[data-testid="grade-button"]').click();
-        cy.url().should('include', '/courses/${getCurrentSemester()}/sample');
+        cy.url().should('include', `/courses/${getCurrentSemester()}/sample`);
         cy.url().should('not.include', 'grading/grade');
         cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'You do not have permission to view submissions until grading opens.');
     });

--- a/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/limited_access_grader.spec.js
@@ -1,3 +1,5 @@
+import { getCurrentSemester } from 'site/cypress/support/utils.js'
+
 describe('Limited Access Grader Submission View Restriction', () => {
     it('Should redirect limited access grader trying to view submission before grade start date', () => {
         // Login as an instructor and submit on behalf of a student with user id boehmd
@@ -19,7 +21,7 @@ describe('Limited Access Grader Submission View Restriction', () => {
             }
         });
         cy.contains('td', 'boehmd').siblings('td').find('a[data-testid="grade-button"]').click();
-        cy.url().should('include', '/courses/s26/sample');
+        cy.url().should('include', '/courses/${getCurrentSemester()}/sample');
         cy.url().should('not.include', 'grading/grade');
         cy.get('[data-testid="popup-message"]').should('be.visible').and('contain', 'You do not have permission to view submissions until grading opens.');
     });

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
@@ -1,4 +1,4 @@
-import { getCurrentSemester } from 'site/cypress/support/utils.js'
+import { getCurrentSemester } from '/cypress/support/utils.js'
 
 describe('TA Grading Panel Switcher', () => {
     const panels = [

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
@@ -1,3 +1,5 @@
+import { getCurrentSemester } from 'site/cypress/support/utils.js'
+
 describe('TA Grading Panel Switcher', () => {
     const panels = [
         {
@@ -110,7 +112,7 @@ describe('TA Grading Panel Switcher', () => {
         it(`Should show correct panel options for ${layout.name}`, () => {
             cy.login('ta');
 
-            cy.visit('/courses/s26/sample/gradeable/no_due_date_no_release/grading/grade?who_id=FI9yKu3j9DrXWt5&sort=id&direction=ASC');
+            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/no_due_date_no_release/grading/grade?who_id=FI9yKu3j9DrXWt5&sort=id&direction=ASC`);
 
             cy.log(`Testing layout: ${layout.name}`);
 

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
@@ -1,4 +1,4 @@
-import { getCurrentSemester } from '/cypress/support/utils.js'
+import { getCurrentSemester } from '/cypress/support/utils.js';
 
 describe('TA Grading Panel Switcher', () => {
     const panels = [


### PR DESCRIPTION
### Why is this Change Important & Necessary?

### What is the New Behavior?
some cypress specs are using hardcoded term values and fail when the testing term rolls over.

### What steps should a reviewer take to reproduce or test the bug or new feature?
updated the failing specs to no longer hardcode the term and instead use the function in utils.js to dynamically get the semester.

### Automated Testing & Documentation

### Other information

