### PR TITLE
[Bugfix:InstructorUI] Course Staff Table Highlight

### DIFF
--- a/site/app/templates/admin/users/StudentList.twig
+++ b/site/app/templates/admin/users/StudentList.twig
@@ -161,7 +161,7 @@
                     {% for student in students %}
                         {% set class = "" %}
                         {% if student.accessGrading() %}
-                            {% set class = "access-grading" %}
+                            {% set class = "highlighted-row" %}
                         {% endif %}
                         <tr id="user-{{ student.getId() }}" class="{{ class }}">
                             <td></td>

--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -275,9 +275,11 @@
 </div>
 
 {% macro render_student(context, section, graded_gradeable, index, info, columns, team_gradeable_view_history, overrides, override_data, anon_ids, max_team_name_length, active_graders) %}
-    <tr class="grade-table" data-testid="grade-table"
+    <tr data-testid="grade-table"
         {% if not graded_gradeable.getSubmitter().isTeam() and graded_gradeable.getSubmitter().getUser().accessGrading() %}
-            style='background: #7bd0f7;'
+            class="grade-table highlighted-row"
+        {% else %}
+            class="grade-table"
         {% endif %}
         {% if not graded_gradeable.getSubmitter().isTeam() and graded_gradeable.getSubmitter().getUser().getRegistration_type() == "withdrawn" %}
             data-student="electronic-grade-withdrawn"

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -260,7 +260,7 @@
             {% set ta_grade = grade.getTaGradedGradeable() %}
             {% set component_grade = ta_grade is not null ? ta_grade.getGradedComponent(component) : null %}
             <td
-                class="cell-grade cell-checkpoint {{ component_grade ? (component_grade.getScore() == 1.0 ? "simple-full-credit" : (component_grade.getScore() == 0.5 ? "simple-half-credit" : "")) : "" }}"
+                class="cell-grade cell-checkpoint no-highlight {{ component_grade ? (component_grade.getScore() == 1.0 ? "simple-full-credit" : (component_grade.getScore() == 0.5 ? "simple-half-credit" : "")) : "" }}"
                 id="cell-{{ section_id }}-{{ index }}-{{ loop.index0 }}"
                 tabindex="0"
                 data-id="{{ component.getId() }}"
@@ -281,7 +281,7 @@
     {% for component in grade.getGradeable().getComponents()|filter((component) => component.isText()) %}
         {% set ta_grade = grade.getTaGradedGradeable() %}
         {% set component_grade = ta_grade is not null ? ta_grade.getGradedComponent(component) : null %}
-        <td class="option-small-input">
+        <td class="option-small-input no-highlight">
             <textarea class="option-small-box cell-grade cell-text-entry"
                   tabindex="0" id="cell-comment-{{ section_id }}-{{ index }}-{{loop.index0 }}"
                   contenteditable
@@ -308,7 +308,7 @@
             {% set component_grade = ta_grade is not null ? ta_grade.getGradedComponent(component) : null %}
             {% set component_score = component_grade ? component_grade.getScore() : 0 %}
             {% set total = total + component_score %}
-            <td class="option-small-input">
+            <td class="option-small-input no-highlight">
                 <input
                     class="option-small-box cell-grade" tabindex="0"
                     style="text-align: center; width: 80px; {{ component_score == 0 ? "color: var(--standard-light-medium-gray);" : "" }}
@@ -336,7 +336,7 @@
             </td>
         {% endfor %}
 
-        <td class="option-small-output">
+        <td class="option-small-output no-highlight">
             <div class="option-small-box cell-total" style="text-align: center" id="total-{{ section_id }}-{{ index }}" data-total="true">{{ total }}</div>
         </td>
     {% endif %}
@@ -345,7 +345,7 @@
     {% for component in grade.getGradeable().getComponents()|filter((component) => component.isText()) %}
         {% set ta_grade = grade.getTaGradedGradeable() %}
         {% set component_grade = ta_grade is not null ? ta_grade.getGradedComponent(component) : null %}
-        <td class="option-small-input">
+        <td class="option-small-input no-highlight">
             <textarea class="option-small-box cell-grade cell-text-entry"
                   tabindex="0" id="cell-{{ section_id }}-{{ index }}-{{ text_start + loop.index0 }}"
                   contenteditable

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -2,6 +2,8 @@
     padding: 20px 10px;
 }
 
+/* Details Table Styling */
+
 #details-table tbody.details-info-header {
     font-size: 15px;
 }
@@ -13,6 +15,19 @@
 /* stylelint-disable-next-line no-descending-specificity */
 #details-table tbody.details-content td {
     text-align: center;
+}
+
+tbody {
+    counter-reset: student;
+}
+
+tbody tr:not(.info) {
+    counter-increment: student;
+}
+
+tbody tr:not(.info) > td:nth-child(1)::after {
+    content: counter(student);
+    padding: 0 1em;
 }
 
 .expand-icon,

--- a/site/public/css/directory.css
+++ b/site/public/css/directory.css
@@ -1,9 +1,3 @@
-.access-grading td,
-.access-grading i {
-    /* stylelint-disable-next-line declaration-no-important */
-    background: var(--standard-focus-cornflower-blue) !important;
-}
-
 #student-table td:nth-of-type(1) {
     display: none;
 }
@@ -120,10 +114,5 @@
     }
     #grader-table td:nth-of-type(1) {
         display: table-cell;
-    }
-
-    tr.access-grading {
-        /* stylelint-disable-next-line declaration-no-important */
-        background: var(--standard-focus-cornflower-blue) !important;
     }
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -331,6 +331,10 @@ table tr.table-header {
     background: var(--default-white);
 }
 
+tr.highlighted-row td:not(.no-highlight) {
+    background: var(--standard-focus-cornflower-blue);
+}
+
 .table > thead > tr,
 .table > tfoot > tr {
     background: var(--standard-hover-light-gray);

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -321,12 +321,18 @@ table tr.table-header {
     border-radius: 4px;
 }
 
-.table-striped > tbody > tr:nth-child(even) {
+/* Table stripe pattern should skip withdrawn students in case they are hidden */
+
+.table-striped > tbody > tr:nth-child(even of :not([data-student$="grade-withdrawn"])) {
     background: var(--standard-hover-light-gray);
 }
 
-.table-striped > tbody > tr:nth-child(odd) {
+.table-striped > tbody > tr:nth-child(odd of :not([data-student$="grade-withdrawn"])) {
     background: var(--default-white);
+}
+
+.table-striped > tbody > tr[data-student$="grade-withdrawn"] {
+    background: var(--standard-light-gray);
 }
 
 .table > thead > tr,

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -323,14 +323,14 @@ table tr.table-header {
 
 /* Table stripe pattern should skip withdrawn students in case they are hidden */
 
-.table-striped 
-    > tbody 
+.table-striped
+    > tbody
     > tr:nth-child(even of :not(.hidden-withdrawn-student-row)) {
     background: var(--standard-hover-light-gray);
 }
 
-.table-striped 
-    > tbody 
+.table-striped
+    > tbody
     > tr:nth-child(odd of :not(.hidden-withdrawn-student-row)) {
     background: var(--default-white);
 }

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -323,11 +323,15 @@ table tr.table-header {
 
 /* Table stripe pattern should skip withdrawn students in case they are hidden */
 
-.table-striped > tbody > tr:nth-child(even of :not(.hidden-withdrawn-student-row)) {
+.table-striped 
+    > tbody 
+    > tr:nth-child(even of :not(.hidden-withdrawn-student-row)) {
     background: var(--standard-hover-light-gray);
 }
 
-.table-striped > tbody > tr:nth-child(odd of :not(.hidden-withdrawn-student-row)) {
+.table-striped 
+    > tbody 
+    > tr:nth-child(odd of :not(.hidden-withdrawn-student-row)) {
     background: var(--default-white);
 }
 

--- a/site/public/css/server.css
+++ b/site/public/css/server.css
@@ -323,16 +323,12 @@ table tr.table-header {
 
 /* Table stripe pattern should skip withdrawn students in case they are hidden */
 
-.table-striped > tbody > tr:nth-child(even of :not([data-student$="grade-withdrawn"])) {
+.table-striped > tbody > tr:nth-child(even of :not(.hidden-withdrawn-student-row)) {
     background: var(--standard-hover-light-gray);
 }
 
-.table-striped > tbody > tr:nth-child(odd of :not([data-student$="grade-withdrawn"])) {
+.table-striped > tbody > tr:nth-child(odd of :not(.hidden-withdrawn-student-row)) {
     background: var(--default-white);
-}
-
-.table-striped > tbody > tr[data-student$="grade-withdrawn"] {
-    background: var(--standard-light-gray);
 }
 
 .table > thead > tr,

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -54,6 +54,19 @@ tr > td:nth-child(5) {
     border-right: 1px solid var(--standard-medium-gray);
 }
 
+tbody {
+    counter-reset: student;
+}
+
+tbody tr:not(.info) {
+    counter-increment: student;
+}
+
+tbody tr:not(.info) > td:nth-child(1)::after {
+    content: counter(student);
+    padding: 0 1em;
+}
+
 .highlighted-row td:nth-child(n + 1):nth-child(-n + 5) {
     /* stylelint-disable-next-line declaration-no-important */
     background: var(--standard-focus-cornflower-blue) !important ;

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -58,26 +58,13 @@ tbody {
     counter-reset: student;
 }
 
-tbody tr:not(.info) {
+tbody > tr:not(.info) {
     counter-increment: student;
 }
 
-tbody tr:not(.info) > td:nth-child(1)::after {
+tbody > tr:not(.info) > td:nth-child(1)::after {
     content: counter(student);
     padding: 0 1em;
-}
-
-.highlighted-row td:nth-child(n + 1):nth-child(-n + 5) {
-    /* stylelint-disable-next-line declaration-no-important */
-    background: var(--standard-focus-cornflower-blue) !important ;
-}
-
-tr:nth-child(odd) td:nth-child(n + 1):nth-child(-n + 5) {
-    background: var(--default-white);
-}
-
-tr:nth-child(even) td:nth-child(n + 1):nth-child(-n + 5) {
-    background: var(--standard-hover-light-gray);
 }
 
 #data-table td:focus,
@@ -111,6 +98,8 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow-x: auto;
 }
 
+/* Key Styles */
+
 .simple-key-full-credit,
 .simple-full-credit {
     color: var(--simple-full-credit-dark-blue);
@@ -136,7 +125,13 @@ input[type="number"]::-webkit-outer-spin-button {
     text-align: center;
 }
 
-/* styling for fields that aren't icons */
+.simple-icon {
+    transform: scaleX(3);
+    width: 20px;
+}
+
+/* Checkpoint Cell Styles */
+
 .simple-full-credit:not(i) {
     background-color: var(--simple-full-credit-dark-blue);
 }
@@ -147,11 +142,6 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .simple-save-error:not(i) {
     background-color: var(--simple-save-error-red);
-}
-
-.simple-icon {
-    transform: scaleX(3);
-    width: 20px;
 }
 
 #details-legend li {

--- a/site/public/js/electronic-grading.js
+++ b/site/public/js/electronic-grading.js
@@ -16,7 +16,4 @@ window.addEventListener('DOMContentLoaded', () => {
             withdrawnFilterElements.hide();
         }
     }
-    window.updateElectronicGradingRowNumbersAndColors();
-    // Remove table-striped to prevent CSS conflicts with JS-set colors
-    $('table').removeClass('table-striped');
 });

--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -990,11 +990,6 @@ window.addEventListener('DOMContentLoaded', () => {
         }
         autoResize();
     }
-
-    window.updateSimpleGradingRowNumbersAndColors();
-
-    // Remove table-striped to prevent CSS conflicts with JS-set colors
-    $('table#data-table').removeClass('table-striped');
 });
 
 function newNumericCsvUploadForm() {

--- a/site/ts/ta-grading-cookies.ts
+++ b/site/ts/ta-grading-cookies.ts
@@ -32,21 +32,20 @@ window.filter_null_section = () => {
 };
 
 window.filter_withdrawn_students = () => {
-    const withdrawn_students = window.Cookies.get('include_withdrawn_students') || 'omit';
+    const withdrawn_students_visibility = window.Cookies.get('include_withdrawn_students') || 'omit';
 
-    // even if this does not exist, we can still hide and show it
-    // This helps as we don't have to determine which page we are on
-    const withdrawn_electronic = $('[data-student="electronic-grade-withdrawn"]');
-    const withdrawn_simple = $('[data-student="simple-grade-withdrawn"]');
+    // includes electronic-grade-withdrawn and simple-grade-withdrawn
+    // for the details and display pages respectively
+    const withdrawn_student_rows = $('[data-student$="grade-withdrawn"]');
 
-    if (withdrawn_students === 'include') {
-        withdrawn_electronic.hide();
-        withdrawn_simple.hide();
+    if (withdrawn_students_visibility === 'include') {
+        withdrawn_student_rows.hide();
+        withdrawn_student_rows.addClass('hidden-withdrawn-student-row');
         window.Cookies.set('include_withdrawn_students', 'omit', cookieArguments);
     }
     else {
-        withdrawn_electronic.show();
-        withdrawn_simple.show();
+        withdrawn_student_rows.show();
+        withdrawn_student_rows.removeClass('hidden-withdrawn-student-row');
         window.Cookies.set('include_withdrawn_students', 'include', cookieArguments);
     }
 };

--- a/site/ts/ta-grading-cookies.ts
+++ b/site/ts/ta-grading-cookies.ts
@@ -49,9 +49,6 @@ window.filter_withdrawn_students = () => {
         withdrawn_simple.show();
         window.Cookies.set('include_withdrawn_students', 'include', cookieArguments);
     }
-
-    // Remove table-striped to prevent CSS conflicts with JS-set colors
-    $('table').removeClass('table-striped');
 };
 
 window.changeSections = () => {

--- a/site/ts/ta-grading-cookies.ts
+++ b/site/ts/ta-grading-cookies.ts
@@ -10,69 +10,11 @@ declare global {
         changeSortOrder: () => void;
         sortTableByColumn: (sort_type?: string, direction?: 'ASC' | 'DESC') => void;
         changeAnon: () => void;
-        updateSimpleGradingRowNumbersAndColors: () => void;
-        updateElectronicGradingRowNumbersAndColors: () => void;
     }
 }
 
 const coursePath = document.body.dataset.coursePath ?? '';
 const cookieArguments = { path: coursePath, expires: 365 };
-
-function updateSimpleGradingRowNumbersAndColors() {
-    $('tbody[id^="section-"]').each(function () {
-        let rowNumber = 1;
-
-        $(this).find('tr[data-student="simple-grade-active"], tr[data-student="simple-grade-withdrawn"]').each(function () {
-            if ($(this).is(':visible')) {
-                $(this).find('td:first').text(rowNumber);
-                const color = rowNumber % 2 === 1 ? 'var(--default-white)' : 'var(--standard-hover-light-gray)';
-
-                $(this).css('background-color', `${color} !important`);
-                $(this).find('td').each(function () {
-                    if ($(this).hasClass('simple-full-credit')) {
-                        $(this).css('background-color', 'var(--simple-full-credit-dark-blue) !important');
-                    }
-                    else if ($(this).hasClass('simple-half-credit')) {
-                        $(this).css('background-color', 'var(--simple-half-credit-light-blue) !important');
-                    }
-                    else if ($(this).hasClass('simple-save-error')) {
-                        $(this).css('background-color', 'var(--simple-save-error-red) !important');
-                    }
-                    else {
-                        $(this).css('background-color', `${color} !important`);
-                    }
-                });
-                rowNumber++;
-            }
-            else {
-                $(this).css('background-color', 'var(--default-white) !important');
-                $(this).find('td').css('background-color', 'var(--default-white) !important');
-            }
-        });
-    });
-}
-
-function updateElectronicGradingRowNumbersAndColors() {
-    $('tbody.details-content').each(function () {
-        let rowNumber = 1;
-
-        $(this).find('tr[data-student="electronic-grade-active"], tr[data-student="electronic-grade-withdrawn"]').each(function () {
-            if ($(this).is(':visible')) {
-                $(this).find('td:first').text(rowNumber);
-                if (rowNumber % 2 === 1) {
-                    $(this).css('background-color', 'var(--default-white) !important');
-                }
-                else {
-                    $(this).css('background-color', 'var(--standard-hover-light-gray) !important');
-                }
-                rowNumber++;
-            }
-            else {
-                $(this).css('background-color', 'var(--default-white) !important');
-            }
-        });
-    });
-}
 
 window.filter_overriden_grades = () => {
     const override_status = window.Cookies.get('include_grade_override') ?? 'omit';
@@ -110,10 +52,6 @@ window.filter_withdrawn_students = () => {
 
     // Remove table-striped to prevent CSS conflicts with JS-set colors
     $('table').removeClass('table-striped');
-
-    // Update row numbers and colors after filtering
-    updateSimpleGradingRowNumbersAndColors();
-    updateElectronicGradingRowNumbersAndColors();
 };
 
 window.changeSections = () => {
@@ -151,6 +89,3 @@ window.changeAnon = () => {
     window.Cookies.set('anon_mode', $('#toggle-anon-students').is(':checked') ? 'on' : 'off', cookieArguments);
     location.reload();
 };
-
-window.updateSimpleGradingRowNumbersAndColors = updateSimpleGradingRowNumbersAndColors;
-window.updateElectronicGradingRowNumbersAndColors = updateElectronicGradingRowNumbersAndColors;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #12584, Related to #12996 

### What is the New Behavior?
Course staff are now properly highlighted on the Simple Grading and Gradeable Details pages. Also, the Gradeable Details page also uses the same blue to highlight the course staff as the rest of the gradeable tables.

### What steps should a reviewer take to reproduce or test the bug or new feature?

Please follow the testing procedure on multiple browsers (at least Chromium and Firefox).

1. Go to the main branch
2. Go to the following gradeables, and for each of them you should see that staff are not highlighted in the tables:
i. Open a gradeable with student file submission
ii. Make a Numeric gradeable with at least on numeric column and at least one text column
iii. Make a Checkpoint gradeable with at least one checkpoint column and at least one text column

<img width="745" height="311" alt="image" src="https://github.com/user-attachments/assets/817dcf9c-5acd-4f8b-af05-9775335adb2f" />

6. Now go to this branch and submitty_install_site
7. Open each gradeable that you opened/made on main and you should now see that staff are highlighted in the tables:

<img width="738" height="274" alt="Screenshot 2026-07-14 111103" src="https://github.com/user-attachments/assets/19f8d392-7dd7-449f-b009-baecba670e7c" />

EDIT: Please ensure that on the numeric and checkpoint gradeables row highlighting stops at the user's identifying information, so that the highlight doesn't interfere with checkpoint grading cells or numeric/text input cells.

e.g.
<img width="724" height="244" alt="image" src="https://github.com/user-attachments/assets/9516baba-2bfc-436c-8162-41cdb5966ecc" />


### Automated Testing & Documentation
There are currently no tests that check for highlighted staff rows in the gradeable tables. Should there be?