### PR TITLE
[Bugfix:TAGrading] Fix Team Version Conflict Handling

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7977,11 +7977,11 @@ AND gc_id IN (
             FROM gradeable_data AS gd
             WHERE (
                 gd.g_id = ?
-                AND gd.gd_user_id = ?
+                AND (gd.gd_user_id = ? OR gd.gd_team_id = ?)
                 AND gcd.gc_id IN ' . $this->createParameterList(count($component_ids)) . '
                 AND gd.gd_id = gcd.gd_id
             )',
-            array_merge([$version, $gradeable_id, $submitter_id], $component_ids)
+            array_merge([$version, $gradeable_id, $submitter_id, $submitter_id], $component_ids)
         );
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Partially Addresses #[13033](https://github.com/Submitty/Submitty/issues/13033) 
Clicking Clear Version Conflicts did not work for team gradeables. This was due to the database query for changing graded versions searched by user_id, but team gradeable components go by team_id.

### What is the New Behavior?
The database query for changing graded versions for components now searches by both user_id and team_id so all version conflicts are caught.

### What steps should a reviewer take to reproduce or test the bug or new feature?
- As a student, intentionally create a version conflict on a team gradeable by making a new submission (I used Grading Homework Team PDF).
- As instructor, verify clicking Clear Version conflict on their rubric resolves conflicts


### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security concern