### PR TITLE
[Feature:TAGrading] Change Peer Grading Purple

### DIFF
--- a/site/public/css/admin-gradeable.css
+++ b/site/public/css/admin-gradeable.css
@@ -139,7 +139,7 @@ select {
 }
 
 .peer-button {
-    background-color: var(--standard-plum-purple);
+    background-color: var(--standard-mediumorchid);
     /* stylelint-disable-next-line color-named */
     color: white;
 }

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -352,7 +352,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern */
 #peer_info_btn {
-    border: 2px solid var(--standard-plum-purple);
+    border: 2px solid var(--standard-mediumorchid);
 }
 
 /* stylelint-disable selector-id-pattern */
@@ -360,7 +360,7 @@ progress::-webkit-progress-value {
 #peer_info_btn.active,
 #peer_info_select option:hover,
 #peer_info_select option:focus {
-    background: var(--standard-plum-purple);
+    background: var(--standard-mediumorchid);
 }
 /* stylelint-enable selector-id-pattern */
 
@@ -617,7 +617,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */
 #peer_info.rubric_panel {
-    border: 5px solid var(--standard-plum-purple);
+    border: 5px solid var(--standard-mediumorchid);
 }
 
 /* stylelint-disable-next-line selector-class-pattern, no-duplicate-selectors */
@@ -747,8 +747,8 @@ progress::-webkit-progress-value {
 }
 
 .icon-selected.fa-users {
-    box-shadow: 0 0 3px 3px var(--standard-plum-purple);
-    background-color: var(--standard-plum-purple);
+    box-shadow: 0 0 3px 3px var(--standard-mediumorchid);
+    background-color: var(--standard-mediumorchid);
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -1047,7 +1047,7 @@ tr.is_publish {
 }
 
 .gradeable .peer-border {
-    border: 3px solid var(--standard-plum-purple);
+    border: 3px solid var(--standard-mediumorchid);
 }
 
 .gradeable .component .badge-container.edit-mode {

--- a/site/public/css/navigation.css
+++ b/site/public/css/navigation.css
@@ -93,7 +93,7 @@
 }
 
 span.peer-progress-bar {
-    background: var(--standard-plum-purple);
+    background: var(--standard-mediumorchid);
 }
 
 @media (max-width: 401px) {

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1452,7 +1452,7 @@ end of styles used in the admin gradeable page
 
 /* color for student/peer grading */
 .grader-4 {
-    background-color: var(--standard-plum-purple); /* purple */
+    background-color: var(--standard-mediumorchid); /* purple */
 }
 
 /* color for a limited access grader */


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The "plum-purple" that is used for Peer Grading elements is difficult to distinguish because of how dark it is. "mediumorchid" is superior due to its vibrance, making it much more noticeable 

### What is the New Behavior?
Before:
<img width="954" height="280" alt="image" src="https://github.com/user-attachments/assets/65361a80-d14a-4028-b1b7-b304ccc0a58b" />

After:
<img width="957" height="278" alt="image" src="https://github.com/user-attachments/assets/504eeb6e-c0ac-4932-930f-2cdbe1368361" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
As an instructor, visit pages where you would expect to see peer grading purple and verify it is now "mediumorchid"
- [Grading details page to see stoplights](http://localhost:1511/courses/f26/sample/gradeable/grading_pdf_peer_homework/grading/details)
- [Gradeables page to see progress bars](http://localhost:1511/courses/f26/sample)
- [Edit Rubric page to see components](http://localhost:1511/courses/f26/sample/gradeable/grading_pdf_peer_homework/update?nav_tab=2)


### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security concern
