### PR TITLE
[Feature:System] nlohmann version pinning

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -206,12 +206,18 @@ echo -e "\nBeginning installation of Submitty\n"
 
 nlohmann_dir="${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/vendor/nlohmann/json"
 
-# If we don't already have a copy of this repository, check it out
-if [ ! -d "${nlohmann_dir}" ]; then
-    git clone --depth 1 "https://github.com/nlohmann/json.git" "${nlohmann_dir}"
+# Fetch a pinned release of the nlohmann C++ JSON library.
+# Re-fetch only when the pinned version (.setup/bin/versions.sh) changes.
+mkdir -p "${nlohmann_dir}"
+pushd "${nlohmann_dir}" > /dev/null
+if [[ ! -f VERSION || $(< VERSION) != "${nlohmann_json_Version}" ]]; then
+    rm -rf include single_include
+    wget -nv "https://github.com/nlohmann/json/releases/download/${nlohmann_json_Version}/include.zip" -O nlohmann_json.zip
+    unzip -o -q nlohmann_json.zip "include/*"
+    rm -f nlohmann_json.zip
+    echo "${nlohmann_json_Version}" > VERSION
 fi
-
-# TODO: We aren't checking / enforcing a specific/minimum version of this library...
+popd > /dev/null
 
 # Add read & traverse permissions for RainbowGrades and vendor repos
 find "${SUBMITTY_INSTALL_DIR}/GIT_CHECKOUT/vendor" -type d -exec chmod o+rx {} \;

--- a/.setup/bin/versions.sh
+++ b/.setup/bin/versions.sh
@@ -13,3 +13,6 @@ export Tutorial_Version=v26.07.00
 export SubmittyCLI_Version=v26.07.01
 export SysadminTools_Version=v25.01.00
 export Localization_Version=v23.08.02
+
+# THIRD PARTY LIBRARIES
+export nlohmann_json_Version=v3.12.0


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This PR implements version pinning for the nlohmann-json dependency which previously was unpinned. 

### What is the New Behavior?
nlohmann-json has been added to a new third party library section in versions.sh. A wget has been added with a version sentinel to ensure that the version stays consistent. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Before running submitty_install:
- run `cat /usr/local/submitty/GIT_CHECKOUT/vendor/nlohmann/json/VERSION` to ensure that the version is not yet stored, the file doesn't yet exist
- check the current version with
```
grep -rh "define NLOHMANN_JSON_VERSION" /usr/local/submitty/vendor/include/nlohmann/ | grep -E "MAJOR|MINOR|PATCH"
```
2. Run submitty_install
3. Check the current version:
- run `cat /usr/local/submitty/GIT_CHECKOUT/vendor/nlohmann/json/VERSION`
- you should see now that the version is 3.12.0, and that this new version file exists
- run `grep -rh "define NLOHMANN_JSON_VERSION" /usr/local/submitty/vendor/include/nlohmann/ | grep -E "MAJOR|MINOR|PATCH"` to verify the version actually changed
4. Change the nlohmann-json version in versions.sh to 3.11.0
5. Run submitty_install
6. Check the current version:
- run `cat /usr/local/submitty/GIT_CHECKOUT/vendor/nlohmann/json/VERSION`
- should now be 3.11.0
7. Change the version back to 3.12.0 and reinstall to do a general functionality test (autograding, submission, etc)
8. Finally, test in conjunction with [PR#94](https://github.com/Submitty/RainbowGrades/pull/94) to make sure that there is no interference between the files

### Automated Testing & Documentation
N/A

### Other information
This is not a breaking change
This are no migrations included
Not a security concern