### PR TITLE
[Bugfix:RainbowGrades] Revert accidential changes

### DIFF
--- a/sbin/auto_rainbow_grades.py
+++ b/sbin/auto_rainbow_grades.py
@@ -22,8 +22,8 @@ from pathlib import Path
 import getpass
 
 # Verify correct number of command line arguments
-if len(sys.argv) not in (4, 5):
-    raise Exception('You must pass 3 or 4 command line arguments: semester, course, source, and optionally sort_order')
+if len(sys.argv) != 4:
+    raise Exception('You must pass 3 command line arguments - semester, course, and source')
 
 # Get path to current file directory
 current_dir = os.path.dirname(__file__)
@@ -62,22 +62,6 @@ source = sys.argv[3]
 
 if source not in ["submitty_gui", "submitty_daemon"]:
     raise Exception('ERROR: Source must be either "submitty_gui" or "submitty_daemon"')
-
-# Rainbow grades summaries that may be requested. Every value except 'all' is a Makefile
-# target (each runs ./process_grades.out by_<x>); 'all' runs `make tables` to build every
-# sorted summary. Keep in sync with RainbowGrades/MakefileHelper and with
-# ReportController::RAINBOW_GRADES_SORT_ORDERS.
-VALID_SORT_ORDERS = frozenset({
-    'all', 'overall', 'name', 'section', 'lab', 'hw', 'test', 'quiz',
-    'exam', 'reading', 'worksheet', 'project', 'participation', 'test_exam', 'zone',
-})
-
-# Optional 4th argument: which sorted summary to build. Defaults to 'overall' so the
-# nightly build and any caller that omits it keep the existing (overall-only) behavior.
-sort_order = sys.argv[4] if len(sys.argv) == 5 else 'overall'
-if sort_order not in VALID_SORT_ORDERS:
-    raise Exception('ERROR: Invalid sort_order "{}"'.format(sort_order))
-
 
 user = daemon_user
 rainbow_grades_path = os.path.join(install_dir, 'GIT_CHECKOUT', 'RainbowGrades')
@@ -209,17 +193,9 @@ else:
 print('Pulling in grade summaries', flush=True)
 cmd_output = os.popen('make pull_test').read()
 
-# Run make to build the requested table
-if sort_order == 'all':
-    make_cmd = ['make', 'tables']
-elif sort_order == 'overall':
-    make_cmd = ['make']
-else:
-    make_cmd = ['make', sort_order]
-print('Compiling rainbow grades ({})'.format(sort_order), flush=True)
-cmd_output = subprocess.run(
-    make_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-).stdout
+# Run make
+print('Compiling rainbow grades', flush=True)
+cmd_output = os.popen('make').read()
 
 # Run make push_test
 print('Exporting to summary_html', flush=True)

--- a/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
+++ b/sbin/submitty_daemon_jobs/submitty_jobs/jobs.py
@@ -118,19 +118,13 @@ class RunAutoRainbowGrades(CourseJob):
         semester = self.job_details['semester']
         course = self.job_details['course']
         source = self.job_details['source']
-        # Optional: which sorted summary to build. If omitted, auto_rainbow_grades.py defaults to the overall table
-        sort_order = self.job_details.get('sort_order')
 
         path = os.path.join(INSTALL_DIR, 'sbin', 'auto_rainbow_grades.py')
         debug_output = os.path.join(DATA_DIR, 'courses', semester, course, 'rainbow_grades', 'auto_debug_output.txt')
 
-        cmd = ['python3', path, semester, course, source]
-        if sort_order:
-            cmd.append(sort_order)
-
         try:
             with open(debug_output, "w") as file:
-                subprocess.call(cmd, stdout=file, stderr=file)
+                subprocess.call(['python3', path, semester, course, source], stdout=file, stderr=file)
         except PermissionError:
             print("error, could not open "+file+" for writing")
 

--- a/site/app/controllers/admin/ReportController.php
+++ b/site/app/controllers/admin/ReportController.php
@@ -37,32 +37,6 @@ class ReportController extends AbstractController {
                                             // wait for the job to complete before timing out and returning failure
     const RG_MANUAL_GENERATION_THRESHOLD_SECONDS = 600; // Allow a small gap between build metadata and pushed HTML files
 
-    /**
-     * Rainbow grades summaries that can be generated from the GUI. Every value except 'all' is a Makefile
-     * target in the RainbowGrades repo, 'all' runs `make tables` to build every sorted summary at once.
-     *
-     * Keep this in sync with the sort-order targets in RainbowGrades/MakefileHelper
-     * and with VALID_SORT_ORDERS in sbin/auto_rainbow_grades.py.
-     */
-    const RAINBOW_GRADES_SORT_ORDERS = [
-        'all' => 'All sorted summaries',
-        'overall' => 'Overall',
-        'name' => 'By Name',
-        'section' => 'By Section',
-        'lab' => 'By Lab',
-        'hw' => 'By Homework',
-        'test' => 'By Test',
-        'quiz' => 'By Quiz',
-        'exam' => 'By Exam',
-        'reading' => 'By Reading',
-        'worksheet' => 'By Worksheet',
-        'project' => 'By Project',
-        'participation' => 'By Participation',
-        'test_exam' => 'By Test & Exam',
-        'zone' => 'By Zone',
-    ];
-
-
     private $all_overrides = [];
     private ?bool $rg_manual_generation_cache = null;        // Cache result of isRainbowGradesLikelyManuallyGenerated()
 
@@ -830,7 +804,6 @@ class ReportController extends AbstractController {
 
             // Print the form
             $this->core->getOutput()->renderTwigOutput('admin/RainbowCustomization.twig', [
-                'sort_order_options' => self::RAINBOW_GRADES_SORT_ORDERS,
                 'summaries_url' => $this->core->buildCourseUrl(['reports', 'summaries']),
                 'grade_summaries_last_run' => $this->getGradeSummariesLastRun(),
                 'manual_customization_download_url' => $this->core->buildCourseUrl(['reports', 'rainbow_grades_customization', 'manual_download']),
@@ -886,18 +859,12 @@ class ReportController extends AbstractController {
     #[Route("/courses/{_semester}/{_course}/reports/build_form", methods: ['POST'])]
     #[Route("/api/courses/{_semester}/{_course}/reports/build_form", methods: ['POST'])]
     public function executeBuildForm(): JsonResponse {
-        $sort_order = $_POST['sort_order'] ?? 'overall';
-        if (!array_key_exists($sort_order, self::RAINBOW_GRADES_SORT_ORDERS)) {
-            $sort_order = 'overall';
-        }
-
         // Configure json to go into jobs queue
         $job_json = [
             'job' => 'RunAutoRainbowGrades',
             'source' => isset($_POST['source']) ? $_POST['source'] : 'submitty_gui',
             'semester' => $this->core->getConfig()->getTerm(),
             'course' => $this->core->getConfig()->getCourse(),
-            'sort_order' => $sort_order,
         ];
 
         // Encode
@@ -1105,97 +1072,22 @@ class ReportController extends AbstractController {
     #[AccessControl(role: "INSTRUCTOR")]
     #[Route("/courses/{_semester}/{_course}/gradebook")]
     public function displayGradebook() {
-        $rainbow_grades_dir = FileUtils::joinPaths($this->core->getConfig()->getCoursePath(), "rainbow_grades");
-
-        //Find any sorts that were already done
-        $available_sorts = $this->getAvailableGradebookSorts($rainbow_grades_dir);
-
-        $selected_sort = 'overall';
-        $requested = $_GET['sort'] ?? null;
-        if (is_string($requested) && isset($available_sorts[$requested])) {
-            $selected_sort = $requested;
-        }
-        elseif (!isset($available_sorts['overall']) && count($available_sorts) > 0) {
-            $selected_sort = array_key_first($available_sorts);
-        }
-
-        $grade_file = null;
-        if (isset($available_sorts[$selected_sort])) {
-            $grade_path = FileUtils::joinPaths($rainbow_grades_dir, $available_sorts[$selected_sort]['file']);
-            if (file_exists($grade_path)) {
-                $grade_file = file_get_contents($grade_path);
-            }
-        }
-
+        $grade_path = $this->core->getConfig()->getCoursePath() . "/rainbow_grades/output.html";
         $grade_summaries_last_run = $this->getGradeSummariesLastRun();
+        $grade_file = null;
+        if (file_exists($grade_path)) {
+            $grade_file = file_get_contents($grade_path);
+        }
 
         return MultiResponse::webOnlyResponse(
             new WebResponse(
                 ['admin', 'Report'],
                 'showFullGradebook',
                 $grade_file,
-                $grade_summaries_last_run,
-                $available_sorts,
-                $selected_sort
+                $grade_summaries_last_run
             )
         );
     }
-
-    /**
-     * Discover which rainbow grades tables have been built in the given directory and
-     * return them as an ordered map of sort-key => ['file' => <filename>, 'label' => <label>].
-     * Recognizes output.html (overall) and output-by-<x>.html (e.g. output-by-section.html).
-     *
-     * @return array<string, array{file: string, label: string}>
-     */
-    private function getAvailableGradebookSorts(string $rainbow_grades_dir): array {
-        $labels = [
-            'overall' => 'Overall',
-            'name' => 'By Name',
-            'section' => 'By Section',
-            'lab' => 'By Lab',
-            'hw' => 'By Homework',
-            'test' => 'By Test',
-            'quiz' => 'By Quiz',
-            'exam' => 'By Exam',
-            'reading' => 'By Reading',
-            'worksheet' => 'By Worksheet',
-            'project' => 'By Project',
-            'participation' => 'By Participation',
-            'zone' => 'By Zone',
-        ];
-
-        $found = [];
-        foreach (glob(FileUtils::joinPaths($rainbow_grades_dir, 'output*.html')) as $path) {
-            $name = basename($path);
-            if ($name === 'output.html') {
-                $key = 'overall';
-            }
-            elseif (preg_match('/^output-by-([a-z0-9_]+)\.html$/', $name, $m)) {
-                $key = $m[1];
-            }
-            else {
-                continue;
-            }
-            $found[$key] = [
-                'file' => $name,
-                'label' => $labels[$key] ?? ('By ' . ucwords(str_replace('_', ' ', $key))),
-            ];
-        }
-
-        $ordered = [];
-        foreach (array_keys($labels) as $key) {
-            if (isset($found[$key])) {
-                $ordered[$key] = $found[$key];
-                unset($found[$key]);
-            }
-        }
-        foreach ($found as $key => $info) {
-            $ordered[$key] = $info;
-        }
-        return $ordered;
-    }
-
 
     /**
      * Generate a custom filename for the downloaded CSV file


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In PR#13002, I accidentally pushed changes intended for a different branch. This PR reverts those changes.

### What is the New Behavior?
Should be the same as on main, with rainbow grades functioning normally.

This PR also fixes an error you get when trying to view the gradebook introduced by the accidentally included changes:
<img width="3080" height="1050" alt="image" src="https://github.com/user-attachments/assets/14c0ad86-b8e9-4816-a486-0979cc5885d3" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Run `submitty_install_site`
2. Navigate to any course as instructor
3. Test features related to rainbow grades (specifically, building and viewing grades)

### Automated Testing & Documentation
N/A
