### PR TITLE
[Testing:TAGrading] Add Cypress for Team Version Conflicts

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7977,11 +7977,11 @@ AND gc_id IN (
             FROM gradeable_data AS gd
             WHERE (
                 gd.g_id = ?
-                AND gd.gd_user_id = ?
+                AND (gd.gd_user_id = ? OR gd.gd_team_id = ?)
                 AND gcd.gc_id IN ' . $this->createParameterList(count($component_ids)) . '
                 AND gd.gd_id = gcd.gd_id
             )',
-            array_merge([$version, $gradeable_id, $submitter_id], $component_ids)
+            array_merge([$version, $gradeable_id, $submitter_id, $submitter_id], $component_ids)
         );
     }
 

--- a/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
@@ -52,7 +52,7 @@ describe('Test cases for checking the clear version conflicts button in the TA g
         cy.login('instructor');
 
         cy.log('Button should exist if there is a version conflict');
-        cy.visit(['sample', 'gradeable', 'grading_team_homework', 'grading', 'grade?who_id=fIS8zNJi2DWpWMg&sort=id&direction=ASC']);
+        cy.visit(['sample', 'gradeable', 'grading_team_homework', 'grading', 'grade?who_id=eyaIcqtZ8q9kRLu&sort=id&direction=ASC']);
         cy.get('[data-testid="grading-rubric-btn"]').click();
         cy.get('[data-testid="change-graded-version"]').should('exist');
         cy.get('[data-testid="version-warning"]').should('exist');
@@ -76,7 +76,7 @@ describe('Test cases for checking the clear version conflicts button in the TA g
                 url: buildUrl(['sample', 'gradeable', 'grading_team_homework', 'grading', 'graded_gradeable', 'change_grade_version']),
                 form: true,
                 body: {
-                    anon_id: 'fIS8zNJi2DWpWMg',
+                    anon_id: 'eyaIcqtZ8q9kRLu',
                     graded_version: 3,
                     component_ids: [92, 93, 94, 95],
                     csrf_token: win.csrfToken,

--- a/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
@@ -48,6 +48,47 @@ describe('Test cases for checking the clear version conflicts button in the TA g
         cy.get('[data-testid="version-warning"]').should('exist');
     });
 
+    it('Clear conflict button should work on team gradeables', () => {
+        cy.login('instructor');
+
+        cy.log('Button should exist if there is a version conflict');
+        cy.visit(['sample', 'gradeable', 'grading_team_homework', 'grading', 'grade?who_id=fIS8zNJi2DWpWMg&sort=id&direction=ASC']);
+        cy.get('[data-testid="grading-rubric-btn"]').click();
+        cy.get('[data-testid="change-graded-version"]').should('exist');
+        cy.get('[data-testid="version-warning"]').should('exist');
+
+        cy.log('Clicking the button should resolve the version conflict');
+        cy.get('[data-testid="grading-rubric-btn"]').click();
+
+        // wait until page is fully loaded
+        cy.get('[data-testid="component-list"]').children().should('have.length.least', 1);
+
+        cy.get('[data-testid="version-warning"]').should('exist');
+
+        cy.get('[data-testid="change-graded-version"]').click();
+        cy.get('[data-testid="change-graded-version"]', { timeout: 10000 }).should('not.be.visible');
+
+        cy.get('[data-testid="version-warning"]').should('not.exist');
+
+        // reset state
+        cy.window().then(async (win) => {
+            cy.request({
+                method: 'POST',
+                url: buildUrl(['sample', 'gradeable', 'grading_team_homework', 'grading', 'graded_gradeable', 'change_grade_version']),
+                form: true,
+                body: {
+                    anon_id: 'fIS8zNJi2DWpWMg',
+                    graded_version: 3,
+                    component_ids: [92, 93, 94, 95],
+                    csrf_token: win.csrfToken,
+                },
+            });
+        });
+
+        cy.reload();
+        cy.get('[data-testid="version-warning"]').should('exist');
+    });
+
     it('Clicking "save" on a component with a version conflict should resolve the conflict for that component', () => {
         cy.login('instructor');
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=K8jI3q4qpdCc1jw&sort=id&direction=ASC&gradeable_version=1']);

--- a/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/clearing_version_conflicts.spec.js
@@ -58,7 +58,6 @@ describe('Test cases for checking the clear version conflicts button in the TA g
         cy.get('[data-testid="version-warning"]').should('exist');
 
         cy.log('Clicking the button should resolve the version conflict');
-        cy.get('[data-testid="grading-rubric-btn"]').click();
 
         // wait until page is fully loaded
         cy.get('[data-testid="component-list"]').children().should('have.length.least', 1);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Related to #13040

### What is the New Behavior?
Adds cypress testing for clearing version conflicts on team gradeables.

### What steps should a reviewer take to reproduce or test the bug or new feature?
- run clearing_version_conflicts.spec.js 
- verify it passes

### Automated Testing & Documentation
Testing for previously added feature

### Other information
Not a breaking change
No migrations
Not a security concern
