### PR TITLE
[Feature:InstructorUI] show user on Authentication Tokens page

### DIFF
--- a/site/app/templates/AuthTokens.twig
+++ b/site/app/templates/AuthTokens.twig
@@ -44,6 +44,7 @@
 
 <div class="content">
     <h1>Authentication Tokens</h1>
+        <p>You are currently logged in as: {{ user_id }}</p>
         <h2>API Token</h2>
         <p>
             To get your API token, press the Get API Token button below.

--- a/site/app/templates/AuthTokens.twig
+++ b/site/app/templates/AuthTokens.twig
@@ -111,4 +111,3 @@
 </div>
 
 {% include('CreateVcsAuthTokenForm.twig') %}
-

--- a/site/app/templates/AuthTokens.twig
+++ b/site/app/templates/AuthTokens.twig
@@ -111,3 +111,4 @@
 </div>
 
 {% include('CreateVcsAuthTokenForm.twig') %}
+

--- a/site/app/views/AuthTokenView.php
+++ b/site/app/views/AuthTokenView.php
@@ -12,7 +12,8 @@ class AuthTokenView extends AbstractView {
             "vcs_tokens" => $tokens,
             "csrf_token" => $this->core->getCsrfToken(),
             "current_time" => $this->core->getDateTimeNow(),
-            "is_faculty" => $is_faculty
+            "is_faculty" => $is_faculty,
+            "user_id" => $this->core->getUser()->getId()
         ];
         if ($new_vcs_token !== null && $new_vcs_token_val !== null) {
             $params["new_vcs_token"] = $new_vcs_token;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
For users who have multiple distinct logins for Submitty, it would be helpful if the Authentication Tokens page displayed which user they were logged in as when viewing their authentication tokens. 

### What is the New Behavior?
The username is now displayed on the Authentication Tokens page. 

<img width="960" height="920" alt="image" src="https://github.com/user-attachments/assets/0a1b6c97-79b7-4336-b126-7403c4738f51" />


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Navigate to the authentication tokens page either by finding a VCS gradeable in the sample course or by pasting this link in your browser: http://localhost:1511/authentication_tokens 
2. Observe that on main, the username is not displayed on this page.
3. Test that the username is displayed for an instructor on the branch
4. Test that the username is displayed for a regular student user on the branch

### Automated Testing & Documentation
This PR is not covered by e2e tests and does not need to be. 

### Other information
This PR is not a breaking change.
