### PR TITLE
[Bugfix:System] add display environment variable field

### DIFF
--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1798,7 +1798,7 @@ AUTOGRADING_WORKERS_SCHEMA = {
             "address": {"type": "string"},
             "username": {"type": "string"},
             "num_autograding_workers": {"type": "integer", "minimum": 1},
-            "display_environment_variable":{"type":"string"},
+            "display_environment_variable": {"type": "string"},
             "enabled": {"type": "boolean"},
             "capabilities": {"type": "array", "items": {"type": "string"}, "minItems": 1},
         },

--- a/autograder/submitty_autograding_shipper.py
+++ b/autograder/submitty_autograding_shipper.py
@@ -1798,6 +1798,7 @@ AUTOGRADING_WORKERS_SCHEMA = {
             "address": {"type": "string"},
             "username": {"type": "string"},
             "num_autograding_workers": {"type": "integer", "minimum": 1},
+            "display_environment_variable":{"type":"string"},
             "enabled": {"type": "boolean"},
             "capabilities": {"type": "array", "items": {"type": "string"}, "minItems": 1},
         },


### PR DESCRIPTION
### Why is this Change Important & Necessary?

The autograding workers schema introduced in PR #12559 is missing the display_environment_variable field.
This causes the autograding shipper to fail.

### What is the New Behavior?

The field is added to the schema, and the shipper should now work.
