### PR TITLE
[Bugfix:TAGrading] Fix Peer Component Version Conflict

### DIFF
--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -1472,17 +1472,18 @@ function getGradedComponentFromDOM(component_id: number): ComponentGradeInfo {
         comment = rawComment?.toString() ?? '';
     }
 
-    const dataDOMElement = domElement.find('.graded-component-data');
-    let gradedVersion = dataDOMElement.attr('data-graded_version')!;
+    const dataDOMElement = domElement.find('.graded-component-data, .peer-graded-component-data');
+    let gradedVersion = dataDOMElement.attr('data-graded_version') ?? '';
     if (gradedVersion === '') {
         gradedVersion = getDisplayVersion().toString();
     }
+    const parsedGradedVersion = parseInt(gradedVersion);
     return {
         score: score,
         comment: comment,
         custom_mark_selected: customMarkSelected,
         mark_ids: mark_ids,
-        graded_version: parseInt(gradedVersion),
+        graded_version: Number.isNaN(parsedGradedVersion) ? getDisplayVersion() : parsedGradedVersion,
         grade_time: dataDOMElement.attr('data-grade_time')!,
         grader_id: dataDOMElement.attr('data-grader_id')!,
         verifier_id: dataDOMElement.attr('data-verifier_id')!,


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes [#10772](https://github.com/Submitty/Submitty/issues/10772) 
Since the process of determining graded version did not include the tag used for peer components (just regular components), NaN was being registered as the graded version for peer components. This caused unnecessary version conflict messages. 

### What is the New Behavior?
Before:
<img width="845" height="185" alt="image" src="https://github.com/user-attachments/assets/3e523c30-bf47-44e2-8a39-5e3bbcf14009" />

After:
<img width="853" height="180" alt="image" src="https://github.com/user-attachments/assets/9b81e96b-593a-4979-b2e1-c3090ac4fe14" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
On Main:
1. Go to grading a gradeable with peer components
2. Open the grading rubric for a student that has been graded
3. Open and close a component several times.
4. See Version Conflict NaN

On Branch: 
1. Repeat steps 1-3 like on main
2. Verify no version conflict appears

### Automated Testing & Documentation
No automated testing added nor documentation needed.

### Other information
Not a breaking change
No migrations
Not a security concern