### PR TITLE
[Bugfix:System] use shutil.move

### DIFF
--- a/migration/migrator/migrations/system/20260616105949_move_usr_configs.py
+++ b/migration/migrator/migrations/system/20260616105949_move_usr_configs.py
@@ -8,6 +8,7 @@ to each capability (worker VMs are committed to support capabilities
 in the autograding_workers.json file.)"""
 
 from pathlib import Path
+import shutil
 
 # The file(s) to move
 files_to_move = [ "autograding_containers.json" ]
@@ -26,7 +27,7 @@ def up(config):
                 raise RuntimeError(f+" exists in both " + str(install_config_dir)
                                    + " and " + str(data_config_dir))
             else:
-                (install_config_dir / f).rename(data_config_dir / f)
+                shutil.move( install_config_dir / f, data_config_dir / f)
         else:
             raise RuntimeError(f+" does not exist in " + str(install_config_dir))
 
@@ -41,7 +42,7 @@ def down(config):
                 raise RuntimeError(f+" exists in both " + str(install_config_dir)
                                    + " and " + str(data_config_dir))
             else:
-                (data_config_dir / f).rename(install_config_dir / f)
+                shutil.move (data_config_dir / f, install_config_dir / f)
         else:
             raise RuntimeError(f+" does not exist in " + str(data_config_dir))
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
PR #12952 used Python path.rename, which unfortunately does not work when the source and destination files are in different partitions.  

### What is the New Behavior?
We switch to using Pythons shutil package instead.

### What steps should a reviewer take to reproduce or test the bug or new feature?
This change is only significant if the /usr and /var directories are located on different partitions.

### Automated Testing & Documentation
Not included in automated testing.
We could update our vagrant & CI system setups to have more complicated (& realistic) partition setups. 
But this is not high priority to do at this time.

### Other information
none.