### PR TITLE
[Feature:InstructorUI] Show username on create course page

### DIFF
--- a/site/app/templates/CreateCourseForm.twig
+++ b/site/app/templates/CreateCourseForm.twig
@@ -1,6 +1,6 @@
 <div class="content">
     <h1>New Course</h1>
-
+    <p>You are currently logged in as: {{ user_id }}</p>
     <form id="course-creation-form" action="{{ course_creation_url }}"
           method="post" enctype="multipart/form-data">
         <div class="option row">

--- a/site/app/views/HomePageView.php
+++ b/site/app/views/HomePageView.php
@@ -99,7 +99,8 @@ class HomePageView extends AbstractView {
             "course_creation_url" => $this->output->buildUrl(['home', 'courses', 'new']),
             "course_code_requirements" => $this->core->getConfig()->getCourseCodeRequirements(),
             "add_term_url" => $this->output->buildUrl(['term', 'new']),
-            "courses" => $course_names
+            "courses" => $course_names,
+            "user_id" => $this->core->getUser()->getId()
         ]);
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?

It would be useful to instructors / sysadmins to know which user they are logged in as when they are creating a course. 

### What is the New Behavior?

<img width="1920" height="920" alt="image" src="https://github.com/user-attachments/assets/fafe593d-154e-4036-9ee3-f54d2f0fef89" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. on main, verify that the username is not displayed on the create course page
2. on the branch, verify that the username is properly displayed on the create course page

### Automated Testing & Documentation
This is not covered by e2e testing and doesn't need to be. 

### Other information
this is not a breaking change.
