### PR TITLE
[Feature:TAGrading] Personal Peer Progress Bar

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -5306,6 +5306,51 @@ AND gc_id IN (
         return intval($row['graded_students']) / $assigned_students;
     }
 
+    public function getAssignedPeerGradingProgress(string $gradeable_id, string $grader_id): float {
+        $this->course_db->query(
+            "SELECT
+                COUNT(DISTINCT pa.user_id) AS assigned_students,
+                COUNT(DISTINCT CASE
+                    WHEN completed.user_id IS NOT NULL THEN pa.user_id
+                END) AS completed_students
+            FROM peer_assign AS pa
+            LEFT JOIN (
+                SELECT
+                    gd.gd_user_id AS user_id,
+                    gcd.gcd_grader_id
+                FROM gradeable_data AS gd
+                INNER JOIN gradeable_component_data AS gcd
+                    ON gcd.gd_id = gd.gd_id
+                INNER JOIN gradeable_component AS gc
+                    ON gc.gc_id = gcd.gc_id
+                    AND gc.g_id = gd.g_id
+                    AND gc.gc_is_peer = TRUE
+                WHERE gd.g_id = ?
+                GROUP BY gd.gd_user_id, gcd.gcd_grader_id
+                HAVING COUNT(DISTINCT gc.gc_id) = (
+                    SELECT COUNT(*)
+                    FROM gradeable_component
+                    WHERE g_id = ?
+                        AND gc_is_peer = TRUE
+                )
+            ) AS completed
+                ON completed.user_id = pa.user_id
+                AND completed.gcd_grader_id = pa.grader_id
+            WHERE pa.g_id = ?
+                AND pa.grader_id = ?",
+            [$gradeable_id, $gradeable_id, $gradeable_id, $grader_id]
+        );
+
+        $row = $this->course_db->row();
+        $assigned_students = intval($row['assigned_students']);
+
+        if ($assigned_students === 0) {
+            return NAN;
+        }
+
+        return intval($row['completed_students']) / $assigned_students;
+    }
+
     public function getGradedPeerComponentsByRegistrationSection($gradeable_id, $sections = []) {
         $where = "";
         $params = [];

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1594,6 +1594,17 @@ class Gradeable extends AbstractModel {
         return $this->core->getQueries()->getPeerGradingProgress($this->getId());
     }
 
+    /**
+     * Gets the percent of peer grading this user has completed
+     * @return float The percentage (0 to 1) of peer grading completed by the user
+     */
+    public function getAssignedPeerGradingProgress(User $grader): float {
+        if (!$this->hasPeerComponent()) {
+            return NAN;
+        }
+        return $this->core->getQueries()->getAssignedPeerGradingProgress($this->getId(), $grader->getId());
+    }
+
      /**
       * Gets the percent of grading complete for the provided user for this gradeable
       * @param User $grader

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -778,13 +778,13 @@ class NavigationView extends AbstractView {
                     if (!is_nan($TA_percent)) {
                         $progress = $TA_percent * 100;
                     }
-                    if ($gradeable->hasPeerComponent()){
+                    if ($gradeable->hasPeerComponent()) {
                         if ($this->core->getUser()->accessGrading()) {
                             $peer_percent = $gradeable->getPeerGradingProgress();
                             if (!is_nan($peer_percent)) {
                                 $peer_progress = $peer_percent * 100;
                             }
-                        } 
+                        }
                         else {
                             $peer_percent = $gradeable->getAssignedPeerGradingProgress($this->core->getUser());
                             if (!is_nan($peer_percent)) {

--- a/site/app/views/NavigationView.php
+++ b/site/app/views/NavigationView.php
@@ -778,11 +778,18 @@ class NavigationView extends AbstractView {
                     if (!is_nan($TA_percent)) {
                         $progress = $TA_percent * 100;
                     }
-                    if ($gradeable->hasPeerComponent() && $this->core->getUser()->accessGrading()) {
-                        $peer_percent = $gradeable->getPeerGradingProgress();
-
-                        if (!is_nan($peer_percent)) {
-                            $peer_progress = $peer_percent * 100;
+                    if ($gradeable->hasPeerComponent()){
+                        if ($this->core->getUser()->accessGrading()) {
+                            $peer_percent = $gradeable->getPeerGradingProgress();
+                            if (!is_nan($peer_percent)) {
+                                $peer_progress = $peer_percent * 100;
+                            }
+                        } 
+                        else {
+                            $peer_percent = $gradeable->getAssignedPeerGradingProgress($this->core->getUser());
+                            if (!is_nan($peer_percent)) {
+                                $peer_progress = $peer_percent * 100;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [#13010](https://github.com/Submitty/Submitty/issues/13010)
Adds a progress bar for peer graders without actual grading access that tracks how much of their peer grading they have completed.

### What is the New Behavior?
Before:
<img width="980" height="43" alt="image" src="https://github.com/user-attachments/assets/db774d26-4201-49e3-bfad-552e693f76c6" />

After:
<img width="979" height="57" alt="image" src="https://github.com/user-attachments/assets/c169933e-d8b8-44c2-9559-2711ee52a491" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. As a student, verify Released Peer PDF Homework has no progress bar on the gradeables navigation page
2. Fully grade one student within the gradeable
3. Verify there is now a progress bar for the gradeable on the navigation page and it is about 10% full (you graded 1 of 10 students)

### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security concern
