### PR TITLE
[Feature:TAGrading] Update Modal Text

### DIFF
--- a/site/app/templates/grading/simple/NumericGradeableUploadForm.twig
+++ b/site/app/templates/grading/simple/NumericGradeableUploadForm.twig
@@ -15,7 +15,7 @@
         <li>"Registration Subsection": Optional; included for readability and ignored by upload.</li>
     </ol>
     <p>
-        List each numeric or text column you want to update, with a header matching the column name shown in the grading table. Only the columns you include will be updated — any others will be left unchanged.
+        List each numeric or text column you want to update, with a header matching the column name shown in the grading table. Only the columns you want to include will be updated. The 'Total' column can be included for readability but will not be read and is instead calculated.
     </p>
     <br />
     <p>&emsp;</p>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Currently the modal for the new Upload CSV does not specify that the Total column is optional. This new behavior allows future instructors/TAs to see that they don't need to have the Total column and that it will be self-calculated.

### What is the New Behavior?
One line Twig change, with clarification on allowed column rules.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. run submitty_install_site
2. Open a numeric/text gradeable
3. Go to upload CSV, notice the new text at the bottom of the Modal

### Automated Testing & Documentation
N/A

### Other information
N/A
