### PR TITLE
[Feature:TAGrading] Add New Peer Grading Stoplight

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -17,8 +17,12 @@
                     Component graded by a limited access grader
                 </li>
                 <li>
+                    <i class="grading-example-circle grader-peer-half"></i>
+                    Peer component has at least one peer grade
+                </li>
+                <li>
                     <i class="grading-example-circle grader-4"></i>
-                    Peer component graded by a student
+                    Peer component graded by you
                 </li>
                 <li>
                     <i class="grading-example-circle grader-1"></i>
@@ -432,9 +436,12 @@
                     {% if graded_gradeable.getAutoGradedGradeable().getActiveVersion() == 0%}
                         {% set class_list = class_list | merge(['grader-NULL']) %}
                     {% else %}
-                        {% if info.graded_groups[index] =="peer-null"   %}
+                        {% if info.graded_groups[index] == "peer-null" or info.graded_groups[index] == "peer-no-submission" %}
                             {# Indicates Peer Component #}
                             {% set class_list = class_list | merge(['grader-NULL']) %}
+                        {% elseif info.graded_groups[index] == "peer-half" %}
+                            {# Indicates Peer Component has at least one grade #}
+                            {% set class_list = class_list | merge(['grader-peer-half']) %}
                         {% else %}
                             {# Indicates Non-Peer Component (Visible)#}
                             {% set class_list = class_list | merge(['grader-' ~ info.graded_groups[index]]) %}
@@ -459,6 +466,9 @@
                     {% elseif info.graded_groups[index] == "peer-null" %}
                         {# Indicates Submitted but Ungraded Peer Component #}
                         <div title="{{ title }}" class="grading-circle grader-NULL"></div>
+                    {% elseif info.graded_groups[index] == "peer-half" %}
+                        {# Indicates Peer Component has at least one grade #}
+                        <div title="{{ title }}" class="grading-circle grader-peer-half"></div>
                     {% elseif info.graded_groups[index] == 4 %}
                         {# Indicates Submitted and Graded Peer Component #}
                         <div title="{{ title }}" class="grading-circle grader-{{ info.graded_groups[index] }}"></div>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -7,6 +7,7 @@
     <div class="details-header-row">
     <h1>Grade Details for {{ gradeable.getTitle() }}</h1>
         <div class="markers-container">
+            {% set peer_only_grader = gradeable.hasPeerComponent() and not core.getAccess().checkGroupPrivilege(core.getUser().getGroup(), gradeable.getMinGradingGroup()) %}
             <ul id="details-legend">
                 <li>
                     <i class="grading-example-circle grader-NULL"></i>
@@ -16,14 +17,21 @@
                     <i class="grading-example-circle grader-3"></i>
                     Component graded by a limited access grader
                 </li>
-                <li>
-                    <i class="grading-example-circle grader-peer-half"></i>
-                    Peer component has at least one peer grade
-                </li>
-                <li>
-                    <i class="grading-example-circle grader-4"></i>
-                    Peer component graded by you
-                </li>
+                {% if not peer_only_grader %}
+                    <li>
+                        <i class="grading-example-circle grader-peer-left-half"></i>
+                        Peer component graded by another peer grader
+                    </li>
+                    <li>
+                        <i class="grading-example-circle grader-peer-right-half"></i>
+                        Peer component graded by you
+                    </li>
+                {% else %}
+                    <li>
+                        <i class="grading-example-circle grader-4"></i>
+                        Peer component graded by you
+                    </li>
+                {% endif %}
                 <li>
                     <i class="grading-example-circle grader-1"></i>
                     Component graded by a full access grader
@@ -420,7 +428,7 @@
     <td class="td-graded-questions" style="text-align: center">
         <span>
             {# check if current user is a peer only grader #}
-            {% set peer_only_grader = graded_gradeable.getGradeable().hasPeerComponent() and core.getUser().accessGrading() and not core.getAccess().checkGroupPrivilege(core.getUser().getGroup(), graded_gradeable.getGradeable().getMinGradingGroup()) %}
+            {% set peer_only_grader = graded_gradeable.getGradeable().hasPeerComponent() and not core.getAccess().checkGroupPrivilege(core.getUser().getGroup(), graded_gradeable.getGradeable().getMinGradingGroup()) %}
             {%- for index in 0..info.graded_groups|length-1 -%}
             {# Non-Peer View for Stoplights #}
             {% if core.getUser().accessGrading() and not peer_only_grader %}
@@ -439,9 +447,12 @@
                         {% if info.graded_groups[index] == "peer-null" or info.graded_groups[index] == "peer-no-submission" %}
                             {# Indicates Peer Component #}
                             {% set class_list = class_list | merge(['grader-NULL']) %}
-                        {% elseif info.graded_groups[index] == "peer-half" %}
-                            {# Indicates Peer Component has at least one grade #}
-                            {% set class_list = class_list | merge(['grader-peer-half']) %}
+                        {% elseif info.graded_groups[index] == "peer-left-half" %}
+                            {# Indicates Peer Component graded by someone other than yourself #}
+                            {% set class_list = class_list | merge(['grader-peer-left-half']) %}
+                        {% elseif info.graded_groups[index] == "peer-right-half" %}
+                            {# Indicates Peer Component graded only by yourself #}
+                            {% set class_list = class_list | merge(['grader-peer-right-half']) %}
                         {% else %}
                             {# Indicates Non-Peer Component (Visible)#}
                             {% set class_list = class_list | merge(['grader-' ~ info.graded_groups[index]]) %}
@@ -466,11 +477,17 @@
                     {% elseif info.graded_groups[index] == "peer-null" %}
                         {# Indicates Submitted but Ungraded Peer Component #}
                         <div title="{{ title }}" class="grading-circle grader-NULL"></div>
-                    {% elseif info.graded_groups[index] == "peer-half" %}
-                        {# Indicates Peer Component has at least one grade #}
-                        <div title="{{ title }}" class="grading-circle grader-peer-half"></div>
+                    {% elseif info.graded_groups[index] == "peer-left-half" %}
+                        {# Indicates Component graded by someone else but not current user #}
+                        {% if peer_only_grader %}
+                            <div title="{{ title }}" class="grading-circle grader-NULL"></div>
+                        {% else %}
+                            <div title="{{ title }}" class="grading-circle grader-peer-left-half"></div>
+                        {% endif %}
+                    {% elseif info.graded_groups[index] == "peer-right-half" %}
+                        {# Indicates Component graded only by current user #}
+                        <div title="{{ title }}" class="grading-circle grader-peer-right-half"></div>
                     {% elseif info.graded_groups[index] == 4 %}
-                        {# Indicates Submitted and Graded Peer Component #}
                         <div title="{{ title }}" class="grading-circle grader-{{ info.graded_groups[index] }}"></div>
                     {% endif %}
                 {% endif %}

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -13,11 +13,11 @@
                     <i class="grading-example-circle grader-NULL"></i>
                     Ungraded component
                 </li>
-                <li>
-                    <i class="grading-example-circle grader-3"></i>
-                    Component graded by a limited access grader
-                </li>
                 {% if not peer_only_grader %}
+                    <li>
+                        <i class="grading-example-circle grader-3"></i>
+                        Component graded by a limited access grader
+                    </li>
                     <li>
                         <i class="grading-example-circle grader-peer-left-half"></i>
                         Peer component graded by another peer grader
@@ -26,28 +26,32 @@
                         <i class="grading-example-circle grader-peer-right-half"></i>
                         Peer component graded by you
                     </li>
+                    <li>
+                        <i class="grading-example-circle grader-4"></i>
+                        Peer component graded by another peer grader and you
+                    </li>
+                    <li>
+                        <i class="grading-example-circle grader-1"></i>
+                        Component graded by a full access grader
+                    </li>
+                    <li>
+                        <i class="grading-example-circle grader-verified"></i>
+                        Limited access grader verified
+                    </li>
+                    <li>
+                        <i class="grading-example-circle grader-double"></i>
+                        Component double-graded by a full access grader or instructor
+                    </li>
+                    <li>
+                        <i class="grading-example-circle grader-active grader-NULL"></i>
+                        Component actively being graded
+                    </li>
                 {% else %}
                     <li>
                         <i class="grading-example-circle grader-4"></i>
                         Peer component graded by you
                     </li>
                 {% endif %}
-                <li>
-                    <i class="grading-example-circle grader-1"></i>
-                    Component graded by a full access grader
-                </li>
-                <li>
-                    <i class="grading-example-circle grader-verified"></i>
-                    Limited access grader verified
-                </li>
-                <li>
-                    <i class="grading-example-circle grader-double"></i>
-                    Component double-graded by a full access grader or instructor
-                </li>
-                <li>
-                    <i class="grading-example-circle grader-active grader-NULL"></i>
-                    Component actively being graded
-                </li>
             </ul>
 
             <div class="row-wrapper">

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -724,23 +724,25 @@ HTML;
             //List of graded components
             $info["graded_groups"] = [];
             foreach ($gradeable->getComponents() as $component) {
-                $graded_component = $row->getOrCreateTaGradedGradeable()->getGradedComponent($component, $this->core->getUser());
+                $ta_graded_gradeable = $row->getOrCreateTaGradedGradeable();
+                $graded_component = $ta_graded_gradeable->getGradedComponent($component, $this->core->getUser());
                 $grade_inquiry = $graded_component !== null ? $row->getGradeInquiryByGcId($graded_component->getComponentId()) : null;
 
-                if ($component->isPeerComponent() && $row->getOrCreateTaGradedGradeable()->isComplete($this->core->getUser())) {
-                    $info["graded_groups"][] = 4;
-                }
-                elseif (($component->isPeerComponent() && $graded_component !== null)) {
-                    //peer submitted and graded
-                    $info["graded_groups"][] = 4;
-                }
-                elseif (($component->isPeerComponent() && $graded_component === null)) {
-                    //peer submitted but not graded
-                    $info["graded_groups"][] = "peer-null";
-                }
-                elseif ($component->isPeerComponent() && !$row->getOrCreateTaGradedGradeable()->isComplete($this->core->getUser())) {
-                    //peer not submitted
-                    $info["graded_groups"][] = "peer-no-submission";
+                if ($component->isPeerComponent()) {
+                    $container = $ta_graded_gradeable->getGradedComponentContainer($component);
+
+                    if ($graded_component !== null) {
+                        $info["graded_groups"][] = 4;
+                    }
+                    elseif ($container !== null && $container->anyGradedComponents()) {
+                        $info["graded_groups"][] = "peer-half";
+                    }
+                    elseif ($ta_graded_gradeable->isComplete($this->core->getUser())) {
+                        $info["graded_groups"][] = "peer-null";
+                    }
+                    else {
+                        $info["graded_groups"][] = "peer-no-submission";
+                    }
                 }
                 elseif ($graded_component === null) {
                     //non-peer not graded

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -730,12 +730,26 @@ HTML;
 
                 if ($component->isPeerComponent()) {
                     $container = $ta_graded_gradeable->getGradedComponentContainer($component);
+                    $current_user_graded = $graded_component !== null;
+                    $someone_else_graded = false;
 
-                    if ($graded_component !== null) {
+                    if ($container !== null) {
+                        foreach ($container->getGradedComponents() as $other_graded_component) {
+                            if ($other_graded_component->getGrader()->getId() !== $this->core->getUser()->getId()) {
+                                $someone_else_graded = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if ($current_user_graded && $someone_else_graded) {
                         $info["graded_groups"][] = 4;
                     }
-                    elseif ($container !== null && $container->anyGradedComponents()) {
-                        $info["graded_groups"][] = "peer-half";
+                    elseif ($current_user_graded) {
+                        $info["graded_groups"][] = "peer-right-half";
+                    }
+                    elseif ($someone_else_graded) {
+                        $info["graded_groups"][] = "peer-left-half";
                     }
                     elseif ($ta_graded_gradeable->isComplete($this->core->getUser())) {
                         $info["graded_groups"][] = "peer-null";

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1455,6 +1455,11 @@ end of styles used in the admin gradeable page
     background-color: var(--standard-plum-purple); /* purple */
 }
 
+/* peer component has at least one peer grade */
+.grader-peer-half {
+    border: 2px solid var(--standard-mediumorchid);
+}
+
 /* color for a limited access grader */
 .grader-3 {
     background-color: var(--important-post); /* yellow */

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1456,8 +1456,21 @@ end of styles used in the admin gradeable page
 }
 
 /* peer component has at least one peer grade */
-.grader-peer-half {
-    border: 2px solid var(--standard-mediumorchid);
+.grader-peer-left-half {
+    background: linear-gradient(
+        to right,
+        var(--standard-mediumorchid) 50%,
+        var(--default-white) 50%
+    );
+}
+
+/* peer component has been graded by current user */
+.grader-peer-right-half {
+    background: linear-gradient(
+        to right,
+        var(--default-white) 50%,
+        var(--standard-mediumorchid) 50%
+    );
 }
 
 /* color for a limited access grader */


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The ability for there to be peer grades from multiple users on a component creates a new issue: instructors/TAs are unable to tell from the details page whether or not a component has received any peer grades.

### What is the New Behavior?
Before (Peer grades have been given on these components):
<img width="959" height="395" alt="image" src="https://github.com/user-attachments/assets/ea8ff1ae-04b0-40ce-b9aa-8ec5ad4a9b9b" />

After:
Instructor:
<img width="956" height="422" alt="image" src="https://github.com/user-attachments/assets/32530775-90fa-4b47-9c27-8e3823fa17d2" />
Student:
<img width="993" height="515" alt="image" src="https://github.com/user-attachments/assets/c71f0a6f-793c-406f-b503-006d5bdccb4f" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. As the instructor, remove your peer grades from a student (adamsg in img)
2. As a student peer grader who is assigned to the student from step 1, grade those components (baliss can grade adamsg)
3. As a student peer grader, grade the components for another student  (robcon graded connk in img)
4. Log back in as instructor and verify the new stoplights appear for the graded students


### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security concern
