### PR TITLE
[Bugfix:Forum] Fix date crash (#12945)

### DIFF
--- a/site/app/models/DateTimeFormat.php
+++ b/site/app/models/DateTimeFormat.php
@@ -26,7 +26,7 @@ class DateTimeFormat extends AbstractModel {
         'MDY' => [
             'gradeable' => 'm/d/Y @ h:i A T',
             'gradeable_with_seconds' => 'm/d/Y @ h:i:s A T',
-            'forum' => 'Y/n/j g:i A',
+            'forum' => 'n/j/Y g:i A',
             'notification' => 'n/j g:i A',
             'solution_ta_notes' => 'j/n g:i A',
             'office_hours_queue' => 'g:i A',
@@ -36,7 +36,7 @@ class DateTimeFormat extends AbstractModel {
         'DMY' => [
             'gradeable' => 'd/m/Y @ h:i A T',
             'gradeable_with_seconds' => 'd/m/Y @ h:i:s A T',
-            'forum' => 'Y/j/n g:i A',
+            'forum' => 'j/n/Y g:i A',
             'notification' => 'j/n g:i A',
             'solution_ta_notes' => 'j/n g:i A',
             'office_hours_queue' => 'g:i A',

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -118,7 +118,7 @@
             <i class="fas fa-ellipsis-v"></i>
         </a>
         <div class="dropdown-menu custom-dropdown-menu" aria-labelledby="dropdownMenuButton">
-            <a class="dropdown-item key_to_click" tabindex="0" onClick="markPostUnread('{{activeThread.id}}', '{{post_id}}', '{{post_date}}');" title="Mark Post Unread" aria-label="Mark Post Unread">Mark Unread</a>
+            <a class="dropdown-item key_to_click" tabindex="0" onClick="markPostUnread('{{activeThread.id}}', '{{post_id}}', '{{post_date_raw}}');" title="Mark Post Unread" aria-label="Mark Post Unread">Mark Unread</a>
             {% if userGroup <= 3 or post.author.id == current_user %}
                 {% if not (isThreadLocked != 1 or userAccessFullGrading == true) %}
                     {#pass#}

--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -70,7 +70,7 @@
         <a class="btn btn-default btn-sm post_button_color text-decoration-none key_to_click" tabindex = "0" onClick="changeThreadStatus({{ post.thread.id }})" title="Mark thread as resolved">Mark as resolved</a>
     {% endif %}
 
-    {% if post.author.id == current_user and first and not thread_announced and date() < date(post_date)|date_modify("+1hour") and userGroup <= 2 %}
+    {% if post.author.id == current_user and first and not thread_announced and date() < date(post_date_raw)|date_modify("+1hour") and userGroup <= 2 %}
         <a class="btn btn-primary btn-sm pin-and-email-message text-decoration-none key_to_click" onclick="sendAnnouncement({{activeThread.id }});"> Pin &amp; email this thread </a>
     {% endif %}
 

--- a/site/app/templates/forum/GeneratePostList.twig
+++ b/site/app/templates/forum/GeneratePostList.twig
@@ -46,7 +46,8 @@
         "has_history": post_d.has_history,
         "thread_previously_merged": post_d.thread_previously_merged,
         "thread_announced": post_d.thread_announced,
-        "post_up_duck": post_d.post_up_duck
+        "post_up_duck": post_d.post_up_duck,
+        "post_date_raw": post_d.post_date_raw
     } only %}
 
 {% endfor %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -706,6 +706,8 @@ class ForumThreadView extends AbstractView {
         $user = $this->core->getUser();
         // Get formatted time stamps
         $date = DateUtils::convertTimeStamp($this->core->getUser(), DateUtils::dateTimeToString($post->getTimestamp()), $this->core->getConfig()->getDateTimeFormat()->getFormat('forum'));
+        // Raw ISO timestamp for Twig date comparisons (avoids locale-formatted string parsing failures)
+        $raw_post_timestamp = DateUtils::dateTimeToString($post->getTimestamp());
 
         if (!$post->getHistory()->isEmpty()) {
             $edit_timestamp = max($post->getHistory()->map(function ($x) {
@@ -857,6 +859,7 @@ class ForumThreadView extends AbstractView {
             "post_user_info" => $post_user_info,
             "post_up_duck" => $post_up_duck,
             "post_date" => $date,
+            "post_date_raw" => $raw_post_timestamp,
             "edit_date" => $edit_date,
             "post_buttons" => $post_button,
             "visible_username" => $visible_username,

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -707,7 +707,7 @@ class ForumThreadView extends AbstractView {
         // Get formatted time stamps
         $date = DateUtils::convertTimeStamp($this->core->getUser(), DateUtils::dateTimeToString($post->getTimestamp()), $this->core->getConfig()->getDateTimeFormat()->getFormat('forum'));
         // Raw ISO timestamp for Twig date comparisons (avoids locale-formatted string parsing failures)
-        $raw_post_timestamp = DateUtils::dateTimeToString($post->getTimestamp());
+        $post_date_raw = DateUtils::dateTimeToString($post->getTimestamp());
 
         if (!$post->getHistory()->isEmpty()) {
             $edit_timestamp = max($post->getHistory()->map(function ($x) {
@@ -859,7 +859,7 @@ class ForumThreadView extends AbstractView {
             "post_user_info" => $post_user_info,
             "post_up_duck" => $post_up_duck,
             "post_date" => $date,
-            "post_date_raw" => $raw_post_timestamp,
+            "post_date_raw" => $post_date_raw,
             "edit_date" => $edit_date,
             "post_buttons" => $post_button,
             "visible_username" => $visible_username,


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12945 

When a user sets their date format preference to MDY or DMY, clicking
on a discussion forum thread caused a server crash due to Twig's
`date()` filter attempting to parse a user-formatted display string
(e.g., `2018/23/5 8:49 PM`) as a date, which PHP cannot reliably parse.

### What is the New Behavior?
- Forum threads now load correctly for all date format preferences.
- A raw ISO timestamp (`post_date_raw`) is passed alongside the display
  string and used for internal date comparisons in `CreatePost.twig`.
- MDY and DMY forum date formats now display in conventional order
  (e.g., `23/5/2018` instead of `2018/23/5`), consistent with all
  other format keys in `DateTimeFormat.php`.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Log in as any user
2. Go to My Profile → change Date Format to **DMY** or **MDY**
3. Navigate to Discussion Forum → click on any thread
4. Verify no server error occurs and dates display in correct order

### Automated Testing & Documentation
No automated tests added. A new GitHub issue should be filed to add
forum date format tests.

### Other information
No breaking changes. No migrations required. No security concerns.
