### PR TITLE
[Feature:TAGrading] Add Peer Progress Bar

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5273,6 +5273,39 @@ AND gc_id IN (
         return intval($this->course_db->row()['cnt']);
     }
 
+    public function getPeerGradingProgress(string $gradeable_id): float {
+        $this->course_db->query(
+            "SELECT
+                COUNT(DISTINCT pa.user_id) AS assigned_students,
+                COUNT(DISTINCT graded.user_id) AS graded_students
+            FROM peer_assign AS pa
+            LEFT JOIN (
+                SELECT DISTINCT
+                    gd.gd_user_id AS user_id
+                FROM gradeable_data AS gd
+                INNER JOIN gradeable_component_data AS gcd
+                    ON gcd.gd_id = gd.gd_id
+                INNER JOIN gradeable_component AS gc
+                    ON gc.gc_id = gcd.gc_id
+                    AND gc.g_id = gd.g_id
+                    AND gc.gc_is_peer = TRUE
+                WHERE gd.g_id = ?
+            ) AS graded
+                ON graded.user_id = pa.user_id
+            WHERE pa.g_id = ?",
+            [$gradeable_id, $gradeable_id]
+        );
+
+        $row = $this->course_db->row();
+        $assigned_students = intval($row['assigned_students']);
+
+        if ($assigned_students === 0) {
+            return NAN;
+        }
+
+        return intval($row['graded_students']) / $assigned_students;
+    }
+
     public function getGradedPeerComponentsByRegistrationSection($gradeable_id, $sections = []) {
         $where = "";
         $params = [];

--- a/site/app/models/Button.php
+++ b/site/app/models/Button.php
@@ -44,6 +44,12 @@ class Button extends AbstractModel implements \JsonSerializable {
      * @var float|null $progress */
     protected $progress;
     /** @prop
+     * @var float|null $peer_progress */
+    protected $peer_progress;
+    /** @prop
+     * @var string|null $peer_progress_class */
+    protected $peer_progress_class;
+    /** @prop
      * @var bool $title_on_hover */
     protected $title_on_hover;
     /** @prop
@@ -79,6 +85,11 @@ class Button extends AbstractModel implements \JsonSerializable {
         if ($this->progress !== null) {
             $this->progress = floatval($this->progress);
         }
+        $this->peer_progress = $details["peer_progress"] ?? null;
+        if ($this->peer_progress !== null) {
+            $this->peer_progress = floatval($this->peer_progress);
+        }
+        $this->peer_progress_class = $details["peer_progress_class"] ?? null;
         $this->title_on_hover = $details["title_on_hover"] ?? false;
         $this->aria_label = $details["aria_label"] ?? null;
         $this->badge = $details["badge"] ?? null;
@@ -135,6 +146,12 @@ class Button extends AbstractModel implements \JsonSerializable {
     public function getProgress(): ?float {
         return $this->progress;
     }
+    public function getPeerProgress(): ?float {
+        return $this->peer_progress;
+    }
+    public function getPeerProgressClass(): ?string {
+        return $this->peer_progress_class;
+    }
     public function getAriaLabel(): ?string {
         return $this->aria_label;
     }
@@ -180,6 +197,12 @@ class Button extends AbstractModel implements \JsonSerializable {
     public function setProgress(?float $progress): void {
         $this->progress = $progress;
     }
+    public function setPeerProgress(?float $progress): void {
+        $this->peer_progress = $progress;
+    }
+    public function setPeerProgressClass(?string $class): void {
+        $this->peer_progress_class = $class;
+    }
     public function setAriaLabel(?string $ariaLabel): void {
         $this->aria_label = $ariaLabel;
     }
@@ -204,6 +227,8 @@ class Button extends AbstractModel implements \JsonSerializable {
      * disabled: bool,
      * prerequisite: string|null,
      * progress: float|null,
+     * peer_progress: float|null,
+     * peer_progress_class: string|null,
      * title_on_hover: bool,
      * aria_label: string|null,
      * badge: string|null,
@@ -224,6 +249,8 @@ class Button extends AbstractModel implements \JsonSerializable {
             'disabled' => $this->disabled,
             'prerequisite' => $this->prerequisite,
             'progress' => $this->progress,
+            'peer_progress' => $this->peer_progress,
+            'peer_progress_class' => $this->peer_progress_class,
             'title_on_hover' => $this->title_on_hover,
             'aria_label' => $this->aria_label,
             'badge' => $this->badge,

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1583,6 +1583,17 @@ class Gradeable extends AbstractModel {
         });
     }
 
+    /**
+     * Gets the percent of students who have received a peer grade for this gradeable
+     * @return float The percentage (0 to 1) of peer grading received or NAN if none required
+     */
+    public function getPeerGradingProgress(): float {
+        if (!$this->hasPeerComponent()) {
+            return NAN;
+        }
+        return $this->core->getQueries()->getPeerGradingProgress($this->getId());
+    }
+
      /**
       * Gets the percent of grading complete for the provided user for this gradeable
       * @param User $grader

--- a/site/app/templates/Navigation.twig
+++ b/site/app/templates/Navigation.twig
@@ -153,6 +153,15 @@
                 <span style="width: {{ max(2, button.getProgress()) }}%"></span>
             </div>
         {% endif %}
+        {% if button.getPeerProgress() != null %}
+            <div class="meter">
+                <span
+                    class="{{ button.getPeerProgressClass() }}"
+                    style="width: {{ max(2, button.getPeerProgress()) }}%"
+                    data-testid="peer-grading-progress-bar"
+                ></span>
+            </div>
+        {% endif %}
     {% endif %}
 {% endmacro %}
 {% include('course/UnregisterForm.twig') %}

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -716,7 +716,7 @@ class NavigationView extends AbstractView {
                 if ($gradeable->isTaGrading()) {
                     $array["progress"] = 100 * $progress_bar;
                 }
-                if ($gradeable->hasPeerComponent()) {
+                if ($gradeable->hasPeerComponent() && $this->core->getUser()->accessGrading()) {
                     $peer_percent = $gradeable->getPeerGradingProgress();
                     if (!is_nan($peer_percent)) {
                         $array["peer_progress"] = 100 * $peer_percent;
@@ -778,7 +778,7 @@ class NavigationView extends AbstractView {
                     if (!is_nan($TA_percent)) {
                         $progress = $TA_percent * 100;
                     }
-                    if ($gradeable->hasPeerComponent()) {
+                    if ($gradeable->hasPeerComponent() && $this->core->getUser()->accessGrading()) {
                         $peer_percent = $gradeable->getPeerGradingProgress();
 
                         if (!is_nan($peer_percent)) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -718,7 +718,6 @@ class NavigationView extends AbstractView {
                 }
                 if ($gradeable->hasPeerComponent()) {
                     $peer_percent = $gradeable->getPeerGradingProgress();
-                    
                     if (!is_nan($peer_percent)) {
                         $array["peer_progress"] = 100 * $peer_percent;
                         $array["peer_progress_class"] = "peer-progress-bar";

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -667,6 +667,7 @@ class NavigationView extends AbstractView {
         $date_text = null;
         $date_time = null;
         $progress = null;
+        $peer_progress = null;
 
         //Button types that override any other buttons
         if ($gradeable->getType() === GradeableType::ELECTRONIC_FILE) {
@@ -714,6 +715,14 @@ class NavigationView extends AbstractView {
                 ];
                 if ($gradeable->isTaGrading()) {
                     $array["progress"] = 100 * $progress_bar;
+                }
+                if ($gradeable->hasPeerComponent()) {
+                    $peer_percent = $gradeable->getPeerGradingProgress();
+                    
+                    if (!is_nan($peer_percent)) {
+                        $array["peer_progress"] = 100 * $peer_percent;
+                        $array["peer_progress_class"] = "peer-progress-bar";
+                    }
                 }
                 return new Button($this->core, $array);
             }
@@ -770,6 +779,13 @@ class NavigationView extends AbstractView {
                     if (!is_nan($TA_percent)) {
                         $progress = $TA_percent * 100;
                     }
+                    if ($gradeable->hasPeerComponent()) {
+                        $peer_percent = $gradeable->getPeerGradingProgress();
+
+                        if (!is_nan($peer_percent)) {
+                            $peer_progress = $peer_percent * 100;
+                        }
+                    }
                 }
                 else {
                     $title = "VIEW SUBMISSIONS";
@@ -799,6 +815,8 @@ class NavigationView extends AbstractView {
             "date" => $date_time,
             "href" => $href,
             "progress" => $progress,
+            "peer_progress" => $peer_progress,
+            "peer_progress_class" => "peer-progress-bar",
             "class" => "btn btn-nav btn-nav-grade {$class}",
             "name" => "grade-btn"
         ]);

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
@@ -112,7 +112,7 @@ describe('TA Grading Panel Switcher', () => {
         it(`Should show correct panel options for ${layout.name}`, () => {
             cy.login('ta');
 
-            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/no_due_date_no_release/grading/grade?who_id=FI9yKu3j9DrXWt5&sort=id&direction=ASC`);
+            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/no_due_date_no_release/grading/grade?who_id=UVSFkMDuolWBQtO&sort=id&direction=ASC`);
 
             cy.log(`Testing layout: ${layout.name}`);
 

--- a/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/ta_grading_panel_switcher.spec.js
@@ -112,7 +112,7 @@ describe('TA Grading Panel Switcher', () => {
         it(`Should show correct panel options for ${layout.name}`, () => {
             cy.login('ta');
 
-            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/no_due_date_no_release/grading/grade?who_id=UVSFkMDuolWBQtO&sort=id&direction=ASC`);
+            cy.visit(`/courses/${getCurrentSemester()}/sample/gradeable/no_due_date_no_release/grading/grade?who_id=FI9yKu3j9DrXWt5&sort=id&direction=ASC`);
 
             cy.log(`Testing layout: ${layout.name}`);
 

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -93,7 +93,7 @@
 }
 
 .peer-progress-bar {
-    background: var(--standard-plum-purple) !important;
+    background: var(--standard-plum-purple);
 }
 
 @media (max-width: 401px) {

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -92,7 +92,7 @@
     background: var(--standard-focus-cornflowe-blue);
 }
 
-.peer-progress-bar {
+span.peer-progress-bar {
     background: var(--standard-plum-purple);
 }
 

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -92,6 +92,10 @@
     background: var(--standard-focus-cornflowe-blue);
 }
 
+.peer-progress-bar {
+    background: var(--standard-plum-purple) !important;
+}
+
 @media (max-width: 401px) {
     .course-section-heading,
     .course-main .course-title {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [#10391](https://github.com/Submitty/Submitty/issues/10391)

### What is the New Behavior?
A second purple progress bar will appear on non-team gradeables with peer grading components. This progress bar represents the % of students within the peer grading matrix who have received at least one peer grading response from another student.

Before:
<img width="934" height="54" alt="image" src="https://github.com/user-attachments/assets/98c76dba-60db-4132-b081-65c50ad41243" />

After:
<img width="956" height="63" alt="image" src="https://github.com/user-attachments/assets/189ac87d-f853-4253-8b57-b2987675c81b" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
A reviewer can either test with a preexisting gradeable (described in steps) or make their own
1. Observe Released Peer PDF Homework on sample as an instructor
2. Should have purple progress bar since only peer components
3. Edit the gradeable and add a normal grading component to the rubric
4. Go in and grade that component for a student in a section assigned to instructor (ex. adamsg)
5. Observe the green progress bar now appears on the gradeable as well

### Automated Testing & Documentation
This feature does not currently have automated testing.

### Other information
Not a breaking change
No migrations
Not a security concern
