### PR TITLE
[Bugfix:Developer] fix gradeable spec race condition

### DIFF
--- a/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
@@ -23,8 +23,12 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             cy.get('[fname = "file1.txt"]').should('not.exist');
             cy.get('#upload1').selectFile([testfile1, testfile2], { action: 'drag-drop' });
 
+            // Dismiss successful upload message
+            cy.get('.alert-success').should('be.visible');
+            cy.get('.alert-success > a').click();
+            cy.get('.alert-success').should('not.exist');
+
             cy.waitPageChange(() => {
-                cy.get('.alert-success > a').click(); // Dismiss successful upload message
                 cy.get('#submit').click();
             });
 

--- a/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/gradeable.spec.js
@@ -23,12 +23,8 @@ describe('Tests cases revolving around gradeable access and submission', () => {
             cy.get('[fname = "file1.txt"]').should('not.exist');
             cy.get('#upload1').selectFile([testfile1, testfile2], { action: 'drag-drop' });
 
-            // Dismiss successful upload message
-            cy.get('.alert-success').should('be.visible');
-            cy.get('.alert-success > a').click();
-            cy.get('.alert-success').should('not.exist');
-
             cy.waitPageChange(() => {
+                cy.get('.alert-success > a', { timeout: 10000 }).click(); // Dismiss successful upload message
                 cy.get('#submit').click();
             });
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In PR #13039 , I observed that Cypress gradeable.spec.js was flaky and I believe it is down to a race condition with the success banner appearing on the page around the time of a reload. 

### What is the New Behavior?
The spec should now pass consistently. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Observe the spec passes on CI
2. Observe the spec passes locally. 
See PR #13039 for an example of this running without retries.

### Automated Testing & Documentation

### Other information
This is not a breaking change.
