### PR TITLE
[Bugfix:InstructorUI] Phantom files notebook sub

### DIFF
--- a/site/app/controllers/admin/NotebookBuilderController.php
+++ b/site/app/controllers/admin/NotebookBuilderController.php
@@ -178,6 +178,7 @@ class NotebookBuilderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('notebook_builder/widgets/multiple-choice-widget.js');
         $this->core->getOutput()->addInternalJs('notebook_builder/widgets/short-answer-widget.js');
         $this->core->getOutput()->addInternalJs('notebook_builder/widgets/image-widget.js');
+        $this->core->getOutput()->addInternalJs('notebook_builder/widgets/file-submission-widget.js');
         $this->core->getOutput()->addInternalJs('notebook_builder/widgets/itempool-widget.js');
         $this->core->getOutput()->addInternalJs('notebook_builder/widgets/item-widget.js');
 

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -399,19 +399,23 @@
             // GET FILES OF THE HIGHEST VERSION
             if (assignment_version == highest_version && highest_version > 0) {
                 $("#getprev").click(function(e){
-                    loadPreviousFilesOnDropBoxes();
+                    {% if not is_notebook %}
+                        loadPreviousFilesOnDropBoxes();
+                    {% endif %}
                     e.stopPropagation();
                 });
             }
 
             function loadPreviousFilesOnDropBoxes(){
-                $("#startnew").click();
+                {% if not is_notebook %}
+                    $("#startnew").click();
                     {% for file in old_files %}
                         addLabel('{{ file.name }}', '{{ file.size }}', {{ file.part }}, true);
                         readPrevious('{{ file.name }}', {{ file.part }});
                     {% endfor %}
                     setUsePrevious();
                     setButtonStatus();
+                {% endif %}
             }
 
             window.loadPreviousFilesOnDropBoxes = loadPreviousFilesOnDropBoxes;

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -399,23 +399,19 @@
             // GET FILES OF THE HIGHEST VERSION
             if (assignment_version == highest_version && highest_version > 0) {
                 $("#getprev").click(function(e){
-                    {% if not is_notebook %}
-                        loadPreviousFilesOnDropBoxes();
-                    {% endif %}
+                    loadPreviousFilesOnDropBoxes();
                     e.stopPropagation();
                 });
             }
-            
+
             function loadPreviousFilesOnDropBoxes(){
-                {% if not is_notebook %}
-                    $("#startnew").click();
+                $("#startnew").click();
                     {% for file in old_files %}
                         addLabel('{{ file.name }}', '{{ file.size }}', {{ file.part }}, true);
                         readPrevious('{{ file.name }}', {{ file.part }});
                     {% endfor %}
                     setUsePrevious();
                     setButtonStatus();
-                {% endif %}
             }
 
             window.loadPreviousFilesOnDropBoxes = loadPreviousFilesOnDropBoxes;

--- a/site/app/templates/submission/homework/SubmitBox.twig
+++ b/site/app/templates/submission/homework/SubmitBox.twig
@@ -399,19 +399,23 @@
             // GET FILES OF THE HIGHEST VERSION
             if (assignment_version == highest_version && highest_version > 0) {
                 $("#getprev").click(function(e){
-                    loadPreviousFilesOnDropBoxes();
+                    {% if not is_notebook %}
+                        loadPreviousFilesOnDropBoxes();
+                    {% endif %}
                     e.stopPropagation();
                 });
             }
-
+            
             function loadPreviousFilesOnDropBoxes(){
-                $("#startnew").click();
+                {% if not is_notebook %}
+                    $("#startnew").click();
                     {% for file in old_files %}
                         addLabel('{{ file.name }}', '{{ file.size }}', {{ file.part }}, true);
                         readPrevious('{{ file.name }}', {{ file.part }});
                     {% endfor %}
                     setUsePrevious();
                     setButtonStatus();
+                {% endif %}
             }
 
             window.loadPreviousFilesOnDropBoxes = loadPreviousFilesOnDropBoxes;

--- a/site/public/js/notebook_builder/builders/abstract-builder.js
+++ b/site/public/js/notebook_builder/builders/abstract-builder.js
@@ -1,4 +1,4 @@
-/* global MultipleChoiceWidget, MarkdownWidget, ShortAnswerWidget, ImageWidget, ItempoolWidget, ItemWidget, getBadItemNames, displayErrorMessage */
+/* global MultipleChoiceWidget, MarkdownWidget, ShortAnswerWidget, ImageWidget, FileSubmissionWidget, ItempoolWidget, ItemWidget, getBadItemNames, displayErrorMessage */
 /* exported AbstractBuilder */
 
 class AbstractBuilder {
@@ -28,6 +28,9 @@ class AbstractBuilder {
                         break;
                     case 'Image':
                         this.widgetAdd(new ImageWidget());
+                        break;
+                    case 'File Submission':
+                        this.widgetAdd(new FileSubmissionWidget());
                         break;
                     case 'Itempool Item':
                         this.widgetAdd(new ItempoolWidget());
@@ -89,6 +92,9 @@ class AbstractBuilder {
                         break;
                     case 'image':
                         widget = new ImageWidget();
+                        break;
+                    case 'file_submission':
+                        widget = new FileSubmissionWidget();
                         break;
                     case 'item':
                         widget = new ItemWidget();

--- a/site/public/js/notebook_builder/builders/root-builder.js
+++ b/site/public/js/notebook_builder/builders/root-builder.js
@@ -9,7 +9,7 @@ class RootBuilder extends AbstractBuilder {
     constructor(attachment_div) {
         super(attachment_div);
 
-        const all_options = this.selector_options.concat(['Item']);
+        const all_options = this.selector_options.concat(['File Submission', 'Item']);
         this.main_selector = new SelectorWidget(all_options, 'Add New Notebook Cell');
 
         this.itempool_selector = new SelectorWidget(['Itempool Item'], 'Add New Itempool Item');

--- a/site/public/js/notebook_builder/notebook-builder-utils.js
+++ b/site/public/js/notebook_builder/notebook-builder-utils.js
@@ -1,5 +1,5 @@
 /* global buildCourseUrl, csrfToken, displayErrorMessage */
-/* exported uploadFiles, getBadItemNames, getBadImageInputs, getBadMarkdownContents */
+/* exported uploadFiles, getBadItemNames, getBadImageInputs, getBadMarkdownContents, getBadFileSubmissionDirectories */
 
 /**
  * Asynchronous upload of configuration dependency file.
@@ -112,4 +112,23 @@ function getBadMarkdownContents() {
     });
 
     return Array.from(bad_markdown_conents);
+}
+
+/**
+ * Determines if any file submission widget has a blank directory.  
+ *
+ * @returns {Array[]} Returns an array containing the directory inputs which were found to be blank.
+*/
+
+function getBadFileSubmissionDirectories() {
+    const bad_directories = new Set();
+    const directory_inputs = document.querySelectorAll('.directory-input');
+
+    directory_inputs.forEach((directory_input) => {
+        if (directory_input.value.trim() === '') {
+            bad_directories.add(directory_input);
+        }
+    });
+
+    return Array.from(bad_directories);
 }

--- a/site/public/js/notebook_builder/notebook-builder-utils.js
+++ b/site/public/js/notebook_builder/notebook-builder-utils.js
@@ -115,7 +115,7 @@ function getBadMarkdownContents() {
 }
 
 /**
- * Determines if any file submission widget has a blank directory.  
+ * Determines if any file submission widget has a blank directory.
  *
  * @returns {Array[]} Returns an array containing the directory inputs which were found to be blank.
 */

--- a/site/public/js/notebook_builder/widgets/file-submission-widget.js
+++ b/site/public/js/notebook_builder/widgets/file-submission-widget.js
@@ -1,0 +1,68 @@
+/* global Widget, escapeSpecialChars */
+/* exported FileSubmissionWidget */
+
+class FileSubmissionWidget extends Widget {
+    constructor() {
+        super();
+
+        this.dom_pointer;
+
+        this.state = {
+            type: 'file_submission',
+            label: '',
+            directory: '',
+        };
+    }
+
+    render() {
+        const container = this.getContainer('File Submission');
+        container.classList.add('file-submission-widget');
+
+        const interactive_area = container.querySelector('.interactive-container');
+        interactive_area.innerHTML = this.getFileSubmissionTemplate(this.state.label, this.state.directory);
+
+        this.dom_pointer = container;
+        return container;
+    }
+
+    commitState() {
+        if (!this.dom_pointer) {
+            return;
+        }
+
+        this.state.label = this.dom_pointer.querySelector('.label-input').value;
+        this.state.directory = this.dom_pointer.querySelector('.directory-input').value;
+    }
+
+    getJSON() {
+        this.commitState();
+        return this.state;
+    }
+
+    load(data) {
+        this.state = data;
+        this.state.label = this.state.label ?? '';
+        this.state.directory = this.state.directory ?? '';
+    }
+
+    /**
+     * Get the markup for the file submission widget.
+     *
+     * @param {string} label Value shown in the label box (displayed to the submitter).
+     * @param {string} directory Value shown in the directory box (folder the files are stored in).
+     * @returns {string}
+     */
+    getFileSubmissionTemplate(label, directory) {
+        return `
+        <div class="basic-options">
+            <div>
+                Label: <input class="label-input" type="text" placeholder="Optional" value="${label ? escapeSpecialChars(label) : ''}">
+                <i>Shown to the submitter in the file upload area (e.g. "Drag your <b>Problem 2</b> file(s) here").</i>
+            </div>
+            <div>
+                Directory: <input class="directory-input" type="text" placeholder="Required (e.g. problem_1)" value="${directory ? escapeSpecialChars(directory) : ''}">
+                <i>Required.  Folder the uploaded files are stored in.  Use a unique directory for each file submission cell.</i>
+            </div>
+        </div>`;
+    }
+}

--- a/site/public/js/notebook_builder/widgets/file-submission-widget.js
+++ b/site/public/js/notebook_builder/widgets/file-submission-widget.js
@@ -19,6 +19,7 @@ class FileSubmissionWidget extends Widget {
         container.classList.add('file-submission-widget');
 
         const interactive_area = container.querySelector('.interactive-container');
+        // eslint-disable-next-line no-unsanitized/property
         interactive_area.innerHTML = this.getFileSubmissionTemplate(this.state.label, this.state.directory);
 
         this.dom_pointer = container;

--- a/site/public/js/notebook_builder/widgets/form-options-widget.js
+++ b/site/public/js/notebook_builder/widgets/form-options-widget.js
@@ -1,4 +1,4 @@
-/* global Widget, notebook_builder, csrfToken, builder_data, buildCourseUrl, uploadFiles, getBadItemNames, getBadImageInputs, getBadMarkdownContents */
+/* global Widget, notebook_builder, csrfToken, builder_data, buildCourseUrl, uploadFiles, getBadItemNames, getBadImageInputs, getBadMarkdownContents, getBadFileSubmissionDirectories */
 /* exported FormOptionsWidget */
 
 class FormOptionsWidget extends Widget {
@@ -101,7 +101,7 @@ class FormOptionsWidget extends Widget {
      * @returns {boolean}
      */
     validate() {
-        return this.validateFileNames() && this.validateItemNames() && this.validateImageWidgets() && this.validateMarkdownWidgets();
+        return this.validateFileNames() && this.validateItemNames() && this.validateImageWidgets() && this.validateMarkdownWidgets() && this.validateFileSubmissionDirectories();
     }
 
     /**
@@ -243,6 +243,26 @@ class FormOptionsWidget extends Widget {
         this.colorFailedInputs([''], '.markdown-textarea');
 
         return bad_markdown_conents.length === 0;
+    }
+
+    /**
+     * Validates that every file submission widget has a non-blank directory.  The directory is required as it
+     * determines where the submitter's uploaded files are stored.  Offending inputs are colored to indicate failure.
+     *
+     * @returns {Boolean} True if all file submission directories are non-blank, false otherwise.
+     */
+    validateFileSubmissionDirectories() {
+        const bad_directories = getBadFileSubmissionDirectories();
+
+        bad_directories.forEach((directory_input) => {
+            directory_input.style.backgroundColor = this.failed_validation_color;
+        });
+
+        if (bad_directories.length !== 0) {
+            this.appendStatusMessage('A file submission directory was found to be blank.  Each file submission cell requires a directory.');
+        }
+
+        return bad_directories.length === 0;
     }
 
     /**


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [Issue#13001](https://github.com/Submitty/Submitty/issues/13001)

### What is the New Behavior?
Prior to the changes, the notebook builder submission box would show 3 files when you had previously submitted just one.
<img width="2280" height="846" alt="image" src="https://github.com/user-attachments/assets/159e9d4b-16ae-4764-814e-e33ed3940516" />
After the changes, the submission box only shows the one file that was submitted.
<img width="1372" height="456" alt="Screenshot 2026-07-07 at 11 24 52 AM" src="https://github.com/user-attachments/assets/ef324f0a-9eaa-40ad-bfd3-c15475e00bb4" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Go to any gradeable with a notebook file submission component (notebook_filesubmission in sample)
2. Submit a file in the submission box
3. Observe error

### Automated Testing & Documentation
This feature is not tested by E2E tests.
