### PR TITLE
[Feature:InstructorUI] Docker alias deletion

### DIFF
--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -212,19 +212,41 @@ class DockerInterfaceController extends AbstractController {
     #[Route("/admin/remove_image", methods: ["POST"])]
     public function removeImage(): JsonResponse {
         $pattern = '/^[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+\/[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/';
-        $image = $_POST['image'] ?? '';
 
-        if (!preg_match($pattern, $image)) {
-            return JsonResponse::getFailResponse('Invalid Docker image name.');
+        // Accept a list of names (primary and/or aliases); fall back to the legacy single-image param.
+        $images = $_POST['images'] ?? null;
+        if (!is_array($images)) {
+            $images = isset($_POST['image']) ? [$_POST['image']] : [];
         }
+        $images = array_values(array_unique(array_filter(
+            $images,
+            fn($i) => is_string($i) && $i !== ''
+        )));
 
-        if ($this->core->getQueries()->getDockerImageOwner($image) === false) {
-            return JsonResponse::getFailResponse('This image is not listed.');
+        if (count($images) === 0) {
+            return JsonResponse::getFailResponse('No image selected for removal.');
         }
 
         $user = $this->core->getUser();
-        if (!$this->core->getQueries()->removeDockerImageOwner($image, $user)) {
-            return JsonResponse::getFailResponse('This image is owned/managed by another instructor/superuser.');
+        $removed = [];
+        $skipped = [];
+
+        foreach ($images as $image) {
+            if (
+                !preg_match($pattern, $image)
+                || $this->core->getQueries()->getDockerImageOwner($image) === false
+                || !$this->core->getQueries()->removeDockerImageOwner($image, $user)
+            ) {
+                $skipped[] = $image;
+                continue;
+            }
+            $removed[] = $image;
+        }
+
+        if (count($removed) === 0) {
+            return JsonResponse::getFailResponse(
+                'Nothing was removed. The selected image(s) are not listed or are managed by another instructor/superuser.'
+            );
         }
 
         $removed = [$image];
@@ -270,8 +292,16 @@ class DockerInterfaceController extends AbstractController {
         $message = implode(', ', $removed) . " has been removed from the configuration. "
             . "Click 'Update dockers and machines' to apply changes.";
         if (count($skipped) > 0) {
+<<<<<<< Updated upstream
             $message .= ' Could not remove (not listed or managed by another user): ' . implode(', ', array_filter($skipped)) . '.';
         }
 
         return JsonResponse::getSuccessResponse($message);
+=======
+            $message .= ' Could not remove (not listed or managed by another user): ' . implode(', ', $skipped) . '.';
+        }
+
+        return JsonResponse::getSuccessResponse($message);
+    }
+>>>>>>> Stashed changes
 }

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -213,7 +213,6 @@ class DockerInterfaceController extends AbstractController {
     public function removeImage(): JsonResponse {
         $pattern = '/^[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+\/[a-z0-9]+[a-z0-9._(__)-]*[a-z0-9]+:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/';
 
-        // Accept a list of names (primary and/or aliases); fall back to the legacy single-image param.
         $images = $_POST['images'] ?? null;
         if (!is_array($images)) {
             $images = isset($_POST['image']) ? [$_POST['image']] : [];
@@ -227,18 +226,48 @@ class DockerInterfaceController extends AbstractController {
             return JsonResponse::getFailResponse('No image selected for removal.');
         }
 
+        $jsonFilePath = FileUtils::joinPaths(
+            $this->core->getConfig()->getSubmittyDataPath(),
+            "config",
+            "autograding_containers.json"
+        );
+        $json = FileUtils::readJsonFile($jsonFilePath);
+
+        // Names actually present in the config (independent of ownership).
+        $in_config = [];
+        foreach ($json as $capability) {
+            foreach ($capability as $name) {
+                $in_config[$name] = true;
+            }
+        }
+
         $user = $this->core->getUser();
         $removed = [];
         $skipped = [];
 
         foreach ($images as $image) {
-            if (
-                !preg_match($pattern, $image)
-                || $this->core->getQueries()->getDockerImageOwner($image) === false
-                || !$this->core->getQueries()->removeDockerImageOwner($image, $user)
-            ) {
+            if (!preg_match($pattern, $image)) {
                 $skipped[] = $image;
                 continue;
+            }
+
+            $owner = $this->core->getQueries()->getDockerImageOwner($image); // string|false
+
+            // Nothing to act on: no owner row and not in the config.
+            if ($owner === false && !isset($in_config[$image])) {
+                $skipped[] = $image;
+                continue;
+            }
+
+            // Protect images managed by another instructor from non-superusers.
+            if ($owner !== false && $owner !== '' && !$user->isSuperUser() && $owner !== $user->getId()) {
+                $skipped[] = $image;
+                continue;
+            }
+
+            // Drop the ownership row if one exists; a missing row is fine.
+            if ($owner !== false) {
+                $this->core->getQueries()->removeDockerImageOwner($image, $user);
             }
             $removed[] = $image;
         }
@@ -249,33 +278,6 @@ class DockerInterfaceController extends AbstractController {
             );
         }
 
-        $removed = [$image];
-        $skipped = [];
-        $aliases = $_POST['aliases'] ?? [];
-        if (!is_array($aliases)) {
-            $aliases = [];
-        }
-
-        foreach ($aliases as $alias) {
-            if (
-                !is_string($alias)
-                || !preg_match($pattern, $alias)
-                || $this->core->getQueries()->getDockerImageOwner($alias) === false
-                || !$this->core->getQueries()->removeDockerImageOwner($alias, $user)
-            ) {
-                $skipped[] = $alias;
-                continue;
-            }
-            $removed[] = $alias;
-        }
-
-        $jsonFilePath = FileUtils::joinPaths(
-            $this->core->getConfig()->getSubmittyDataPath(),
-            "config",
-            "autograding_containers.json"
-        );
-        $json = FileUtils::readJsonFile($jsonFilePath);
-
         foreach ($removed as $name) {
             foreach ($json as $capability_key => $capability) {
                 if (($key = array_search($name, $capability, true)) !== false) {
@@ -284,10 +286,7 @@ class DockerInterfaceController extends AbstractController {
             }
         }
 
-        FileUtils::writeJsonFile(
-            $jsonFilePath,
-            $json,
-        );
+        FileUtils::writeJsonFile($jsonFilePath, $json);
 
         $message = implode(', ', $removed) . " has been removed from the configuration. "
             . "Click 'Update dockers and machines' to apply changes.";

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -292,16 +292,9 @@ class DockerInterfaceController extends AbstractController {
         $message = implode(', ', $removed) . " has been removed from the configuration. "
             . "Click 'Update dockers and machines' to apply changes.";
         if (count($skipped) > 0) {
-<<<<<<< Updated upstream
-            $message .= ' Could not remove (not listed or managed by another user): ' . implode(', ', array_filter($skipped)) . '.';
-        }
-
-        return JsonResponse::getSuccessResponse($message);
-=======
             $message .= ' Could not remove (not listed or managed by another user): ' . implode(', ', $skipped) . '.';
         }
 
         return JsonResponse::getSuccessResponse($message);
     }
->>>>>>> Stashed changes
 }

--- a/site/app/controllers/DockerInterfaceController.php
+++ b/site/app/controllers/DockerInterfaceController.php
@@ -227,6 +227,26 @@ class DockerInterfaceController extends AbstractController {
             return JsonResponse::getFailResponse('This image is owned/managed by another instructor/superuser.');
         }
 
+        $removed = [$image];
+        $skipped = [];
+        $aliases = $_POST['aliases'] ?? [];
+        if (!is_array($aliases)) {
+            $aliases = [];
+        }
+
+        foreach ($aliases as $alias) {
+            if (
+                !is_string($alias)
+                || !preg_match($pattern, $alias)
+                || $this->core->getQueries()->getDockerImageOwner($alias) === false
+                || !$this->core->getQueries()->removeDockerImageOwner($alias, $user)
+            ) {
+                $skipped[] = $alias;
+                continue;
+            }
+            $removed[] = $alias;
+        }
+
         $jsonFilePath = FileUtils::joinPaths(
             $this->core->getConfig()->getSubmittyDataPath(),
             "config",
@@ -234,9 +254,11 @@ class DockerInterfaceController extends AbstractController {
         );
         $json = FileUtils::readJsonFile($jsonFilePath);
 
-        foreach ($json as $capability_key => $capability) {
-            if (($key = array_search($image, $capability, true)) !== false) {
-                array_splice($json[$capability_key], $key, 1);
+        foreach ($removed as $name) {
+            foreach ($json as $capability_key => $capability) {
+                if (($key = array_search($name, $capability, true)) !== false) {
+                    array_splice($json[$capability_key], $key, 1);
+                }
             }
         }
 
@@ -245,7 +267,11 @@ class DockerInterfaceController extends AbstractController {
             $json,
         );
 
-        return JsonResponse::getSuccessResponse($image . ' has been removed from the configuration. 
-                                                            Click \'Update dockers and machines\' to apply changes.');
-    }
+        $message = implode(', ', $removed) . " has been removed from the configuration. "
+            . "Click 'Update dockers and machines' to apply changes.";
+        if (count($skipped) > 0) {
+            $message .= ' Could not remove (not listed or managed by another user): ' . implode(', ', array_filter($skipped)) . '.';
+        }
+
+        return JsonResponse::getSuccessResponse($message);
 }

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -140,13 +140,38 @@
                 <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>
                 <td>
                     {% if is_super_user or (docker_image_owners[image.primary_name] is defined and user_id == docker_image_owners[image.primary_name]) %}
+<<<<<<< Updated upstream
                         <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" onclick="confirmationDialog('{{ admin_url }}/remove_image', this)">Remove</button>
+=======
+                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" onclick="openRemoveDialog(this, '{{ admin_url }}/remove_image')">Remove</button>
+>>>>>>> Stashed changes
                     {% endif %}
                 </td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
+</div>
+
+<div class="popup-form" style="display: none;" id="remove-image-form">
+    <div class="popup-box">
+        <div class="popup-window" style="position: relative;">
+            <div class="form-title">
+                <h1>Remove Image</h1>
+            </div>
+            <div class="form-body">
+                <p>Select which name(s) to remove from the configuration. Aliases point at the same underlying image, so you can remove one, the other, or both.</p>
+                <div id="remove-image-options"></div>
+                <span id="remove-image-error" style="color: var(--standard-red, red);"></span>
+                <div class="form-buttons">
+                    <div class="form-button-container">
+                        <a onclick="closePopup('remove-image-form');" class="btn btn-default">Cancel</a>
+                        <button id="remove-image-submit" class="btn btn-danger" type="button" onclick="submitRemoveImage()">Remove Selected</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 {% if no_image_capabilities | length > 0 %}

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -140,11 +140,7 @@
                 <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>
                 <td>
                     {% if is_super_user or (docker_image_owners[image.primary_name] is defined and user_id == docker_image_owners[image.primary_name]) %}
-<<<<<<< Updated upstream
-                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" onclick="confirmationDialog('{{ admin_url }}/remove_image', this)">Remove</button>
-=======
-                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" onclick="openRemoveDialog(this, '{{ admin_url }}/remove_image')">Remove</button>
->>>>>>> Stashed changes
+                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" data-testid="remove-image-button" onclick="openRemoveDialog(this, '{{ admin_url }}/remove_image')">Remove</button>
                     {% endif %}
                 </td>
             </tr>
@@ -153,7 +149,7 @@
     </table>
 </div>
 
-<div class="popup-form" style="display: none;" id="remove-image-form">
+<div class="popup-form" style="display: none;" id="remove-image-form" data-testid="remove-image-form">
     <div class="popup-box">
         <div class="popup-window" style="position: relative;">
             <div class="form-title">
@@ -161,12 +157,12 @@
             </div>
             <div class="form-body">
                 <p>Select which name(s) to remove from the configuration. Aliases point at the same underlying image, so you can remove one, the other, or both.</p>
-                <div id="remove-image-options"></div>
-                <span id="remove-image-error" style="color: var(--standard-red, red);"></span>
+                <div id="remove-image-options" data-testid="remove-image-options"></div>
+                <span id="remove-image-error" data-testid="remove-image-error" style="color: var(--standard-red, red);"></span>
                 <div class="form-buttons">
                     <div class="form-button-container">
-                        <a onclick="closePopup('remove-image-form');" class="btn btn-default">Cancel</a>
-                        <button id="remove-image-submit" class="btn btn-danger" type="button" onclick="submitRemoveImage()">Remove Selected</button>
+                        <a onclick="closePopup('remove-image-form');" class="btn btn-default" data-testid="remove-image-cancel">Cancel</a>
+                        <button id="remove-image-submit" data-testid="remove-image-submit" class="btn btn-danger" type="button" onclick="submitRemoveImage()">Remove Selected</button>
                     </div>
                 </div>
             </div>

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -156,7 +156,7 @@
                 <h1>Remove Image</h1>
             </div>
             <div class="form-body">
-                <p>Select which name(s) to remove from the configuration. Aliases point at the same underlying image, so you can remove one, the other, or both.</p>
+                <p>Select which name(s) to remove from the configuration.</p>
                 <div id="remove-image-options" data-testid="remove-image-options"></div>
                 <span id="remove-image-error" data-testid="remove-image-error" style="color: var(--standard-red, red);"></span>
                 <div class="form-buttons">

--- a/site/app/templates/admin/Docker.twig
+++ b/site/app/templates/admin/Docker.twig
@@ -140,7 +140,7 @@
                 <td>{{ docker_image_owners[image.primary_name] | default("") }}</td>
                 <td>
                     {% if is_super_user or (docker_image_owners[image.primary_name] is defined and user_id == docker_image_owners[image.primary_name]) %}
-                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" onclick=confirmationDialog("{{admin_url}}/remove_image",id)>Remove</button>
+                        <button class="send-button btn btn-default" id="{{ image.primary_name }}" data-image-id="{{ image.primary_name }}" data-aliases="{{ image.aliases | join(',') | e('html_attr') }}" onclick="confirmationDialog('{{ admin_url }}/remove_image', this)">Remove</button>
                     {% endif %}
                 </td>
             </tr>

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -156,31 +156,6 @@ function submitRemoveImage() {
     removeImage(removeDialogUrl, selected);
 }
 
-function removeImage(url, images) {
-    $.ajax({
-        url: url,
-        type: 'POST',
-        data: {
-            images: images,
-            csrf_token: csrfToken,
-        },
-        success: (data) => {
-            const json = JSON.parse(data);
-            if (json.status === 'success') {
-                sessionStorage.setItem('successMessage', json.data);
-                location.reload();
-            }
-            else {
-                displayErrorMessage(json.message);
-            }
-        },
-        error: (err) => {
-            console.error(err);
-            window.alert('Something went wrong. Please try again.');
-        },
-    });
-}
-
 function addImage(url) {
     const capability = $('#capability-form').val();
     const image = $('#add-field').val();

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -65,10 +65,47 @@ function addFieldOnChange() {
     }
 }
 
-function confirmationDialog(url, id) {
-    if (confirm(`Are you sure you want to remove ${id} image?`)) {
-        removeImage(url, id);
+function confirmationDialog(url, button) {
+    const id = button.dataset.imageId;
+    const aliases = (button.dataset.aliases || '').split(',').filter(Boolean);
+
+    if (aliases.length === 0) {
+        if (confirm(`Are you sure you want to remove ${id} from the configuration?`)) {
+            removeImage(url, id, []);
+        }
+        return;
     }
+
+    const aliasList = aliases.join(', ');
+    if (confirm(`${id} shares an image with these alias(es): ${aliasList}.\n\nRemove ${id} and its alias(es) from the configuration?`)) {
+        removeImage(url, id, aliases);
+    }
+}
+
+function removeImage(url, id, aliases = []) {
+    $.ajax({
+        url: url,
+        type: 'POST',
+        data: {
+            image: id,
+            aliases: aliases,
+            csrf_token: csrfToken,
+        },
+        success: (data) => {
+            const json = JSON.parse(data);
+            if (json.status === 'success') {
+                sessionStorage.setItem('successMessage', json.data);
+                location.reload();
+            }
+            else {
+                displayErrorMessage(json.message);
+            }
+        },
+        error: (err) => {
+            console.error(err);
+            window.alert('Something went wrong. Please try again.');
+        },
+    });
 }
 
 function removeImage(url, id) {

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -126,11 +126,11 @@ function openRemoveDialog(button, url) {
         const wrapper = $('<div>', { class: 'remove-image-option' });
         const label = $('<label>', { for: checkboxId });
         const checkbox = $('<input>', {
-            type: 'checkbox',
-            id: checkboxId,
-            class: 'remove-image-checkbox',
+            'type': 'checkbox',
+            'id': checkboxId,
+            'class': 'remove-image-checkbox',
             'data-testid': 'remove-image-checkbox',
-            value: entry.name,
+            'value': entry.name,
         }).prop('checked', entry.primary);
         label.append(checkbox);
         label.append(document.createTextNode(` ${entry.name}${entry.primary ? ' (primary)' : ''}`));

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -129,6 +129,7 @@ function openRemoveDialog(button, url) {
             type: 'checkbox',
             id: checkboxId,
             class: 'remove-image-checkbox',
+            'data-testid': 'remove-image-checkbox',
             value: entry.name,
         }).prop('checked', entry.primary);
         label.append(checkbox);

--- a/site/public/js/docker_interface.js
+++ b/site/public/js/docker_interface.js
@@ -1,5 +1,5 @@
-/* exported collapseSection, confirmationDialog, removeImage, addImage, updateImage */
-/* global csrfToken, displayErrorMessage, displaySuccessMessage */
+/* exported collapseSection, openRemoveDialog, submitRemoveImage, removeImage, addImage, updateImage */
+/* global csrfToken, displayErrorMessage, displaySuccessMessage, showPopup, closePopup */
 /**
 * toggles visibility of a content sections on the Docker UI
 * @param {string} id of the section to toggle
@@ -108,12 +108,59 @@ function removeImage(url, id, aliases = []) {
     });
 }
 
-function removeImage(url, id) {
+let removeDialogUrl = null;
+
+function openRemoveDialog(button, url) {
+    removeDialogUrl = url;
+    const primary = button.dataset.imageId;
+    const aliases = (button.dataset.aliases || '').split(',').filter(Boolean);
+
+    const options = $('#remove-image-options');
+    options.empty();
+
+    const names = [{ name: primary, primary: true }]
+        .concat(aliases.map((a) => ({ name: a, primary: false })));
+
+    names.forEach((entry, i) => {
+        const checkboxId = `remove-image-option-${i}`;
+        const wrapper = $('<div>', { class: 'remove-image-option' });
+        const label = $('<label>', { for: checkboxId });
+        const checkbox = $('<input>', {
+            type: 'checkbox',
+            id: checkboxId,
+            class: 'remove-image-checkbox',
+            value: entry.name,
+        }).prop('checked', entry.primary);
+        label.append(checkbox);
+        label.append(document.createTextNode(` ${entry.name}${entry.primary ? ' (primary)' : ''}`));
+        wrapper.append(label);
+        options.append(wrapper);
+    });
+
+    $('#remove-image-error').text('');
+    showPopup('#remove-image-form');
+}
+
+function submitRemoveImage() {
+    const selected = $('.remove-image-checkbox:checked').map(function () {
+        return $(this).val();
+    }).get();
+
+    if (selected.length === 0) {
+        $('#remove-image-error').text('Select at least one name to remove.');
+        return;
+    }
+
+    closePopup('remove-image-form');
+    removeImage(removeDialogUrl, selected);
+}
+
+function removeImage(url, images) {
     $.ajax({
         url: url,
         type: 'POST',
         data: {
-            image: id,
+            images: images,
             csrf_token: csrfToken,
         },
         success: (data) => {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes [Issue#11988](https://github.com/Submitty/Submitty/issues/11988)

### What is the New Behavior?
Previously, if there was a tag and alias to that same tag, clicking remove would delete both. Now, we check if images have an alias, and if they do, we check against the managed list to see if any of the names match the names in our list.
<img width="2844" height="1468" alt="image" src="https://github.com/user-attachments/assets/ec90be0c-34b3-4710-a2c8-dc668fd8fd3e" />
<img width="1426" height="656" alt="image" src="https://github.com/user-attachments/assets/e963abf5-8d5e-441d-a45f-246fe1a8c075" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Log in as instructor
2. Go to DockerUI
3. On the bottom of the page add `submitty/julia:latest` and `submitty/julia:1.11.5` (currently 1.11.5 is the latest)
4. Verify that the modal opens and you can delete either tag or both

### Automated Testing & Documentation
This feature is not covered by testing, cypress to be added in another PR.

### Other information
Not a breaking change
Not a security concern
No migration