### PR TITLE
[Bugfix:TAGrading] Median/Count Fix

### DIFF
--- a/site/app/templates/grading/electronic/ta_status/GradingHistogram.twig
+++ b/site/app/templates/grading/electronic/ta_status/GradingHistogram.twig
@@ -18,40 +18,44 @@
             id="submit_bucket_{{ type }}"
             name="sub-{{ type }}"
             value="Submit"
-            onclick="createNewBuckets(range{{type}},buckets,xValue,yValue,xBuckets,mode,modeCount,max{{ type }},min{{ type }})"
+            onclick="createNewBuckets(range{{ type }}, buckets{{ type }}, xValue{{ type }}, yValue{{ type }}, xBuckets{{ type }}, mode{{ type }}, modeCount{{ type }}, max{{ type }}, min{{ type }}, median{{ type }})"
         />
     </div>
 
     <div id="Histogram{{ type == 'auto' ? '3' : (type == 'manual' ? '4' : '') }}"><!-- Plotly chart will be drawn inside this DIV --></div>
 
     <script>
-        var buckets = new Map();
+        var median{{ type }} = 0;
+        var buckets{{ type }} = new Map();
+        var mode{{ type }} = 0;
+        var xValue{{ type }} = [];
+        var yValue{{ type }} = [];
+        var xBuckets{{ type }} = [];
         var buttonLayerHeight = 1.0;
         var ct = 0;
         var max{{ type }} = 0;
         var min{{ type }} = {{ overall_total }} + 50;
-        var median = 0;
-        var mode = 0;
-        var modeCount = 0;
+        var modeCount{{ type }} = 0;
 
         var range{{ type }} = 0;
-        var xValue = [];
-        var yValue = [];
-        var xBuckets = [];
 
-        xValue = [{{ histograms[type == 'manual' ? 'tTA' : type == 'auto' ? 'bAuto' : type == 'total' ? 'bTA'] | join(',') }}];
-        xValue.sort((a, b) => a - b);
+        xValue{{ type }} = [{{ histograms[type == 'manual' ? 'tTA' : type == 'auto' ? 'bAuto' : type == 'total' ? 'bTA'] | join(',') }}];
+        xValue{{ type }}.sort((a, b) => a - b);
 
-        if (xValue.length > 0) {
-            min{{ type }} = xValue[0];
-            max{{ type }} = xValue[xValue.length-1];
-            // range = max - min;
-            let pivot = Math.floor((xValue.length - 1) / 2);
-            if (xValue.length % 2 === 0) {
-                median = (xValue[pivot] + xValue[pivot+1]) / 2;
+        if (xValue{{ type }}.length > 0) {
+            min{{ type }} = xValue{{ type }}[0];
+            max{{ type }} = xValue{{ type }}[xValue{{ type }}.length - 1];
+
+            let pivot = Math.floor((xValue{{ type }}.length - 1) / 2);
+
+            if (xValue{{ type }}.length % 2 === 0) {
+                median{{ type }} = (
+                    xValue{{ type }}[pivot]
+                    + xValue{{ type }}[pivot + 1]
+                ) / 2;
             }
             else {
-                median = xValue[pivot];
+                median{{ type }} = xValue{{ type }}[pivot];
             }
         }
 
@@ -60,11 +64,11 @@
         }
 
         if (min{{ type }} != max{{ type }}) {
-            mode = fillBucketsForRange(range{{ type }}, buckets, xValue, yValue, xBuckets, mode, modeCount, max{{ type }}, min{{ type }});
+            mode{{ type }}= fillBucketsForRange(range{{ type }}, buckets{{ type }}, xValue{{ type }}, yValue{{ type }}, xBuckets{{ type }}, mode{{ type }}, modeCount{{ type }}, max{{ type }}, min{{ type }});
         } else {
-            mode = xValue[0];
-            xBuckets = [String(mode)];
-            yValue = [xValue.length];
+            mode{{ type }}= xValue{{ type }}[0];
+            xBuckets{{ type }} = [String(mode{{ type }})];
+            yValue{{ type }} = [xValue{{ type }}.length];
         }
 
         if (max{{ type }}==0 && min{{ type }}==50) {
@@ -72,12 +76,12 @@
         }
 
         var trace1 = {
-            x: xBuckets,
-            y: yValue,
+            x: xBuckets{{ type }},
+            y: yValue{{ type }},
             mode: 'markers',
             name: 'Students with Each Score',
             type: 'bar',
-            text: yValue,
+            text: yValue{{ type }},
             textposition: 'auto',
             hoverinfo: 'none',
             marker: {
@@ -124,8 +128,8 @@
                     : (type == 'auto' ? autograded_average != null ? autograded_average.getAverageScore() | default(0) : 0
                     : (type == 'manual' ? manual_average != null ? manual_average.getAverageScore() | default(0) : 0 ))
                     }} + '</span>' +
-                    '<span><b>Mode: </b>' + mode + '</span>' +
-                    '<span><b>Median: </b>' + median + '</span>' +
+                    '<span><b>Mode: </b>' + mode{{ type }} + '</span>' +
+                    '<span><b>Median: </b>' + median{{ type }} + '</span>' +
                     '<span><b>Minimum: </b>' + min{{ type }} + '</span>' +
                     '<span><b>Maximum: </b>' + max{{ type }} + '</span>' +
                     '<span><b>Range: </b>' + (max{{ type }} - min{{ type }}) + '</span>' +

--- a/site/app/templates/grading/electronic/ta_status/StatusBase.twig
+++ b/site/app/templates/grading/electronic/ta_status/StatusBase.twig
@@ -74,7 +74,7 @@
     }
 
 
-    function createNewBuckets(range,buckets,xValue,yValue,xBuckets,mode,modeCount,max,min) {
+    function createNewBuckets(range,buckets,xValue,yValue,xBuckets,mode,modeCount,max,min,median) {
         var bucketInputTotal = document.getElementById("bucket-size-total");
         var bucketInputAuto = document.getElementById("bucket-size-auto");
         var bucketInputManual = document.getElementById("bucket-size-manual");


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes issue #12975 

### What is the New Behavior?
Prior to this fix, changing the bucket size in the autograding histogram could incorrectly change the displayed median, and in some cases silently drop or miscount students in the rebucketed totals. The median and total student count now stay consistent when the bucket size is changed, while the histogram updates as expected.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Checkout main branch
2. In localhost, open a gradeable with autograding enabled.
3. Navigate to the autograding histogram.
4. Change the bucket size several times (e.g. 1, 2, 4).
4. Observe that the displayed median (sometimes can be flaky and not change) 
5. Repeat the steps in the PR branch but notice how it doesn't change

Main example: 
<img width="810" height="419" alt="image" src="https://github.com/user-attachments/assets/ecfbf73e-eafe-4662-a0d9-081311e6128b" />
<img width="816" height="447" alt="image" src="https://github.com/user-attachments/assets/ba6637cf-fcad-44d3-8c67-591ed86e7597" />

PR example: 
<img width="821" height="375" alt="image" src="https://github.com/user-attachments/assets/e91560e6-af70-48af-99e2-2697bf325c53" />
<img width="812" height="419" alt="image" src="https://github.com/user-attachments/assets/bd8e467c-eb50-4baf-a5b5-600b12afe27c" />


### Automated Testing & Documentation
N/A

### Other information
<!-- Is this a breaking change?  
N/A
