### PR TITLE
[Bugfix:TAGrading] Fix Stoplight Yellow

### DIFF
--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -1445,7 +1445,7 @@ end of styles used in the admin gradeable page
     /* yellow       green   */
     background: linear-gradient(
         to right,
-        var(--standard-vibrant-yellow) 50%,
+        var(--important-post) 50%,
         var(--standard-vibrant-green) 50%
     );
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
On dark mode, "vibrant yellow" turns to a darker shade, causing the "limited access grader verified" stoplight to change color to not match the "Component graded by a limited access grader" stoplight. This PR fixes this by changing the former's yellow color to match the yellow used in the latter's css.

### What is the New Behavior?
Before:
<img width="148" height="17" alt="image" src="https://github.com/user-attachments/assets/4c102622-6834-4162-b7d6-b0fcb7f3638a" />

After
<img width="165" height="19" alt="image" src="https://github.com/user-attachments/assets/08fee25c-954c-44dc-902a-d067e1f01fcc" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
On dark mode, visit any gradeable's details page and notice the change in the legend


### Automated Testing & Documentation
No automated testing

### Other information
Not a breaking change
No migrations
Not a security risk