### PR TITLE
[Bugfix:RainbowGrades] Revert reload on build success

### DIFF
--- a/site/public/js/rainbow-customization.js
+++ b/site/public/js/rainbow-customization.js
@@ -787,7 +787,6 @@ function checkBuildStatus() {
             if (response.status === 'success') {
                 $('#save_status').text('Rainbow grades successfully generated!');
                 showLogButton(response.data);
-                window.location.reload();
             }
             else if (response.status === 'fail') {
                 $('#save_status').text('A failure occurred generating rainbow grades');


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In [PR#13026](https://github.com/Submitty/Submitty/pull/13026), I added a reload on build success to clear the manual generation banner if it was present. This had the side effect of changing the message shown by the output of building rainbow grades, which broke the grades configuration spec. The reload would also clear the log button, so this change is better reverted and I can work on a fix for clearing the banner in another PR.

### What is the New Behavior?
The page will no longer reload on a successful build of rainbow grades.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Checkout the branch and do submitty_install_site
2. Do a manual generation of rainbow grades
3. After the banner appears, click build in the UI
4. The page should no longer reload

### Other information
N/A
