### PR TITLE
[Feature:System] Add GET /api/token validation endpoint

### DIFF
--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -209,7 +209,7 @@ class AuthenticationController extends AbstractController {
      *
      * @return MultiResponse
      */
-    #[Route("/api/token", methods: ["GET"])]
+    #[Route("/api/token/validate", methods: ["GET"])]
     public function validateToken() {
         $user = $this->core->getUser();
 

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -201,6 +201,7 @@ class AuthenticationController extends AbstractController {
             return MultiResponse::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
         }
     }
+
     /**
      * Validate whether the supplied API token is still valid.
      *
@@ -224,9 +225,6 @@ class AuthenticationController extends AbstractController {
             ])
         );
     }
-
-
-       
 
     /**
      * Handle stateless authentication for the VCS endpoints.

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -201,6 +201,32 @@ class AuthenticationController extends AbstractController {
             return MultiResponse::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
         }
     }
+    /**
+     * Validate whether the supplied API token is still valid.
+     *
+     * Returns the authenticated user's ID when the bearer token is valid.
+     *
+     * @return MultiResponse
+     */
+    #[Route("/api/token", methods: ["GET"])]
+    public function validateToken() {
+        $user = $this->core->getUser();
+
+        if ($user === null) {
+            return MultiResponse::JsonOnlyResponse(
+                JsonResponse::getFailResponse("Invalid or expired token.")
+            );
+        }
+
+        return MultiResponse::JsonOnlyResponse(
+            JsonResponse::getSuccessResponse([
+                'user_id' => $user->getId(),
+            ])
+        );
+    }
+
+
+       
 
     /**
      * Handle stateless authentication for the VCS endpoints.

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -296,11 +296,11 @@ class AuthenticationController extends AbstractController {
         }
         elseif ($_POST['user_id'] !== $_POST['id']) {
             $msg = "This user cannot check out that repository.";
-            return MultiResponse::JsonOnlyResponse(JsonResponse::getFailResponse($msg));
+            return JsonResponse::getFailResponse($msg);
         }
 
         $msg = "Successfully logged in as {$_POST['user_id']}";
-        return MultiResponse::JsonOnlyResponse(JsonResponse::getSuccessResponse(['message' => $msg, 'authenticated' => true]));
+        return JsonResponse::getSuccessResponse(['message' => $msg, 'authenticated' => true]);
     }
 
     /**

--- a/site/app/controllers/AuthenticationController.php
+++ b/site/app/controllers/AuthenticationController.php
@@ -214,16 +214,12 @@ class AuthenticationController extends AbstractController {
         $user = $this->core->getUser();
 
         if ($user === null) {
-            return MultiResponse::JsonOnlyResponse(
-                JsonResponse::getFailResponse("Invalid or expired token.")
-            );
+            return JsonResponse::getFailResponse("Invalid or expired token.");
         }
 
-        return MultiResponse::JsonOnlyResponse(
-            JsonResponse::getSuccessResponse([
-                'user_id' => $user->getId(),
-            ])
-        );
+        return JsonResponse::getSuccessResponse([
+            'user_id' => $user->getId(),
+        ]);
     }
 
     /**
@@ -296,11 +292,18 @@ class AuthenticationController extends AbstractController {
         }
         elseif ($_POST['user_id'] !== $_POST['id']) {
             $msg = "This user cannot check out that repository.";
-            return JsonResponse::getFailResponse($msg);
+            return MultiResponse::JsonOnlyResponse(
+                JsonResponse::getFailResponse($msg)
+            );
         }
 
         $msg = "Successfully logged in as {$_POST['user_id']}";
-        return JsonResponse::getSuccessResponse(['message' => $msg, 'authenticated' => true]);
+        return MultiResponse::JsonOnlyResponse(
+            JsonResponse::getSuccessResponse([
+                'message' => $msg,
+                'authenticated' => true,
+            ])
+        );
     }
 
     /**


### PR DESCRIPTION
## Why is this Change Important & Necessary?
Closes #12856. 

This change introduces a dedicated endpoint for clients to explicitly validate the status of their API tokens. Currently, external applications and integration scripts lack a lightweight mechanism to check if a token is still active or expired without making redundant resource requests. Adding this endpoint improves session management for API clients and aligns Submitty with standard token authentication practices.

## What is the New Behavior?
Adds a GET /api/token endpoint to allow clients to validate whether an API token is still valid. 

The implementation reuses the existing authentication performed by WebRouter::isApiLoggedIn(), which resolves the authenticated user before the controller is invoked. 

If a valid bearer token is provided, the endpoint returns the authenticated user's ID. Otherwise, it returns a fail response indicating the token is invalid or expired.

## What steps should a reviewer take to reproduce or test the bug or new feature?
1. Start the Submitty vagrant or docker dev environment.
2. Generate a token for a test user by running: curl -X POST http://localhost/api/token -F user_id=instructor -F password=instructor
3. Call the new endpoint with the returned token by running: curl -H "Authorization: <token>" http://localhost/api/token
4. Verify that the response returns 200 with the authenticated user's ID.
5. Call it with an invalid or garbage token and verify that it returns a fail response with no 500 errors.

## Automated Testing & Documentation
Automated tests are not included for this endpoint. The changes are verified via manual API testing as outlined in the testing instructions above.

## Other Information
This implementation relies on existing session management core functions and introduces zero breaking changes to existing API routes or consumer scripts.