### PR TITLE
[Bugfix:Testing] Peer Download Own Submission

### DIFF
--- a/site/app/controllers/MiscController.php
+++ b/site/app/controllers/MiscController.php
@@ -440,7 +440,7 @@ class MiscController extends AbstractController {
             $this->core->redirect($this->core->buildCourseUrl());
         }
 
-        $peer = $gradeable->hasPeerComponent() && $this->core->getUser()->getGroup() === User::GROUP_STUDENT;
+        $peer = $gradeable->hasPeerComponent() && $this->core->getUser()->getGroup() === User::GROUP_STUDENT && $origin !== 'submission';
         $blind_grading = ($peer && $gradeable->getPeerBlind() !== Gradeable::UNBLIND_GRADING) || ($gradeable->getLimitedAccessBlind() === Gradeable::SINGLE_BLIND_GRADING && $this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER);
         if ($blind_grading || $is_anon === "true") {
             $submitter_id = $this->core->getQueries()->getSubmitterIdFromAnonId($anon_id, $gradeable_id);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #13079 

### What is the New Behavior?
Student was being considered a peer on their own submission since they are a student and the gradeable has a peer component. The peer determining condition now takes into account if the submission was made by the currently logged in student. Student can now Download All on their own submission.

### What steps should a reviewer take to reproduce or test the bug or new feature?
- Log in as a student and access Released Peer PDF Homework if there is a currently active submission (if there isn't, log in as a diff student until you find one who does)
- Attempt to "Download all files" and verify the zip is actually downloaded


### Automated Testing & Documentation
No automated testing added

### Other information
Not a breaking change
No migrations
Not a security concern
