### PR TITLE
[Bugfix:TAGrading] uas json accessible w/ cancelled

### DIFF
--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -496,7 +496,7 @@ class Access {
             }
 
             if ($grading_checks && self::checkBits($checks, self::CHECK_HAS_SUBMISSION)) {
-                if ($graded_gradeable !== null && $graded_gradeable->getAutoGradedGradeable()->getActiveVersion() <= 0) {
+                if ($graded_gradeable !== null && $graded_gradeable->getAutoGradedGradeable()->getHighestVersion() <= 0) {
                     $grading_checks = false;
                 }
             }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
When an instructor goes to grade a student with a cancelled submission, they should be able to see the `user_assignment_settings.json`, which contains useful information about their submission history. However, when attempting to open the file, you would receive an access denied error. 

### What is the New Behavior?
Now, an instructor will be able to see a student's `user_assignment_settings.json` even if they have a cancelled submission.

Before (on a cancelled submission):
<img width="1640" height="593" alt="image" src="https://github.com/user-attachments/assets/228ec910-762d-4cf0-8775-0639bb447eae" />

After (on a cancelled submission):
<img width="1640" height="593" alt="image" src="https://github.com/user-attachments/assets/052fe58b-c091-46c3-98ee-69d444f2120e" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On main, verify that for students with cancelled submissions you cannot view their `user_assignment_settings.json`
2. checkout the branch and run `submitty_install_site`
3. Verify that when grading students with cancelled submissions you can view the `user_assignment_settings.json`
4. Verify that behavior for grading students with regular / no submission the behavior has not changed. 

### Automated Testing & Documentation
This feature is NOT sufficiently documented with e2e testing. In a future PR, after better error messages have been implemented, we will add testing to the files panel page concerning `user_assignment_settings.json`

### Other information
This is not a breaking change.
