### PR TITLE
[Feature:InstructorUI] Checkpoint column sizing

### DIFF
--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -125,7 +125,6 @@
                     {% endfor %}
                 </colgroup>
             {% endif %}
-            <caption />
             {# Table header #}
             <thead>
                 <tr>

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -105,26 +105,14 @@
 
     <div class="scrollable-table">
         {# This is a data table #}
+        {% set lab_component_count = action == 'lab' and gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1 %}
         <table
             id="data-table"
             data-current-grader="{{ user_id }}"
             class="table table-striped table-bordered persist-area {{ action == 'lab' ? 'lab-dynamic-columns' : '' }}"
-            style="table-layout: fixed;"
+            style="table-layout: fixed;{{ action == 'lab' ? ' --lab-checkpoint-cols: ' ~ lab_component_count ~ ';' : '' }}"
         >
             <caption />
-            {% if action == 'lab' %}
-                {% set lab_component_count = gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1 %}
-                <colgroup>
-                    <col style="width: 5%;">
-                    <col style="width: 10%;">
-                    <col style="width: 12%;">
-                    <col style="width: 11%;">
-                    <col style="width: 12%;">
-                    {% for component in gradeable.getComponents() %}
-                        <col style="width: calc(50% / {{ lab_component_count }});">
-                    {% endfor %}
-                </colgroup>
-            {% endif %}
             {# Table header #}
             <thead>
                 <tr>

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -105,7 +105,12 @@
 
     <div class="scrollable-table">
         {# This is a data table #}
-        <table id="data-table" data-current-grader="{{ user_id }}" class="table table-striped table-bordered persist-area" style="table-layout: fixed;">
+        <table
+            id="data-table"
+            data-current-grader="{{ user_id }}"
+            class="table table-striped table-bordered persist-area {{ action == 'lab' ? 'lab-dynamic-columns' : '' }}"
+            style="table-layout: fixed; {{ action == 'lab' ? '--lab-component-count: ' ~ (gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1) ~ ';' : '' }}"
+        >
             <caption />
             {# Table header #}
             <thead>
@@ -119,7 +124,7 @@
                     {% if action == 'lab' %}
                         {% set colspan = 5 + gradeable.getComponents()|length %}
                         {% for component in gradeable.getComponents() %}
-                            <th style="{{ component.isText() ? 'width: 200px;' : 'width: 125px;' }}" scope="col">
+                            <th scope="col">
                                 {{ component.getTitle() }}
                             </th>
                         {% endfor %}
@@ -161,15 +166,19 @@
                                     Students Assigned to Rotating Section {{ section_id | default('NULL') }}
                                 {% endif %}
                             </td>
-                            <td colspan="{{ colspan - 6 }}" style="text-align: center; background-color: var(--alert-border-blue)">
-                            </td>
+                            {% if colspan > 6 %}
+                                <td colspan="{{ colspan - 6 }}" style="text-align: center; background-color: var(--alert-border-blue)">
+                                </td>
+                            {% endif %}
                         </tr>
                         <tr class="info">
                             <td colspan="6" style="text-align: left; z-index: 1; background-color: var(--alert-border-blue)">
                                 Graders: {{ section.grader_names|length ? section.grader_names|join(", ") : "Nobody" }}
                             </td>
-                            <td colspan="{{ colspan - 6 }}" style="text-align: center; background-color: var(--alert-border-blue)">
-                            </td>
+                            {% if colspan > 6 %}
+                                <td colspan="{{ colspan - 6 }}" style="text-align: center; background-color: var(--alert-border-blue)">
+                                </td>
+                            {% endif %}
                         </tr>
                     </tbody>
                     {# /Section header #}

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -111,6 +111,7 @@
             class="table table-striped table-bordered persist-area {{ action == 'lab' ? 'lab-dynamic-columns' : '' }}"
             style="table-layout: fixed;"
         >
+            <caption />
             {% if action == 'lab' %}
                 {% set lab_component_count = gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1 %}
                 <colgroup>

--- a/site/app/templates/grading/simple/Display.twig
+++ b/site/app/templates/grading/simple/Display.twig
@@ -109,8 +109,21 @@
             id="data-table"
             data-current-grader="{{ user_id }}"
             class="table table-striped table-bordered persist-area {{ action == 'lab' ? 'lab-dynamic-columns' : '' }}"
-            style="table-layout: fixed; {{ action == 'lab' ? '--lab-component-count: ' ~ (gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1) ~ ';' : '' }}"
+            style="table-layout: fixed;"
         >
+            {% if action == 'lab' %}
+                {% set lab_component_count = gradeable.getComponents()|length > 0 ? gradeable.getComponents()|length : 1 %}
+                <colgroup>
+                    <col style="width: 5%;">
+                    <col style="width: 10%;">
+                    <col style="width: 12%;">
+                    <col style="width: 11%;">
+                    <col style="width: 12%;">
+                    {% for component in gradeable.getComponents() %}
+                        <col style="width: calc(50% / {{ lab_component_count }});">
+                    {% endfor %}
+                </colgroup>
+            {% endif %}
             <caption />
             {# Table header #}
             <thead>

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -98,8 +98,8 @@ input[type="number"]::-webkit-outer-spin-button {
     width: 100%;
 }
 
-#data-table.lab-dynamic-columns tr > th:nth-of-type(n+6),
-#data-table.lab-dynamic-columns tr > td:nth-of-type(n+6) {
+#data-table.lab-dynamic-columns tr > th:nth-of-type(n + 6),
+#data-table.lab-dynamic-columns tr > td:nth-of-type(n + 6) {
     width: calc((100% - 410px) / var(--lab-component-count));
 }
 

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -98,11 +98,6 @@ input[type="number"]::-webkit-outer-spin-button {
     width: 100%;
 }
 
-#data-table.lab-dynamic-columns tr > th:nth-of-type(n + 6),
-#data-table.lab-dynamic-columns tr > td:nth-of-type(n + 6) {
-    width: calc((100% - 410px) / var(--lab-component-count));
-}
-
 /* Key Styles */
 
 .simple-key-full-credit,

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -89,6 +89,20 @@ input[type="number"]::-webkit-outer-spin-button {
     overflow-x: auto;
 }
 
+#data-table {
+    width: max-content;
+    min-width: 100%;
+}
+
+#data-table.lab-dynamic-columns {
+    width: 100%;
+}
+
+#data-table.lab-dynamic-columns tr > th:nth-of-type(n+6),
+#data-table.lab-dynamic-columns tr > td:nth-of-type(n+6) {
+    width: calc((100% - 410px) / var(--lab-component-count));
+}
+
 /* Key Styles */
 
 .simple-key-full-credit,

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -90,12 +90,11 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 #data-table {
-    width: max-content;
-    min-width: 100%;
+    --fixed-cols-width: 410px;
 }
 
 #data-table.lab-dynamic-columns {
-    width: 100%;
+    min-width: max(100%, calc(var(--fixed-cols-width) + var(--lab-checkpoint-cols, 1) * 125px));
 }
 
 /* Key Styles */

--- a/site/public/css/simple-grading.css
+++ b/site/public/css/simple-grading.css
@@ -94,7 +94,10 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 #data-table.lab-dynamic-columns {
-    min-width: max(100%, calc(var(--fixed-cols-width) + var(--lab-checkpoint-cols, 1) * 125px));
+    min-width: max(
+        100%,
+        calc(var(--fixed-cols-width) + var(--lab-checkpoint-cols, 1) * 125px)
+    );
 }
 
 /* Key Styles */


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Related to #13030
This PR solves 1st of the 4 sub-issues #13030 mentions - _Let the columns expand to fit the table, as currently labs with few checkpoints look squished on the left side of the table, leaving lots of empty space on the page._

I was only to reproduce this checkpoint squished behaviour when the gradeable had only 1 checkpoint.

### What is the New Behavior?
New : 
- The first five columns have fixed proportions
- Each checkpoint column gets an equal share of the remaining space

https://github.com/user-attachments/assets/bbcce43d-6323-40e0-9dcc-f9e5acea2db5


https://github.com/user-attachments/assets/b3e38824-0d4e-4b58-8087-7f7ffcbaf99a


### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Login as Instructor
2. Open or Create any LAB gradeable
3. Make sure to keep checkpoints = 1 and see the column width issue is gone


### Automated Testing & Documentation
No test added or needed.

### Other information
1. Not a breaking change
2. No migrations needed
