### PR TITLE
[Feature:InstructorUI] Add Icon to Editing Peer Components

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -1046,6 +1046,14 @@ tr.is_publish {
     cursor: default;
 }
 
+.gradeable .component .peer-component-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    font-size: 20px;
+}
+
 .gradeable .peer-border {
     border: 3px solid var(--standard-mediumorchid);
 }

--- a/site/public/templates/grading/EditComponentHeader.twig
+++ b/site/public/templates/grading/EditComponentHeader.twig
@@ -4,6 +4,12 @@
     </strong>
 </span>
 
+{% if component.peer_component %}
+    <span class="peer-component-icon col-no-gutters">
+        <i class="fas fa-users" title="Peer grading component"></i>
+    </span>
+{% endif %}
+
 <span class="component-title col-no-gutters">
     <b><span class="component-title-text">{{ component.title|escape }}</span></b>
 </span>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Adds an icon to peer components on the edit rubric page to further emphasize that they are distinct from regular components.

### What is the New Behavior?
Before:
<img width="928" height="338" alt="image" src="https://github.com/user-attachments/assets/205e2c6d-0f40-418f-9cd1-a512a78936e9" />

After:
<img width="934" height="335" alt="image" src="https://github.com/user-attachments/assets/f08b7296-c27c-4eab-bdb7-1492f81b7ac6" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
As an instructor, visit the edit rubric page any gradeable with peer components and notice icon.


### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security risk
