### PR TITLE
[Feature:TAGrading] Numeric CSV Download

### DIFF
--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -8,12 +8,14 @@ use app\libraries\response\ResponseInterface;
 use app\models\gradeable\GradedGradeable;
 use app\models\User;
 use app\controllers\AbstractController;
+use app\entities\poll\Response;
 use app\libraries\Utils;
 use app\libraries\routers\AccessControl;
 use app\libraries\response\JsonResponse;
 use app\libraries\response\WebResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use app\libraries\socket\Client;
+use app\libraries\response\DownloadResponse;
 use WebSocket;
 
 /**
@@ -207,6 +209,141 @@ class SimpleGraderController extends AbstractController {
         );
     }
 
+    #[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grading/csv", methods:["GET"])]
+    public function downloadNumericCsv($gradeable_id, $sort = "section_subsection"): ResponseInterface {
+        try {
+            $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
+        }
+        catch (\InvalidArgumentException $e) {
+            return new WebResponse('Error', 'noGradeable', $gradeable_id);
+        }
+
+        if ($gradeable->getType() !== GradeableType::NUMERIC_TEXT) {
+            $this->core->addErrorMessage('This gradeable is not a numeric text gradeable');
+            return new RedirectResponse($this->core->buildCourseUrl());
+        }
+
+        // TODO: copy the same student/section/rows setup from gradePage()
+        // so access rules + sort match the actual grading page.
+
+        //If you can see the page, you can grade the page
+        if (!$this->core->getAccess()->canI("grading.simple.grade", ["gradeable" => $gradeable])) {
+            $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
+            return new RedirectResponse($this->core->buildCourseUrl());
+        }
+        if ($gradeable->isGradeByRegistration()) {
+            $grading_count = count($this->core->getUser()->getGradingRegistrationSections());
+        }
+        else {
+            $grading_count = count(
+                $this->core->getQueries()->getRotatingSectionsForGradeableAndUser(
+                    $gradeable->getId(),
+                    $this->core->getUser()->getId()
+                )
+            );
+        }
+
+        $can_show_all = $this->core->getAccess()->canI("grading.simple.show_all");
+        $show_all = $grading_count === 0 && $can_show_all;
+
+        if ($show_all) {
+            $sections = $gradeable->getAllGradingSections();
+        }
+        else {
+            $sections = $gradeable->getGradingSectionsForUser($this->core->getUser());
+        }
+
+        $students = [];
+        foreach ($sections as $section) {
+            $students = array_merge($students, $section->getUsers());
+        }
+
+        $student_ids = array_map(function (User $user) {
+            return $user->getId();
+        }, $students);
+
+        if ($gradeable->isGradeByRegistration()) {
+            $section_key = "registration_section";
+        }
+        else {
+            $section_key = "rotating_section";
+        }
+        //Sort the page:
+        if ($sort === "id") {
+            $sort_key = "u.user_id";
+        }
+
+        elseif ($sort === "first") {
+            $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
+        }
+
+        elseif ($sort === "last") {
+            $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
+        }
+        else {
+            $sort_key = "u.registration_subsection";
+        }
+
+        $fp = fopen('php://temp', 'r+');
+
+        $numeric_components = [];
+        $text_components = [];
+
+        foreach ($gradeable->getComponents() as $component) {
+            if ($component->isText()) {
+                $text_components[] = $component;
+            }
+            else {
+                $numeric_components[] = $component;
+            }
+        }
+
+        $header = [
+            "User ID",
+            "Given Name",
+            "Family Name",
+        ];
+
+        foreach ($numeric_components as $component) {
+            $header[] = $component->getTitle();
+        }
+
+        $header[] = "Total points earned";
+
+        foreach ($text_components as $component) {
+            $header[] = $component->getTitle();
+        }
+
+        fputcsv($fp, $header);
+
+        // TODO: foreach ($rows as $row) build data rows here
+        $rows = $this->core->getQueries()->getGradedGradeables(
+            [$gradeable],
+            $student_ids,
+            null,
+            [$section_key, $sort_key, "u.user_id"]
+        );
+        foreach ($rows as $row) {
+            $user = $row->getSubmitter()->getUser();
+            $csv_row = [
+                $user->getId(),
+                $user->getDisplayedGivenName(),
+                $user->getDisplayedFamilyName(),
+            ];
+
+            fputcsv($fp, $csv_row);
+        }
+        
+        rewind($fp);
+        $csv = stream_get_contents($fp);
+        fclose($fp);
+
+        return DownloadResponse::getDownloadResponse(
+            $csv,
+            "{$gradeable_id}.csv",
+            "application/csv"
+        );
+    }
     /**
      * @param string $gradeable_id
      *

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -8,7 +8,6 @@ use app\libraries\response\ResponseInterface;
 use app\models\gradeable\GradedGradeable;
 use app\models\User;
 use app\controllers\AbstractController;
-use app\entities\poll\Response;
 use app\libraries\Utils;
 use app\libraries\routers\AccessControl;
 use app\libraries\response\JsonResponse;
@@ -270,11 +269,11 @@ class SimpleGraderController extends AbstractController {
             $sort_key = "u.user_id";
         }
 
-        elseif ($sort === "first") {
+        else if ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
         }
 
-        elseif ($sort === "last") {
+        else if ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
         }
         else {

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -267,11 +267,9 @@ class SimpleGraderController extends AbstractController {
         //Sort the page:
         if ($sort === "id") {
             $sort_key = "u.user_id";
-        }
-
-        else if ($sort === "first") {
+        } elseif ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
-        } else if ($sort === "last") {
+        } elseif ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
         } else {
             $sort_key = "u.registration_subsection";

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -267,13 +267,16 @@ class SimpleGraderController extends AbstractController {
         //Sort the page:
         if ($sort === "id") {
             $sort_key = "u.user_id";
-        } 
+        }
+
         elseif ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
-        } 
+        }
+
         elseif ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
-        } 
+        }
+
         else {
             $sort_key = "u.registration_subsection";
         }

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -268,15 +268,12 @@ class SimpleGraderController extends AbstractController {
         if ($sort === "id") {
             $sort_key = "u.user_id";
         }
-
         elseif ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
         }
-
         elseif ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
         }
-
         else {
             $sort_key = "u.registration_subsection";
         }

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -267,11 +267,14 @@ class SimpleGraderController extends AbstractController {
         //Sort the page:
         if ($sort === "id") {
             $sort_key = "u.user_id";
-        } elseif ($sort === "first") {
+        } 
+        elseif ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
-        } elseif ($sort === "last") {
+        } 
+        elseif ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
-        } else {
+        } 
+        else {
             $sort_key = "u.registration_subsection";
         }
 

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -223,9 +223,6 @@ class SimpleGraderController extends AbstractController {
             return new RedirectResponse($this->core->buildCourseUrl());
         }
 
-        // TODO: copy the same student/section/rows setup from gradePage()
-        // so access rules + sort match the actual grading page.
-
         //If you can see the page, you can grade the page
         if (!$this->core->getAccess()->canI("grading.simple.grade", ["gradeable" => $gradeable])) {
             $this->core->addErrorMessage("You do not have permission to grade {$gradeable->getTitle()}");
@@ -305,7 +302,7 @@ class SimpleGraderController extends AbstractController {
         ];
 
         foreach ($numeric_components as $component) {
-            $header[] = $component->getTitle();
+            $header[] = $component->getTitle() . "(" . $component->getMaxValue() . ")";
         }
 
         $header[] = "Total points earned";
@@ -316,7 +313,6 @@ class SimpleGraderController extends AbstractController {
 
         fputcsv($fp, $header);
 
-        // TODO: foreach ($rows as $row) build data rows here
         $rows = $this->core->getQueries()->getGradedGradeables(
             [$gradeable],
             $student_ids,
@@ -331,9 +327,24 @@ class SimpleGraderController extends AbstractController {
                 $user->getDisplayedFamilyName(),
             ];
 
+            $ta_grade = $row->getTaGradedGradeable();
+            $total = 0;
+            foreach ($numeric_components as $component) {
+                $component_grade = $ta_grade !== null ? $ta_grade->getGradedComponent($component) : null;
+                $component_score = $component_grade !== null ? $component_grade->getScore() : 0;
+                $csv_row[] = $component_score;
+                $total += $component_score;
+            }
+
+            $csv_row[] = $total;
+            foreach ($text_components as $component) {
+                $component_grade = $ta_grade !== null ? $ta_grade->getGradedComponent($component) : null;
+                $csv_row[] = $component_grade !== null ? $component_grade->getComment() : "";
+            }
+
             fputcsv($fp, $csv_row);
         }
-        
+
         rewind($fp);
         $csv = stream_get_contents($fp);
         fclose($fp);

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -209,7 +209,7 @@ class SimpleGraderController extends AbstractController {
     }
 
     #[Route("/courses/{_semester}/{_course}/gradeable/{gradeable_id}/grading/csv", methods:["GET"])]
-    public function downloadNumericCsv($gradeable_id, $sort = "section_subsection"): ResponseInterface {
+    public function downloadNumericCsv(string $gradeable_id, string $sort = "section_subsection"): ResponseInterface {
         try {
             $gradeable = $this->core->getQueries()->getGradeableConfig($gradeable_id);
         }

--- a/site/app/controllers/grading/SimpleGraderController.php
+++ b/site/app/controllers/grading/SimpleGraderController.php
@@ -271,12 +271,9 @@ class SimpleGraderController extends AbstractController {
 
         else if ($sort === "first") {
             $sort_key = "coalesce(u.user_preferred_givenname, u.user_givenname)";
-        }
-
-        else if ($sort === "last") {
+        } else if ($sort === "last") {
             $sort_key = "coalesce(u.user_preferred_familyname, u.user_familyname)";
-        }
-        else {
+        } else {
             $sort_key = "u.registration_subsection";
         }
 

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -116,6 +116,13 @@
             <label for="csvUpload">Upload CSV
                 <input class="csvButtonUpload" type="file" id="csvUpload" accept=".csv, .txt">
             </label>
+            <a 
+                class="btn btn-primary"
+                id="csvDownload"
+                href="{{ csv_download_url }}?view={{ view_all ? 'all'}}&sort={{ sort}}"
+            >
+                Download CSV
+            </a>
             <p>
                 The CSV file should be formatted as such:
                 <br />

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -20,8 +20,21 @@
 
         <div>
             {% include "Vue.twig" with { 'type': 'component', 'name': 'FullScreenButton', 'class': 'fullscreen-btn-wrapper' } %}
+            {% if action == 'numeric' and core.getUser().accessAdmin() %}
+                <label for="csvUpload" class="btn btn-primary" tabindex="0">
+                    Upload CSV
+                </label>
+                <input class="csvButtonUpload" type="file" id="csvUpload" accept=".csv, .txt" style="display: none;">
+                <a 
+                    class="btn btn-primary"
+                    id="csvDownload"
+                    href="{{ csv_download_url }}?view={{ view_all ? 'all'}}&sort={{ sort}}"
+                >
+                    Download CSV
+                </a>
             <button class="btn btn-primary" tabindex="0" id="settings-btn" onclick='showSettings()'>Settings/Hotkeys</button>
             <button class="btn btn-primary" tabindex="0" id="simple-stats-btn" onclick='showSimpleGraderStats("{{ action }}")'>View Statistics</button>
+            {%endif %}
         </div>
     </div>
 
@@ -111,24 +124,12 @@
             </option>
         </select>
     </div>
-    {% if action == 'numeric' and core.getUser().accessAdmin() %}
-        <div class="column-wrapper">
-            <label for="csvUpload">Upload CSV
-                <input class="csvButtonUpload" type="file" id="csvUpload" accept=".csv, .txt">
-            </label>
-            <a 
-                class="btn btn-primary"
-                id="csvDownload"
-                href="{{ csv_download_url }}?view={{ view_all ? 'all'}}&sort={{ sort}}"
-            >
-                Download CSV
-            </a>
+        {% if action == 'numeric' and core.getUser().accessAdmin() %}
             <p>
                 The CSV file should be formatted as such:
                 <br />
                 user id,given name,family name,grade1,grade2,...,total points earned,text1,text2,...
             </p>
-        </div>
     {% endif %}
     <div class="scrollable-table">
 

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -96,6 +96,7 @@ class SimpleGraderView extends AbstractView {
             "print_lab_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'print']),
             "grading_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading']),
             "gradeable_url" => $gradeable->getInstructionsUrl(),
+            "csv_download_url" => $this->core->buildCourseUrl(['gradeable', $gradeable->getId(), 'grading', 'csv']),
             "user_id" => $this->core->getUser()->getId(),
             "anon_ids" => $anon_ids,
             'show_grader' => isset($_COOKIE['show_grader']) ? ($_COOKIE['show_grader'] === 'true') : false,
@@ -110,7 +111,7 @@ class SimpleGraderView extends AbstractView {
         ]);
 
         $return .= $this->core->getOutput()->renderTwigTemplate("grading/SettingsForm.twig");
-
+        
         return $return;
     }
 

--- a/site/app/views/grading/SimpleGraderView.php
+++ b/site/app/views/grading/SimpleGraderView.php
@@ -111,7 +111,6 @@ class SimpleGraderView extends AbstractView {
         ]);
 
         $return .= $this->core->getOutput()->renderTwigTemplate("grading/SettingsForm.twig");
-        
         return $return;
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #12921 

### What is the New Behavior?

Prior to this PR, on the Numeric/Text gradeable type there was no option to Download a CSV file, despite being able to upload one.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Run submitty_install_site
2. Log in as an instructor
3. Create/open a numeric/gradeable type
4. Click Download CSV
5. Verify that Download CSV contains User ID, Given Name, Family Name, Grade columns, and Total points earned
6. Modify grades 
7. Test Download CSV to see if grades modified as well

### Other information

Does this PR include migrations to update existing installations?  

N/A
