### PR TITLE
[Bugfix:InstructorUI] Save Grader Sections 

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -1094,6 +1094,7 @@ WHERE term=? AND course=? AND user_id=?",
                 "UPDATE users SET rotating_section=?, registration_subsection=?{$date_registered_sql} WHERE user_id=?",
                 $params
             );
+            $this->updateGradingRegistration($user->getId(), $user->getGroup(), $user->getGradingRegistrationSections());
         }
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes #13090

Editing a grader's assigned registration sections through the Edit Grader modal on the Manage Graders page silently failed to save. The controller correctly parsed the submitted sections and set them on the User object, but `DatabaseQueries::updateUser()` never persisted them — the existing `updateGradingRegistration()` method was defined but never called, so the `grading_registration` table was never updated on edit. 

### What is the New Behavior?
`updateUser()` now calls `updateGradingRegistration()` with the grader's ID, group, and updated sections, so changes made in the Edit Grader modal are correctly saved to the database and reflected on the Manage Graders page.

### What steps should a reviewer take to reproduce or test?
1. Sign in as instructor, go to the sample course.
2. Go to Manage Graders, click the Edit Grader (pencil) icon on any Full Access Grader or Limited Access Grader.
3. Check/uncheck sections under "Assigned Registration Sections for Grading" and click Submit.
4. Confirm the "Registration Sections" column updates immediately, and that reopening the Edit Grader modal shows the new selections persisted.

### Automated Testing & Documentation
No automated tests added. Manually verified via the Vagrant dev environment: confirmed sections update correctly on submit and persist across page reload and modal reopen.

### Other information
None.


https://github.com/user-attachments/assets/1edd45bb-6fdb-47ba-b198-f2da803ce41f



