### PR TITLE
[Bugfix:Testing] submission spec now pass in isolation

### DIFF
--- a/site/cypress/e2e/Cypress-Gradeable/submission.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/submission.spec.js
@@ -25,7 +25,7 @@ describe('Test Uploading Files', () => {
     beforeEach(() => {
         const gradeableId = 'open_homework';
         const headingText = 'New submission for: Open Homework';
-        cy.login();
+        cy.login('aphacker');
         cy.visit(['sample', 'gradeable', gradeableId]);
         cy.get('h1').contains(headingText).should('be.visible');
     });


### PR DESCRIPTION
### Why is this Change Important & Necessary?

After we updated the way seeding is done for courses and gradeables in PR #12948 , submission data changed and submission.spec.js was no longer passing if you ran it on a fresh VM in isolation. This was because 'instructor' no longer starts with submissions for the Open Homework gradeable. 

It was however passing CI because other specs that ran before it made submissions for 'instructor' and then the test would work. 

### What is the New Behavior?
submission.spec.js has been updated to test with an arbitrary user that already has a submission for the Open Homework gradeable.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On main, make sure your VM doesn't have any changes to the sample data from prior testing (you may need to destroy and up or recreate_sample_courses).
2. On main, verify that submission.spec.js fails when running it alone.
3. Optional, on main, verify that if you run all the specs in Cypress-Gradeable, submission.spec.js passes. 
4. On the branch, verify that submission.spec.js passes in isolation. 

### Automated Testing & Documentation
This feature is a small update to automated testing and does not need to be documented. 

### Other information
There may be other specs in a similar situation (fail in isolation but pass on CI due to data from prior specs persisting), so it's possible there will be more PRs like this in the future. 
