### PR TITLE
[Feature:TAGrading] Cluster grading

### DIFF
--- a/sbin/grading_clustering/algorithms/dummy_split.py
+++ b/sbin/grading_clustering/algorithms/dummy_split.py
@@ -17,8 +17,8 @@ class DummySplit(ClusteringAlgorithm):
         for submitter in submitters:
             # submitter is a dict with 'user_id' and 'team_id'
             identifier = submitter.get('user_id') or submitter.get('team_id') or ''
-            
-            # find the first alphabetic character to ignore leading numbers or symbols
+
+            # Find the first alphabetic character to ignore leading numbers or symbols
             first_letter = ''
             for char in identifier:
                 if char.isalpha():

--- a/sbin/grading_clustering/algorithms/dummy_split.py
+++ b/sbin/grading_clustering/algorithms/dummy_split.py
@@ -17,9 +17,15 @@ class DummySplit(ClusteringAlgorithm):
         for submitter in submitters:
             # submitter is a dict with 'user_id' and 'team_id'
             identifier = submitter.get('user_id') or submitter.get('team_id') or ''
-            first_char = identifier[0].upper() if identifier else ''
+            
+            # find the first alphabetic character to ignore leading numbers or symbols
+            first_letter = ''
+            for char in identifier:
+                if char.isalpha():
+                    first_letter = char.upper()
+                    break
 
-            if 'A' <= first_char <= 'M':
+            if 'A' <= first_letter <= 'M' and first_letter != '':
                 cluster_a.append(submitter)
             else:
                 cluster_b.append(submitter)

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2143,7 +2143,7 @@ class ElectronicGraderController extends AbstractController {
 
         $is_unclustered = true; // default to true, meaning they won't trigger cluster cascade unless proven otherwise
         if ($ta_grading_cluster_mode) {
-            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $who_id);
+            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $graded_gradeable->getSubmitter()->getId());
             if ($cluster !== null && strtolower($cluster->getClusterName() ?? '') !== 'unclustered') {
                 $is_unclustered = false;
             }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2158,15 +2158,15 @@ class ElectronicGraderController extends AbstractController {
                 $valid_members = $cluster->getValidMembers($active_versions);
                 $cluster_student_count = count($valid_members);
 
+                // Check if the current student is a valid member or not - means that the current version of 
+                // the student is same or not the time the clusters were created
+                //But if it is not same that means we should consider it "Unclustered", furthermore we should not appply cluster-grading feature to this
                 foreach ($valid_members as $member) {
                     if ($member->getSubmitterId() === $submitter_id) {
                         $is_clustered = true;
+                        $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
                         break;
                     }
-                }
-
-                if ($is_clustered) {
-                    $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
                 }
             }
         }
@@ -2569,22 +2569,24 @@ class ElectronicGraderController extends AbstractController {
                     $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
 
                     $valid_members = $cluster->getValidMembers($active_versions);
-                    $is_current_valid = false; //this tells us that if this student is valid itself or not (i.e. whether student should belong in Unclustered mode)
+                    $is_valid_cluster_member = false; //this tells us that if this student is valid itself or not (i.e. whether student should belong in Unclustered mode)
                     //checking among all valid_members if anyone of them is this student
                     foreach ($valid_members as $member) {
                         if ($member->getSubmitterId() === $submitter_id) {
-                            $is_current_valid = true;
+                            $is_valid_cluster_member = true;
+                            break;
                         }
                     }
                     // if this student is valid then other students in its cluster can also be graded simultaneously
                     //but if not then this student should be graded as 'Unclustered'
-                    if ($is_current_valid) {
+                    if ($is_valid_cluster_member) {
                         foreach ($valid_members as $member) {
                             $submitters_to_grade[] = $member->getSubmitterId();
                         }
                     }
                 }
                 //if the student is "Unclustered" that means he just needs to be graded individually, so we add to the submitters_to_grade array
+                //this happens when either cluster is Null or this student is not a valid member
                 if (count($submitters_to_grade) === 0) {
                     $submitters_to_grade[] = $submitter_id;
                 }
@@ -2594,6 +2596,7 @@ class ElectronicGraderController extends AbstractController {
                 foreach ($submitters_to_grade as $s_id) {
                     $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
                     if ($gg === false) {
+                        Logger::error("Cluster Grading: Could not find graded gradeable for submitter {$s_id} in gradeable {$gradeable_id}");
                         continue;
                     }
 
@@ -2602,7 +2605,9 @@ class ElectronicGraderController extends AbstractController {
                         continue;
                     }
 
-                    // use each member's own active version to avoid version conflicts
+                    //the fallback component_version will be used/triggered only for the current student the TA is on, two cases this might happen-
+                    // 1) current Student is not in a cluster at all, when $cluster=== null
+                    //2) the current student was in a cluster, but deleted all of their submissions
                     $member_version = $active_versions[$s_id] ?? $component_version;
 
                     $ta_gg = $gg->getOrCreateTaGradedGradeable();

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2137,7 +2137,30 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading);
+        $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
+        $clusters_exist = false;
+        if ($clustering_enabled) {
+            $clusters_exist = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        }
+        $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
+
+        $is_unclustered = true; // default to true
+        if ($ta_grading_cluster_mode) {
+            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $graded_gradeable->getSubmitter()->getId());
+            if ($cluster !== null) {
+                $submitter_id = $graded_gradeable->getSubmitter()->getId();
+                $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, [$submitter_id]);
+                $valid_members = $cluster->getValidMembers($active_versions);
+
+                foreach ($valid_members as $member) {
+                    if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
+                        $is_unclustered = false;
+                        break;
+                    }
+                }
+            }
+        }
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');
@@ -2504,8 +2527,17 @@ class ElectronicGraderController extends AbstractController {
                 return;
             }
         }
+        $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
+        $ta_grading_cluster_mode = false;
+        if ($clustering_enabled && ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true') {
+            $ta_grading_cluster_mode = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        }
+
         // Check if the user can silently edit assigned marks
-        if (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
+        if ($ta_grading_cluster_mode) {
+            $silent_edit = false;
+        }
+        elseif (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
             $silent_edit = false;
         }
 
@@ -2521,19 +2553,80 @@ class ElectronicGraderController extends AbstractController {
         Logger::logTAGrading($logger_params);
 
         try {
-            $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
-            $graded_component = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
+            if (!$ta_grading_cluster_mode) {
+                $ta_gg = $graded_gradeable->getOrCreateTaGradedGradeable();
+                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
 
-            $this->saveGradedComponent(
-                $ta_graded_gradeable,
-                $graded_component,
-                $grader,
-                $custom_points,
-                $custom_message,
-                $marks,
-                $component_version,
-                !$silent_edit
-            );
+                $this->saveGradedComponent(
+                    $ta_gg,
+                    $gc,
+                    $grader,
+                    $custom_points,
+                    $custom_message,
+                    $marks,
+                    $component_version,
+                    !$silent_edit
+                );
+            }
+            else {
+                $submitters_to_grade = [];
+                $active_versions = [];
+                $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $submitter_id);
+                if ($cluster !== null) {
+                    $member_ids = [];
+                    foreach ($cluster->getMembers() as $member) {
+                        $member_ids[] = $member->getUserId() ?? $member->getTeamId();
+                    }
+                    $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
+
+                    $valid_members = $cluster->getValidMembers($active_versions);
+                    $is_current_valid = false; //this tells us that if this student is valid itself or not (i.e. whether student should belong in Unclustered mode)
+                    //checking among all valid_members if anyone of them is this student
+                    foreach ($valid_members as $member) {
+                        if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
+                            $is_current_valid = true;
+                        }
+                    }
+                    // if this student is valid then other students in its cluster can also be graded simultaneously
+                    //but if not then this student should be graded as 'Unclustered'
+                    if ($is_current_valid) {
+                        foreach ($valid_members as $member) {
+                            $submitters_to_grade[] = $member->getUserId() ?? $member->getTeamId();
+                        }
+                    }
+                }
+                //if the student is "Unclustered" that means he just needs to be graded individually, so we add to the submitters_to_grade array
+                if (count($submitters_to_grade) === 0) {
+                    $submitters_to_grade[] = $submitter_id;
+                }
+                //running a for-loop to assign marks to all members in submitters_to_grade
+                foreach ($submitters_to_grade as $s_id) {
+                    $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
+                    if ($gg === false) {
+                        continue;
+                    }
+
+                    // We have skipped permission check for current submitter as it was already checked at the top of the function
+                    if ($s_id !== $submitter_id && !$this->core->getAccess()->canI("grading.electronic.save_graded_component", ["gradeable" => $gradeable, "graded_gradeable" => $gg, "component" => $component])) {
+                        continue;
+                    }
+
+                    $ta_gg = $gg->getOrCreateTaGradedGradeable();
+                    $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
+
+                    $this->saveGradedComponent(
+                        $ta_gg,
+                        $gc,
+                        $grader,
+                        $custom_points,
+                        $custom_message,
+                        $marks,
+                        $component_version,
+                        !$silent_edit
+                    );
+                }
+            }
+
             $this->core->getOutput()->renderJsonSuccess();
         }
         catch (\InvalidArgumentException $e) {

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2158,7 +2158,7 @@ class ElectronicGraderController extends AbstractController {
                 $valid_members = $cluster->getValidMembers($active_versions);
                 $cluster_student_count = count($valid_members);
 
-                // Check if the current student is a valid member or not - means that the current version of 
+                // Check if the current student is a valid member or not - means that the current version of
                 // the student is same or not the time the clusters were created
                 //But if it is not same that means we should consider it "Unclustered", furthermore we should not appply cluster-grading feature to this
                 foreach ($valid_members as $member) {

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2134,7 +2134,21 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('grade-inquiry.js');
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading);
+        $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
+        $clusters_exist = false;
+        if ($clustering_enabled) {
+            $clusters_exist = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        }
+        $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
+
+        $is_unclustered = true; // default to true, meaning they won't trigger cluster cascade unless proven otherwise
+        if ($ta_grading_cluster_mode) {
+            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $who_id);
+            if ($cluster !== null && strtolower($cluster->getClusterName() ?? '') !== 'unclustered') {
+                $is_unclustered = false;
+            }
+        }
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');
@@ -2501,8 +2515,17 @@ class ElectronicGraderController extends AbstractController {
                 return;
             }
         }
+        $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
+        $clusters_exist = false;
+        if ($clustering_enabled) {
+            $clusters_exist = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        }
+        $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
+
         // Check if the user can silently edit assigned marks
-        if (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
+        if ($ta_grading_cluster_mode) {
+            $silent_edit = false;
+        } elseif (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
             $silent_edit = false;
         }
 
@@ -2518,19 +2541,50 @@ class ElectronicGraderController extends AbstractController {
         Logger::logTAGrading($logger_params);
 
         try {
-            $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
-            $graded_component = $ta_graded_gradeable->getOrCreateGradedComponent($component, $grader, true);
+            $submitters_to_grade = [];
+            if ($ta_grading_cluster_mode) {
+                $active_versions = [];
+                foreach ($this->core->getQueries()->getActiveSubmittersForGradeable($gradeable_id) as $s) {
+                    $id = $s['user_id'] ?? $s['team_id'];
+                    $active_versions[$id] = (int) $s['active_version'];
+                }
 
-            $this->saveGradedComponent(
-                $ta_graded_gradeable,
-                $graded_component,
-                $grader,
-                $custom_points,
-                $custom_message,
-                $marks,
-                $component_version,
-                !$silent_edit
-            );
+                $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $submitter_id);
+                if ($cluster !== null) {
+                    foreach ($cluster->getValidMembers($active_versions) as $member) {
+                        $submitters_to_grade[] = $member->getUserId() ?? $member->getTeamId();
+                    }
+                }
+            }
+            if (count($submitters_to_grade) === 0) {
+                $submitters_to_grade[] = $submitter_id;
+            }
+
+            foreach ($submitters_to_grade as $s_id) {
+                $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
+                if ($gg === false) {
+                    continue;
+                }
+
+                // Skip permission check for current submitter as it was already checked at the top of the function
+                if ($s_id !== $submitter_id && !$this->core->getAccess()->canI("grading.electronic.save_graded_component", ["gradeable" => $gradeable, "graded_gradeable" => $gg, "component" => $component])) {
+                    continue;
+                }
+
+                $ta_gg = $gg->getOrCreateTaGradedGradeable();
+                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
+
+                $this->saveGradedComponent(
+                    $ta_gg,
+                    $gc,
+                    $grader,
+                    $custom_points,
+                    $custom_message,
+                    $marks,
+                    $component_version,
+                    !$silent_edit
+                );
+            }
             $this->core->getOutput()->renderJsonSuccess();
         }
         catch (\InvalidArgumentException $e) {

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2151,12 +2151,12 @@ class ElectronicGraderController extends AbstractController {
             $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $graded_gradeable->getSubmitter()->getId());
             if ($cluster !== null) {
                 $submitter_id = $graded_gradeable->getSubmitter()->getId();
-                
+
                 $member_ids = [];
                 foreach ($cluster->getMembers() as $member) {
                     $member_ids[] = $member->getUserId() ?? $member->getTeamId();
                 }
-                
+
                 $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
                 $valid_members = $cluster->getValidMembers($active_versions);
                 $cluster_student_count = count($valid_members);

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2141,11 +2141,20 @@ class ElectronicGraderController extends AbstractController {
         }
         $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
 
-        $is_unclustered = true; // default to true, meaning they won't trigger cluster cascade unless proven otherwise
+        $is_unclustered = true; // default to true
         if ($ta_grading_cluster_mode) {
             $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $graded_gradeable->getSubmitter()->getId());
-            if ($cluster !== null && strtolower($cluster->getClusterName() ?? '') !== 'unclustered') {
-                $is_unclustered = false;
+            if ($cluster !== null) {
+                $submitter_id = $graded_gradeable->getSubmitter()->getId();
+                $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, [$submitter_id]);
+                $valid_members = $cluster->getValidMembers($active_versions);
+                
+                foreach ($valid_members as $member) {
+                    if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
+                        $is_unclustered = false;
+                        break;
+                    }
+                }
             }
         }
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
@@ -2541,50 +2550,92 @@ class ElectronicGraderController extends AbstractController {
         Logger::logTAGrading($logger_params);
 
         try {
-            $submitters_to_grade = [];
-            if ($ta_grading_cluster_mode) {
-                $active_versions = [];
-                foreach ($this->core->getQueries()->getActiveSubmittersForGradeable($gradeable_id) as $s) {
-                    $id = $s['user_id'] ?? $s['team_id'];
-                    $active_versions[$id] = (int) $s['active_version'];
-                }
+            if (!$ta_grading_cluster_mode) {
+                $gg = $this->tryGetGradedGradeable($gradeable, $submitter_id);
+                if ($gg !== false) {
+                    $ta_gg = $gg->getOrCreateTaGradedGradeable();
+                    $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
 
+                    $this->saveGradedComponent(
+                        $ta_gg,
+                        $gc,
+                        $grader,
+                        $custom_points,
+                        $custom_message,
+                        $marks,
+                        $component_version,
+                        !$silent_edit,
+                        true //execute database query immediately
+                    );
+                }
+            } else {
+                $submitters_to_grade = [];
+                $active_versions = [];
                 $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $submitter_id);
                 if ($cluster !== null) {
-                    foreach ($cluster->getValidMembers($active_versions) as $member) {
-                        $submitters_to_grade[] = $member->getUserId() ?? $member->getTeamId();
+                    $member_ids = [];
+                    foreach ($cluster->getMembers() as $member) {
+                        $member_ids[] = $member->getUserId() ?? $member->getTeamId();
+                    }
+                    $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
+
+                    $valid_members = $cluster->getValidMembers($active_versions);
+                    $is_current_valid = false; //this tells us that if this student is valid itself or not (i.e. whether student should belong in Unclustered mode)
+                    foreach ($valid_members as $member) {
+                        if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
+                            $is_current_valid = true;
+                        }
+                    }
+                    // if this student is valid then other students in its cluster can also be graded simultaneously
+                    if ($is_current_valid) {
+                        foreach ($valid_members as $member) {
+                            $submitters_to_grade[] = $member->getUserId() ?? $member->getTeamId();
+                        }
+                    }
+                }
+                //if the student is "Unclustered" that means he just needs to be graded individually
+                if (count($submitters_to_grade) === 0) {
+                    $submitters_to_grade[] = $submitter_id;
+                }
+                $ta_graded_gradeables_to_save = [];
+
+                foreach ($submitters_to_grade as $s_id) {
+                    $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
+                    if ($gg === false) {
+                        continue;
+                    }
+
+                    // We have skipped permission check for current submitter as it was already checked at the top of the function
+                    if ($s_id !== $submitter_id && !$this->core->getAccess()->canI("grading.electronic.save_graded_component", ["gradeable" => $gradeable, "graded_gradeable" => $gg, "component" => $component])) {
+                        continue;
+                    }
+
+                    $ta_gg = $gg->getOrCreateTaGradedGradeable();
+                    $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
+
+                    $this->saveGradedComponent(
+                        $ta_gg,
+                        $gc,
+                        $grader,
+                        $custom_points,
+                        $custom_message,
+                        $marks,
+                        $component_version,
+                        !$silent_edit,
+                        false //do not save to database yet
+                    );
+                    $ta_graded_gradeables_to_save[] = $ta_gg;
+                }
+                
+                $this->core->getQueries()->bulkSaveTaGradedGradeables($ta_graded_gradeables_to_save);
+                foreach ($ta_graded_gradeables_to_save as $ta_gg) {
+                    $submitter = $ta_gg->getGradedGradeable()->getSubmitter();
+                    if ($submitter->isTeam()) {
+                        $this->core->getQueries()->clearTeamViewedTime($submitter->getId());
                     }
                 }
             }
-            if (count($submitters_to_grade) === 0) {
-                $submitters_to_grade[] = $submitter_id;
-            }
-
-            foreach ($submitters_to_grade as $s_id) {
-                $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
-                if ($gg === false) {
-                    continue;
-                }
-
-                // Skip permission check for current submitter as it was already checked at the top of the function
-                if ($s_id !== $submitter_id && !$this->core->getAccess()->canI("grading.electronic.save_graded_component", ["gradeable" => $gradeable, "graded_gradeable" => $gg, "component" => $component])) {
-                    continue;
-                }
-
-                $ta_gg = $gg->getOrCreateTaGradedGradeable();
-                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
-
-                $this->saveGradedComponent(
-                    $ta_gg,
-                    $gc,
-                    $grader,
-                    $custom_points,
-                    $custom_message,
-                    $marks,
-                    $component_version,
-                    !$silent_edit
-                );
-            }
+            
             $this->core->getOutput()->renderJsonSuccess();
         }
         catch (\InvalidArgumentException $e) {
@@ -2696,7 +2747,7 @@ class ElectronicGraderController extends AbstractController {
         return $this->changeComponentGraders($gradeable_id, $_POST['anon_id'] ?? '', $_POST['component_id'] ?? '', GradingAction::CLOSE_COMPONENT);
     }
 
-    public function saveGradedComponent(TaGradedGradeable $ta_graded_gradeable, GradedComponent $graded_component, User $grader, float $custom_points, string $custom_message, array $mark_ids, int $component_version, bool $overwrite) {
+    public function saveGradedComponent(TaGradedGradeable $ta_graded_gradeable, GradedComponent $graded_component, User $grader, float $custom_points, string $custom_message, array $mark_ids, int $component_version, bool $overwrite, bool $save_to_db = true) {
         // Only update the grader if we're set to overwrite it
         if ($overwrite) {
             $graded_component->setGrader($grader);
@@ -2733,11 +2784,13 @@ class ElectronicGraderController extends AbstractController {
         // Reset the user viewed date since we updated the grade
         $ta_graded_gradeable->resetUserViewedDate();
 
-        // Finally, save the changes to the database
-        $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
-        $submitter = $ta_graded_gradeable->getGradedGradeable()->getSubmitter();
-        if ($submitter->isTeam()) {
-            $this->core->getQueries()->clearTeamViewedTime($submitter->getId());
+        if ($save_to_db) {
+            // Finally, save the changes to the database
+            $this->core->getQueries()->saveTaGradedGradeable($ta_graded_gradeable);
+            $submitter = $ta_graded_gradeable->getGradedGradeable()->getSubmitter();
+            if ($submitter->isTeam()) {
+                $this->core->getQueries()->clearTeamViewedTime($submitter->getId());
+            }
         }
     }
 

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2151,7 +2151,7 @@ class ElectronicGraderController extends AbstractController {
                 $submitter_id = $graded_gradeable->getSubmitter()->getId();
                 $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, [$submitter_id]);
                 $valid_members = $cluster->getValidMembers($active_versions);
-                
+
                 foreach ($valid_members as $member) {
                     if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
                         $is_unclustered = false;
@@ -2554,24 +2554,22 @@ class ElectronicGraderController extends AbstractController {
 
         try {
             if (!$ta_grading_cluster_mode) {
-                $gg = $this->tryGetGradedGradeable($gradeable, $submitter_id);
-                if ($gg !== false) {
-                    $ta_gg = $gg->getOrCreateTaGradedGradeable();
-                    $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
+                $ta_gg = $graded_gradeable->getOrCreateTaGradedGradeable();
+                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
 
-                    $this->saveGradedComponent(
-                        $ta_gg,
-                        $gc,
-                        $grader,
-                        $custom_points,
-                        $custom_message,
-                        $marks,
-                        $component_version,
-                        !$silent_edit,
-                        true //execute database query immediately
-                    );
-                }
-            } else {
+                $this->saveGradedComponent(
+                    $ta_gg,
+                    $gc,
+                    $grader,
+                    $custom_points,
+                    $custom_message,
+                    $marks,
+                    $component_version,
+                    !$silent_edit,
+                    true //execute database query immediately
+                );
+            }
+            else {
                 $submitters_to_grade = [];
                 $active_versions = [];
                 $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $submitter_id);
@@ -2629,7 +2627,7 @@ class ElectronicGraderController extends AbstractController {
                     );
                     $ta_graded_gradeables_to_save[] = $ta_gg;
                 }
-                
+
                 $this->core->getQueries()->bulkSaveTaGradedGradeables($ta_graded_gradeables_to_save);
                 foreach ($ta_graded_gradeables_to_save as $ta_gg) {
                     $submitter = $ta_gg->getGradedGradeable()->getSubmitter();
@@ -2638,7 +2636,7 @@ class ElectronicGraderController extends AbstractController {
                     }
                 }
             }
-            
+
             $this->core->getOutput()->renderJsonSuccess();
         }
         catch (\InvalidArgumentException $e) {

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2145,12 +2145,21 @@ class ElectronicGraderController extends AbstractController {
         $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
 
         $is_unclustered = true; // default to true
+        $cluster_student_count = 0;
+        $cluster_name = null;
         if ($ta_grading_cluster_mode) {
             $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $graded_gradeable->getSubmitter()->getId());
             if ($cluster !== null) {
                 $submitter_id = $graded_gradeable->getSubmitter()->getId();
-                $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, [$submitter_id]);
+                
+                $member_ids = [];
+                foreach ($cluster->getMembers() as $member) {
+                    $member_ids[] = $member->getUserId() ?? $member->getTeamId();
+                }
+                
+                $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
                 $valid_members = $cluster->getValidMembers($active_versions);
+                $cluster_student_count = count($valid_members);
 
                 foreach ($valid_members as $member) {
                     if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
@@ -2158,9 +2167,13 @@ class ElectronicGraderController extends AbstractController {
                         break;
                     }
                 }
+
+                if (!$is_unclustered) {
+                    $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
+                }
             }
         }
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count, $cluster_name);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');
@@ -2600,6 +2613,8 @@ class ElectronicGraderController extends AbstractController {
                     $submitters_to_grade[] = $submitter_id;
                 }
                 //running a for-loop to assign marks to all members in submitters_to_grade
+                // Wrap in a transaction so either all cluster members are graded or none are
+                $this->core->getCourseDB()->beginTransaction();
                 foreach ($submitters_to_grade as $s_id) {
                     $gg = $this->tryGetGradedGradeable($gradeable, $s_id);
                     if ($gg === false) {
@@ -2611,6 +2626,9 @@ class ElectronicGraderController extends AbstractController {
                         continue;
                     }
 
+                    // use each member's own active version to avoid version conflicts
+                    $member_version = $active_versions[$s_id] ?? $component_version;
+
                     $ta_gg = $gg->getOrCreateTaGradedGradeable();
                     $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
 
@@ -2621,18 +2639,25 @@ class ElectronicGraderController extends AbstractController {
                         $custom_points,
                         $custom_message,
                         $marks,
-                        $component_version,
+                        $member_version,
                         !$silent_edit
                     );
                 }
+                $this->core->getCourseDB()->commit();
             }
 
             $this->core->getOutput()->renderJsonSuccess();
         }
         catch (\InvalidArgumentException $e) {
+            if ($this->core->getCourseDB()->inTransaction()) {
+                $this->core->getCourseDB()->rollback();
+            }
             $this->core->getOutput()->renderJsonFail($e->getMessage());
         }
         catch (\Exception $e) {
+            if ($this->core->getCourseDB()->inTransaction()) {
+                $this->core->getCourseDB()->rollback();
+            }
             $this->core->getOutput()->renderJsonError($e->getMessage());
         }
     }

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -1222,7 +1222,7 @@ class ElectronicGraderController extends AbstractController {
 
             foreach ($config->getClusters() as $cluster) {
                 foreach ($cluster->getValidMembers($active_versions) as $member) {
-                    $id = $member->getUserId() ?? $member->getTeamId();
+                    $id = $member->getSubmitterId();
                     $cluster_map[$id] = $cluster->getClusterName();
                 }
             }
@@ -2138,13 +2138,10 @@ class ElectronicGraderController extends AbstractController {
         $this->core->getOutput()->addInternalJs('websocket.js');
         $show_hidden = $this->core->getAccess()->canI("autograding.show_hidden_cases", ["gradeable" => $gradeable]);
         $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
-        $clusters_exist = false;
-        if ($clustering_enabled) {
-            $clusters_exist = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
-        }
+        $clusters_exist = $clustering_enabled && $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
         $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
 
-        $is_unclustered = true; // default to true
+        $is_clustered = false; // default to false
         $cluster_student_count = 0;
         $cluster_name = null;
         if ($ta_grading_cluster_mode) {
@@ -2154,7 +2151,7 @@ class ElectronicGraderController extends AbstractController {
 
                 $member_ids = [];
                 foreach ($cluster->getMembers() as $member) {
-                    $member_ids[] = $member->getUserId() ?? $member->getTeamId();
+                    $member_ids[] = $member->getSubmitterId();
                 }
 
                 $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
@@ -2162,18 +2159,18 @@ class ElectronicGraderController extends AbstractController {
                 $cluster_student_count = count($valid_members);
 
                 foreach ($valid_members as $member) {
-                    if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
-                        $is_unclustered = false;
+                    if ($member->getSubmitterId() === $submitter_id) {
+                        $is_clustered = true;
                         break;
                     }
                 }
 
-                if (!$is_unclustered) {
+                if ($is_clustered) {
                     $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
                 }
             }
         }
-        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count, $cluster_name);
+        $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'hwGradingPage', $gradeable, $graded_gradeable, $display_version, $progress, $show_hidden, $can_inquiry, $can_verify, $show_verify_all, $show_silent_edit, $late_status, $rollback_submission, $sort, $direction, $who_id, $solution_ta_notes, $submitter_itempool_map, $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_clustered, $cluster_student_count, $cluster_name);
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupStudents');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupMarkConflicts');
         $this->core->getOutput()->renderOutput(['grading', 'ElectronicGrader'], 'popupSettings');
@@ -2541,16 +2538,10 @@ class ElectronicGraderController extends AbstractController {
             }
         }
         $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
-        $ta_grading_cluster_mode = false;
-        if ($clustering_enabled && ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true') {
-            $ta_grading_cluster_mode = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
-        }
+        $ta_grading_cluster_mode = $clustering_enabled && ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
 
         // Check if the user can silently edit assigned marks
-        if ($ta_grading_cluster_mode) {
-            $silent_edit = false;
-        }
-        elseif (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
+        if ($ta_grading_cluster_mode || !$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
             $silent_edit = false;
         }
 
@@ -2566,29 +2557,14 @@ class ElectronicGraderController extends AbstractController {
         Logger::logTAGrading($logger_params);
 
         try {
-            if (!$ta_grading_cluster_mode) {
-                $ta_gg = $graded_gradeable->getOrCreateTaGradedGradeable();
-                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
-
-                $this->saveGradedComponent(
-                    $ta_gg,
-                    $gc,
-                    $grader,
-                    $custom_points,
-                    $custom_message,
-                    $marks,
-                    $component_version,
-                    !$silent_edit
-                );
-            }
-            else {
+            if ($ta_grading_cluster_mode) {
                 $submitters_to_grade = [];
                 $active_versions = [];
                 $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable_id, $submitter_id);
                 if ($cluster !== null) {
                     $member_ids = [];
                     foreach ($cluster->getMembers() as $member) {
-                        $member_ids[] = $member->getUserId() ?? $member->getTeamId();
+                        $member_ids[] = $member->getSubmitterId();
                     }
                     $active_versions = $this->core->getQueries()->getActiveVersions($gradeable, $member_ids);
 
@@ -2596,7 +2572,7 @@ class ElectronicGraderController extends AbstractController {
                     $is_current_valid = false; //this tells us that if this student is valid itself or not (i.e. whether student should belong in Unclustered mode)
                     //checking among all valid_members if anyone of them is this student
                     foreach ($valid_members as $member) {
-                        if (($member->getUserId() ?? $member->getTeamId()) === $submitter_id) {
+                        if ($member->getSubmitterId() === $submitter_id) {
                             $is_current_valid = true;
                         }
                     }
@@ -2604,7 +2580,7 @@ class ElectronicGraderController extends AbstractController {
                     //but if not then this student should be graded as 'Unclustered'
                     if ($is_current_valid) {
                         foreach ($valid_members as $member) {
-                            $submitters_to_grade[] = $member->getUserId() ?? $member->getTeamId();
+                            $submitters_to_grade[] = $member->getSubmitterId();
                         }
                     }
                 }
@@ -2644,6 +2620,21 @@ class ElectronicGraderController extends AbstractController {
                     );
                 }
                 $this->core->getCourseDB()->commit();
+            }
+            else {
+                $ta_gg = $graded_gradeable->getOrCreateTaGradedGradeable();
+                $gc = $ta_gg->getOrCreateGradedComponent($component, $grader, true);
+
+                $this->saveGradedComponent(
+                    $ta_gg,
+                    $gc,
+                    $grader,
+                    $custom_points,
+                    $custom_message,
+                    $marks,
+                    $component_version,
+                    !$silent_edit
+                );
             }
 
             $this->core->getOutput()->renderJsonSuccess();

--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2516,16 +2516,16 @@ class ElectronicGraderController extends AbstractController {
             }
         }
         $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
-        $clusters_exist = false;
-        if ($clustering_enabled) {
-            $clusters_exist = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        $ta_grading_cluster_mode = false;
+        if ($clustering_enabled && ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true') {
+            $ta_grading_cluster_mode = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
         }
-        $ta_grading_cluster_mode = ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $clustering_enabled && $clusters_exist;
 
         // Check if the user can silently edit assigned marks
         if ($ta_grading_cluster_mode) {
             $silent_edit = false;
-        } elseif (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
+        }
+        elseif (!$this->core->getAccess()->canI('grading.electronic.silent_edit')) {
             $silent_edit = false;
         }
 

--- a/site/app/entities/grading_cluster/GradingCluster.php
+++ b/site/app/entities/grading_cluster/GradingCluster.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: \app\repositories\grading_cluster\GradingClusterRepository::class)]
 #[ORM\Table(name: "ta_grading_clusters")]
 class GradingCluster {
     #[ORM\Id]

--- a/site/app/entities/grading_cluster/GradingCluster.php
+++ b/site/app/entities/grading_cluster/GradingCluster.php
@@ -71,7 +71,7 @@ class GradingCluster {
     public function getValidMembers(array $active_versions): array {
         $valid = [];
         foreach ($this->members as $m) {
-            $id = $m->getUserId() ?? $m->getTeamId();
+            $id = $m->getSubmitterId();
             if (isset($active_versions[$id]) && $active_versions[$id] === $m->getActiveVersion()) {
                 $valid[] = $m;
             }

--- a/site/app/entities/grading_cluster/GradingClusterMember.php
+++ b/site/app/entities/grading_cluster/GradingClusterMember.php
@@ -52,6 +52,10 @@ class GradingClusterMember {
         return $this->team_id;
     }
 
+    public function getSubmitterId(): ?string {
+        return $this->getUserId() ?? $this->getTeamId();
+    }
+
     public function getActiveVersion(): int {
         return $this->active_version;
     }

--- a/site/app/entities/grading_cluster/GradingClusterMember.php
+++ b/site/app/entities/grading_cluster/GradingClusterMember.php
@@ -52,7 +52,7 @@ class GradingClusterMember {
         return $this->team_id;
     }
 
-    public function getSubmitterId(): ?string {
+    public function getSubmitterId(): string {
         return $this->getUserId() ?? $this->getTeamId();
     }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7991,17 +7991,18 @@ AND gc_id IN (
         foreach ($ta_graded_gradeables as $ta_graded_gradeable) {
             if ($ta_graded_gradeable->getId() < 1) {
                 $insert_ta_gradeables[] = $ta_graded_gradeable;
-                
+
                 $is_team = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->isTeam();
                 $submitter_id = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->getId();
                 $g_id = $ta_graded_gradeable->getGradedGradeable()->getGradeable()->getId();
-                
+
                 $gd_insert_values[] = '(?, ?, ?, ?)';
                 $gd_insert_params[] = $g_id;
                 $gd_insert_params[] = $is_team ? null : $submitter_id;
                 $gd_insert_params[] = $is_team ? $submitter_id : null;
                 $gd_insert_params[] = $ta_graded_gradeable->getUserViewedDate() !== null ? DateUtils::dateTimeToString($ta_graded_gradeable->getUserViewedDate()) : null;
-            } else {
+            }
+            else {
                 $update_ta_gradeables[] = $ta_graded_gradeable;
             }
         }
@@ -8014,7 +8015,7 @@ AND gc_id IN (
             ";
             $this->course_db->query($gd_insert_query, $gd_insert_params);
             $returned_gds = $this->course_db->rows();
-            
+
             foreach ($insert_ta_gradeables as $ta_graded_gradeable) {
                 $is_team = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->isTeam();
                 $submitter_id = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->getId();
@@ -8022,7 +8023,8 @@ AND gc_id IN (
                     if ($is_team && $row['gd_team_id'] === $submitter_id) {
                         $ta_graded_gradeable->setIdFromDatabase($row['gd_id']);
                         break;
-                    } elseif (!$is_team && $row['gd_user_id'] === $submitter_id) {
+                    }
+                    elseif (!$is_team && $row['gd_user_id'] === $submitter_id) {
                         $ta_graded_gradeable->setIdFromDatabase($row['gd_id']);
                         break;
                     }
@@ -8055,15 +8057,15 @@ AND gc_id IN (
 
         $gcd_insert_values = [];
         $gcd_insert_params = [];
-        
+
         $gcd_update_values = [];
         $gcd_update_params = [];
-        
+
         $gcd_peer_update_values = [];
         $gcd_peer_update_params = [];
 
         $marks_to_delete = [];
-        
+
         $gcmd_insert_values = [];
         $gcmd_insert_params = [];
 
@@ -8081,7 +8083,8 @@ AND gc_id IN (
                         $gcd_insert_params[] = DateUtils::dateTimeToString($component_grade->getGradeTime());
                         $gcd_insert_params[] = $component_grade->getVerifierId() !== '' ? $component_grade->getVerifierId() : null;
                         $gcd_insert_params[] = !is_null($component_grade->getVerifyTime()) ? DateUtils::dateTimeToString($component_grade->getVerifyTime()) : null;
-                    } else if ($component_grade->isModified()) {
+                    }
+                    elseif ($component_grade->isModified()) {
                         if (!$component_grade->getComponent()->isPeerComponent()) {
                             $gcd_update_values[] = '(CAST(? AS integer), CAST(? AS integer), CAST(? AS double precision), CAST(? AS varchar), CAST(? AS integer), CAST(? AS timestamp), CAST(? AS varchar), CAST(? AS varchar), CAST(? AS timestamp))';
                             $gcd_update_params[] = $ta_graded_gradeable->getId();
@@ -8093,7 +8096,8 @@ AND gc_id IN (
                             $gcd_update_params[] = $component_grade->getGraderId();
                             $gcd_update_params[] = $component_grade->getVerifierId() !== '' ? $component_grade->getVerifierId() : null;
                             $gcd_update_params[] = !is_null($component_grade->getVerifyTime()) ? DateUtils::dateTimeToString($component_grade->getVerifyTime()) : null;
-                        } else {
+                        }
+                        else {
                             $gcd_peer_update_values[] = '(CAST(? AS integer), CAST(? AS integer), CAST(? AS varchar), CAST(? AS double precision), CAST(? AS varchar), CAST(? AS integer), CAST(? AS timestamp), CAST(? AS varchar), CAST(? AS timestamp))';
                             $gcd_peer_update_params[] = $ta_graded_gradeable->getId();
                             $gcd_peer_update_params[] = $component_grade->getComponentId();
@@ -8110,7 +8114,7 @@ AND gc_id IN (
                     if ($component_grade->isMarksModified()) {
                         $new_marks = array_diff($component_grade->getMarkIds(), $component_grade->getDbMarkIds() ?? []);
                         $deleted_marks = array_diff($component_grade->getDbMarkIds() ?? [], $component_grade->getMarkIds());
-                        
+
                         foreach ($deleted_marks as $mark_id) {
                             $marks_to_delete[] = ['gc_id' => $component_grade->getComponentId(), 'gd_id' => $ta_graded_gradeable->getId(), 'gcm_grader_id' => $component_grade->getGraderId(), 'gcm_id' => $mark_id];
                         }
@@ -8129,7 +8133,7 @@ AND gc_id IN (
                 $this->deleteGradedComponent($component_grade);
             }
             $ta_graded_gradeable->clearDeletedGradedComponents();
-            
+
             $this->updateOverallComments($ta_graded_gradeable);
         }
 

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8304,7 +8304,7 @@ AND gc_id IN (
      *
      * @param  \app\models\gradeable\Gradeable $gradeable
      * @param  string[]                        $submitter_ids
-     * @return bool[] Map of id=>version
+     * @return array<string, int> Map of id=>version
      */
     public function getActiveVersions(Gradeable $gradeable, array $submitter_ids) {
         if (count($submitter_ids) === 0) {

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7975,6 +7975,229 @@ AND gc_id IN (
     }
 
     /**
+     * Saves an array of TaGradedGradeable models in bulk.
+     * @param TaGradedGradeable[] $ta_graded_gradeables
+     */
+    public function bulkSaveTaGradedGradeables(array $ta_graded_gradeables): void {
+        if (count($ta_graded_gradeables) === 0) {
+            return;
+        }
+
+        $gd_insert_values = [];
+        $gd_insert_params = [];
+        $update_ta_gradeables = [];
+        $insert_ta_gradeables = [];
+
+        foreach ($ta_graded_gradeables as $ta_graded_gradeable) {
+            if ($ta_graded_gradeable->getId() < 1) {
+                $insert_ta_gradeables[] = $ta_graded_gradeable;
+                
+                $is_team = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->isTeam();
+                $submitter_id = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->getId();
+                $g_id = $ta_graded_gradeable->getGradedGradeable()->getGradeable()->getId();
+                
+                $gd_insert_values[] = '(?, ?, ?, ?)';
+                $gd_insert_params[] = $g_id;
+                $gd_insert_params[] = $is_team ? null : $submitter_id;
+                $gd_insert_params[] = $is_team ? $submitter_id : null;
+                $gd_insert_params[] = $ta_graded_gradeable->getUserViewedDate() !== null ? DateUtils::dateTimeToString($ta_graded_gradeable->getUserViewedDate()) : null;
+            } else {
+                $update_ta_gradeables[] = $ta_graded_gradeable;
+            }
+        }
+
+        if (count($insert_ta_gradeables) > 0) {
+            $gd_insert_query = "
+                INSERT INTO gradeable_data (g_id, gd_user_id, gd_team_id, gd_user_viewed_date)
+                VALUES " . implode(', ', $gd_insert_values) . "
+                RETURNING gd_id, gd_user_id, gd_team_id
+            ";
+            $this->course_db->query($gd_insert_query, $gd_insert_params);
+            $returned_gds = $this->course_db->rows();
+            
+            foreach ($insert_ta_gradeables as $ta_graded_gradeable) {
+                $is_team = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->isTeam();
+                $submitter_id = $ta_graded_gradeable->getGradedGradeable()->getSubmitter()->getId();
+                foreach ($returned_gds as $row) {
+                    if ($is_team && $row['gd_team_id'] === $submitter_id) {
+                        $ta_graded_gradeable->setIdFromDatabase($row['gd_id']);
+                        break;
+                    } elseif (!$is_team && $row['gd_user_id'] === $submitter_id) {
+                        $ta_graded_gradeable->setIdFromDatabase($row['gd_id']);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (count($update_ta_gradeables) > 0) {
+            $update_values = [];
+            $update_params = [];
+            $has_modified = false;
+            foreach ($update_ta_gradeables as $ta_graded_gradeable) {
+                if ($ta_graded_gradeable->isModified()) {
+                    $has_modified = true;
+                    $update_values[] = '(CAST(? AS integer), CAST(? AS timestamp))';
+                    $update_params[] = $ta_graded_gradeable->getId();
+                    $update_params[] = $ta_graded_gradeable->getUserViewedDate() !== null ? DateUtils::dateTimeToString($ta_graded_gradeable->getUserViewedDate()) : null;
+                }
+            }
+            if ($has_modified) {
+                $gd_update_query = "
+                    UPDATE gradeable_data
+                    SET gd_user_viewed_date = v.date
+                    FROM (VALUES " . implode(', ', $update_values) . ") AS v(gd_id, date)
+                    WHERE gradeable_data.gd_id = v.gd_id
+                ";
+                $this->course_db->query($gd_update_query, $update_params);
+            }
+        }
+
+        $gcd_insert_values = [];
+        $gcd_insert_params = [];
+        
+        $gcd_update_values = [];
+        $gcd_update_params = [];
+        
+        $gcd_peer_update_values = [];
+        $gcd_peer_update_params = [];
+
+        $marks_to_delete = [];
+        
+        $gcmd_insert_values = [];
+        $gcmd_insert_params = [];
+
+        foreach ($ta_graded_gradeables as $ta_graded_gradeable) {
+            foreach ($ta_graded_gradeable->getGradedComponentContainers() as $container) {
+                foreach ($container->getGradedComponents() as $component_grade) {
+                    if ($component_grade->isNew()) {
+                        $gcd_insert_values[] = '(?, ?, ?, ?, ?, ?, ?, ?, ?)';
+                        $gcd_insert_params[] = $component_grade->getComponentId();
+                        $gcd_insert_params[] = $ta_graded_gradeable->getId();
+                        $gcd_insert_params[] = $component_grade->getScore();
+                        $gcd_insert_params[] = $component_grade->getComment();
+                        $gcd_insert_params[] = $component_grade->getGraderId();
+                        $gcd_insert_params[] = $component_grade->getGradedVersion();
+                        $gcd_insert_params[] = DateUtils::dateTimeToString($component_grade->getGradeTime());
+                        $gcd_insert_params[] = $component_grade->getVerifierId() !== '' ? $component_grade->getVerifierId() : null;
+                        $gcd_insert_params[] = !is_null($component_grade->getVerifyTime()) ? DateUtils::dateTimeToString($component_grade->getVerifyTime()) : null;
+                    } else if ($component_grade->isModified()) {
+                        if (!$component_grade->getComponent()->isPeerComponent()) {
+                            $gcd_update_values[] = '(CAST(? AS integer), CAST(? AS integer), CAST(? AS double precision), CAST(? AS varchar), CAST(? AS integer), CAST(? AS timestamp), CAST(? AS varchar), CAST(? AS varchar), CAST(? AS timestamp))';
+                            $gcd_update_params[] = $ta_graded_gradeable->getId();
+                            $gcd_update_params[] = $component_grade->getComponentId();
+                            $gcd_update_params[] = $component_grade->getScore();
+                            $gcd_update_params[] = $component_grade->getComment();
+                            $gcd_update_params[] = $component_grade->getGradedVersion();
+                            $gcd_update_params[] = DateUtils::dateTimeToString($component_grade->getGradeTime());
+                            $gcd_update_params[] = $component_grade->getGraderId();
+                            $gcd_update_params[] = $component_grade->getVerifierId() !== '' ? $component_grade->getVerifierId() : null;
+                            $gcd_update_params[] = !is_null($component_grade->getVerifyTime()) ? DateUtils::dateTimeToString($component_grade->getVerifyTime()) : null;
+                        } else {
+                            $gcd_peer_update_values[] = '(CAST(? AS integer), CAST(? AS integer), CAST(? AS varchar), CAST(? AS double precision), CAST(? AS varchar), CAST(? AS integer), CAST(? AS timestamp), CAST(? AS varchar), CAST(? AS timestamp))';
+                            $gcd_peer_update_params[] = $ta_graded_gradeable->getId();
+                            $gcd_peer_update_params[] = $component_grade->getComponentId();
+                            $gcd_peer_update_params[] = $component_grade->getGraderId();
+                            $gcd_peer_update_params[] = $component_grade->getScore();
+                            $gcd_peer_update_params[] = $component_grade->getComment();
+                            $gcd_peer_update_params[] = $component_grade->getGradedVersion();
+                            $gcd_peer_update_params[] = DateUtils::dateTimeToString($component_grade->getGradeTime());
+                            $gcd_peer_update_params[] = $component_grade->getVerifierId() !== '' ? $component_grade->getVerifierId() : null;
+                            $gcd_peer_update_params[] = !is_null($component_grade->getVerifyTime()) ? DateUtils::dateTimeToString($component_grade->getVerifyTime()) : null;
+                        }
+                    }
+
+                    if ($component_grade->isMarksModified()) {
+                        $new_marks = array_diff($component_grade->getMarkIds(), $component_grade->getDbMarkIds() ?? []);
+                        $deleted_marks = array_diff($component_grade->getDbMarkIds() ?? [], $component_grade->getMarkIds());
+                        
+                        foreach ($deleted_marks as $mark_id) {
+                            $marks_to_delete[] = ['gc_id' => $component_grade->getComponentId(), 'gd_id' => $ta_graded_gradeable->getId(), 'gcm_grader_id' => $component_grade->getGraderId(), 'gcm_id' => $mark_id];
+                        }
+                        foreach ($new_marks as $mark_id) {
+                            $gcmd_insert_values[] = '(?, ?, ?, ?)';
+                            $gcmd_insert_params[] = $ta_graded_gradeable->getId();
+                            $gcmd_insert_params[] = $component_grade->getComponentId();
+                            $gcmd_insert_params[] = $component_grade->getGraderId();
+                            $gcmd_insert_params[] = $mark_id;
+                        }
+                    }
+                }
+            }
+
+            foreach ($ta_graded_gradeable->getDeletedGradedComponents() as $component_grade) {
+                $this->deleteGradedComponent($component_grade);
+            }
+            $ta_graded_gradeable->clearDeletedGradedComponents();
+            
+            $this->updateOverallComments($ta_graded_gradeable);
+        }
+
+        if (count($gcd_insert_values) > 0) {
+            $query = "
+                INSERT INTO gradeable_component_data(
+                  gc_id, gd_id, gcd_score, gcd_component_comment, gcd_grader_id, 
+                  gcd_graded_version, gcd_grade_time, gcd_verifier_id, gcd_verify_time)
+                VALUES " . implode(', ', $gcd_insert_values);
+            $this->course_db->query($query, $gcd_insert_params);
+        }
+
+        if (count($gcd_update_values) > 0) {
+            $query = "
+                UPDATE gradeable_component_data 
+                SET
+                  gcd_score = v.gcd_score,
+                  gcd_component_comment = v.gcd_component_comment,
+                  gcd_graded_version = v.gcd_graded_version,
+                  gcd_grade_time = v.gcd_grade_time,
+                  gcd_grader_id = v.gcd_grader_id,
+                  gcd_verifier_id = v.gcd_verifier_id,
+                  gcd_verify_time = v.gcd_verify_time
+                FROM (VALUES " . implode(', ', $gcd_update_values) . ") AS v(gd_id, gc_id, gcd_score, gcd_component_comment, gcd_graded_version, gcd_grade_time, gcd_grader_id, gcd_verifier_id, gcd_verify_time)
+                WHERE gradeable_component_data.gd_id = v.gd_id AND gradeable_component_data.gc_id = v.gc_id
+            ";
+            $this->course_db->query($query, $gcd_update_params);
+        }
+
+        if (count($gcd_peer_update_values) > 0) {
+            $query = "
+                UPDATE gradeable_component_data 
+                SET
+                  gcd_score = v.gcd_score,
+                  gcd_component_comment = v.gcd_component_comment,
+                  gcd_graded_version = v.gcd_graded_version,
+                  gcd_grade_time = v.gcd_grade_time,
+                  gcd_verifier_id = v.gcd_verifier_id,
+                  gcd_verify_time = v.gcd_verify_time
+                FROM (VALUES " . implode(', ', $gcd_peer_update_values) . ") AS v(gd_id, gc_id, gcd_grader_id, gcd_score, gcd_component_comment, gcd_graded_version, gcd_grade_time, gcd_verifier_id, gcd_verify_time)
+                WHERE gradeable_component_data.gd_id = v.gd_id AND gradeable_component_data.gc_id = v.gc_id AND gradeable_component_data.gcd_grader_id = v.gcd_grader_id
+            ";
+            $this->course_db->query($query, $gcd_peer_update_params);
+        }
+
+        if (count($marks_to_delete) > 0) {
+            $del_clauses = [];
+            $del_params = [];
+            foreach ($marks_to_delete as $mark) {
+                $del_clauses[] = "(gd_id=? AND gc_id=? AND gcd_grader_id=? AND gcm_id=?)";
+                array_push($del_params, $mark['gd_id'], $mark['gc_id'], $mark['gcm_grader_id'], $mark['gcm_id']);
+            }
+            $del_query = "DELETE FROM gradeable_component_mark_data WHERE " . implode(' OR ', $del_clauses);
+            $this->course_db->query($del_query, $del_params);
+        }
+
+        if (count($gcmd_insert_values) > 0) {
+            $query = "
+                INSERT INTO gradeable_component_mark_data(
+                  gd_id, gc_id, gcd_grader_id, gcm_id)
+                VALUES " . implode(', ', $gcmd_insert_values) . "
+                ON CONFLICT (gc_id, gd_id, gcd_grader_id, gcm_id) DO NOTHING
+            ";
+            $this->course_db->query($query, $gcmd_insert_params);
+        }
+    }
+
+    /**
      * Changes the graded version of a gradeable for a particular student
      *
      * @param int[] $component_ids

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -8087,7 +8087,7 @@ AND gc_id IN (
      *
      * @param  \app\models\gradeable\Gradeable $gradeable
      * @param  string[]                        $submitter_ids
-     * @return bool[] Map of id=>version
+     * @return array<string, int> Map of id=>version
      */
     public function getActiveVersions(Gradeable $gradeable, array $submitter_ids) {
         if (count($submitter_ids) === 0) {

--- a/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
@@ -39,14 +39,15 @@ class GradingClusterConfigRepository extends EntityRepository {
      * Checks if a gradeable has any clusters configured without fetching them all.
      */
     public function hasClusters(string $gradeable_id): bool {
-        $count = $this->getEntityManager()->createQuery('
-            SELECT COUNT(cl.id)
+        $result = $this->getEntityManager()->createQuery('
+            SELECT 1
             FROM \app\entities\grading_cluster\GradingClusterConfig c
             JOIN c.clusters cl
             WHERE c.gradeable_id = :gradeable_id
         ')
         ->setParameter('gradeable_id', $gradeable_id)
-        ->getSingleScalarResult();
-        return $count > 0;
+        ->setMaxResults(1)
+        ->getOneOrNullResult();
+        return $result !== null;
     }
 }

--- a/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
@@ -34,4 +34,19 @@ class GradingClusterConfigRepository extends EntityRepository {
         ->setParameter('gradeable_id', $gradeable_id)
         ->getOneOrNullResult();
     }
+
+    /**
+     * Checks if a gradeable has any clusters configured without fetching them all.
+     */
+    public function hasClusters(string $gradeable_id): bool {
+        $count = $this->getEntityManager()->createQuery('
+            SELECT COUNT(cl.id)
+            FROM \app\entities\grading_cluster\GradingClusterConfig c
+            JOIN c.clusters cl
+            WHERE c.gradeable_id = :gradeable_id
+        ')
+        ->setParameter('gradeable_id', $gradeable_id)
+        ->getSingleScalarResult();
+        return $count > 0;
+    }
 }

--- a/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterConfigRepository.php
@@ -34,4 +34,20 @@ class GradingClusterConfigRepository extends EntityRepository {
         ->setParameter('gradeable_id', $gradeable_id)
         ->getOneOrNullResult();
     }
+
+    /**
+     * Checks if a gradeable has any clusters configured without fetching them all.
+     */
+    public function hasClusters(string $gradeable_id): bool {
+        $count = $this->getEntityManager()->createQuery('
+            SELECT COUNT(cl.id)
+            FROM \app\entities\grading_cluster\GradingClusterConfig c
+            JOIN c.clusters cl
+            WHERE c.gradeable_id = :gradeable_id
+        ')
+        ->setParameter('gradeable_id', $gradeable_id)
+        ->getSingleScalarResult();
+
+        return $count > 0;
+    }
 }

--- a/site/app/repositories/grading_cluster/GradingClusterRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterRepository.php
@@ -24,16 +24,16 @@ class GradingClusterRepository extends EntityRepository {
         }
 
         return $this->getEntityManager()->createQuery('
-            SELECT cl, m
-            FROM \app\entities\grading_cluster\GradingCluster cl
-            JOIN cl.config c
-            JOIN cl.members m
-            WHERE c.gradeable_id = :gradeable_id
+            SELECT cluster, cluster_member
+            FROM \app\entities\grading_cluster\GradingCluster cluster
+            JOIN cluster.config cluster_config
+            JOIN cluster.members cluster_member
+            WHERE cluster_config.gradeable_id = :gradeable_id
               AND EXISTS (
                   SELECT 1
-                  FROM \app\entities\grading_cluster\GradingClusterMember m2
-                  WHERE m2.cluster = cl 
-                    AND (m2.user_id = :submitter_id OR m2.team_id = :submitter_id)
+                  FROM \app\entities\grading_cluster\GradingClusterMember search_member
+                  WHERE search_member.cluster = cluster 
+                    AND (search_member.user_id = :submitter_id OR search_member.team_id = :submitter_id)
               )
         ')
         ->setParameter('gradeable_id', $gradeable_id)

--- a/site/app/repositories/grading_cluster/GradingClusterRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\repositories\grading_cluster;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @extends EntityRepository<\app\entities\grading_cluster\GradingCluster>
+ */
+class GradingClusterRepository extends EntityRepository {
+
+    /**
+     * Fetches the specific GradingCluster that the given submitter (user or team) belongs to
+     * for a specific gradeable, bypassing the need to load all clusters.
+     *
+     * @param string $gradeable_id
+     * @param string $submitter_id
+     * @return \app\entities\grading_cluster\GradingCluster|null
+     */
+    public function findClusterBySubmitter(string $gradeable_id, string $submitter_id): ?\app\entities\grading_cluster\GradingCluster {
+        return $this->getEntityManager()->createQuery('
+            SELECT cl, m
+            FROM \app\entities\grading_cluster\GradingCluster cl
+            JOIN cl.config c
+            JOIN cl.members m
+            WHERE c.gradeable_id = :gradeable_id
+              AND EXISTS (
+                  SELECT 1
+                  FROM \app\entities\grading_cluster\GradingClusterMember m2
+                  WHERE m2.cluster = cl 
+                    AND (m2.user_id = :submitter_id OR m2.team_id = :submitter_id)
+              )
+        ')
+        ->setParameter('gradeable_id', $gradeable_id)
+        ->setParameter('submitter_id', $submitter_id)
+        ->getOneOrNullResult();
+    }
+}

--- a/site/app/repositories/grading_cluster/GradingClusterRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterRepository.php
@@ -19,6 +19,10 @@ class GradingClusterRepository extends EntityRepository {
      * @return \app\entities\grading_cluster\GradingCluster|null
      */
     public function findClusterBySubmitter(string $gradeable_id, string $submitter_id): ?\app\entities\grading_cluster\GradingCluster {
+        if ($gradeable_id === '' || $submitter_id === '') {
+            return null;
+        }
+
         return $this->getEntityManager()->createQuery('
             SELECT cl, m
             FROM \app\entities\grading_cluster\GradingCluster cl

--- a/site/app/repositories/grading_cluster/GradingClusterRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterRepository.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\EntityRepository;
  * @extends EntityRepository<\app\entities\grading_cluster\GradingCluster>
  */
 class GradingClusterRepository extends EntityRepository {
-
     /**
      * Fetches the specific GradingCluster that the given submitter (user or team) belongs to
      * for a specific gradeable, bypassing the need to load all clusters.

--- a/site/app/repositories/grading_cluster/GradingClusterRepository.php
+++ b/site/app/repositories/grading_cluster/GradingClusterRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\repositories\grading_cluster;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @extends EntityRepository<\app\entities\grading_cluster\GradingCluster>
+ */
+class GradingClusterRepository extends EntityRepository {
+    /**
+     * Fetches the specific GradingCluster that the given submitter (user or team) belongs to
+     * for a specific gradeable, bypassing the need to load all clusters.
+     *
+     * @param string $gradeable_id
+     * @param string $submitter_id
+     * @return \app\entities\grading_cluster\GradingCluster|null
+     */
+    public function findClusterBySubmitter(string $gradeable_id, string $submitter_id): ?\app\entities\grading_cluster\GradingCluster {
+        return $this->getEntityManager()->createQuery('
+            SELECT cl, m
+            FROM \app\entities\grading_cluster\GradingCluster cl
+            JOIN cl.config c
+            JOIN cl.members m
+            WHERE c.gradeable_id = :gradeable_id
+              AND EXISTS (
+                  SELECT 1
+                  FROM \app\entities\grading_cluster\GradingClusterMember m2
+                  WHERE m2.cluster = cl 
+                    AND (m2.user_id = :submitter_id OR m2.team_id = :submitter_id)
+              )
+        ')
+        ->setParameter('gradeable_id', $gradeable_id)
+        ->setParameter('submitter_id', $submitter_id)
+        ->getOneOrNullResult();
+    }
+}

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -38,7 +38,12 @@
             },
             'class': 'grading_toolbar',
             'events': {
-                'select-layout': '({ panels, isLeftTaller, twoInRight }) => { window.changePanelsLayout(panels, isLeftTaller, twoInRight); }'
+                'select-layout': '({ panels, isLeftTaller, twoInRight }) => { window.changePanelsLayout(panels, isLeftTaller, twoInRight); }',
+                'toggle-cluster-mode': '() => { 
+                    const currentMode = ' ~ (ta_grading_cluster_mode ? 'true' : 'false') ~ '; 
+                    Cookies.set("ta_grading_cluster_mode", !currentMode, { expires: 1, path: "/" });
+                    window.location.reload(); 
+                }'
             }
         }%}
     </div>

--- a/site/app/templates/grading/electronic/NavigationBar.twig
+++ b/site/app/templates/grading/electronic/NavigationBar.twig
@@ -13,6 +13,14 @@
                     <br/>
                 {% endif %}
             {% endif %}
+            {% if ta_grading_cluster_mode %}
+                <br/>
+                {% if cluster_name %}
+                    {{ cluster_name }} ({{ cluster_size }} students)
+                {% else %}
+                    Unclustered
+                {% endif %}
+            {% endif %}
         </b>
     </div>
     <div class="navigation-box">
@@ -23,7 +31,10 @@
                 'homeUrl': home_url,
                 'prevStudentUrl': prev_student_url,
                 'nextStudentUrl': next_student_url,
-                'progress': progress
+                'progress': progress,
+                'clusteringEnabled': clustering_enabled,
+                'clustersExist': clusters_exist,
+                'taGradingClusterMode': ta_grading_cluster_mode
             },
             'class': 'grading_toolbar',
             'events': {

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -50,9 +50,10 @@
                     {% endif %}
 
                     {# Silent Edit Checkbox #}
-                    {% if show_silent_edit %}
+                    {% if show_silent_edit and not ta_grading_cluster_mode %}
                         <div class="col-no-gutters">
-                            <input id="silent-edit-id" class="key_to_click" tabindex="0" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/><label for="silent-edit-id">Silent Regrade (don't change who graded)</label>
+                            <input id="silent-edit-id" class="key_to_click" tabindex="0" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/>
+                            <label for="silent-edit-id">Silent Regrade (don't change who graded)</label>
                         </div>
                     {% endif %}
                     {# Edit Mode Checkbox #}
@@ -62,6 +63,11 @@
                     </div>
                     {% endif %}
                 </div>
+                {% if ta_grading_cluster_mode %}
+                    <div class="blue-message w-100" style="margin-top: 5px; margin-bottom: 5px; text-align: center;">
+                        <strong>Clustering Mode Enabled:</strong> The grade you apply here will automatically be applied to all students within this student's cluster. But if this student is in the "Unclustered" group, they will be graded normally.<br>
+                    </div>
+                {% endif %}
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id }}" data-can_verify="{{ can_verify }}" hidden></div>
                 <div id="student-grader" is-student-grader="{{ student_grader }}" hidden></div>
                 <div class="inner-container" id="grading-box">

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -64,9 +64,15 @@
                     {% endif %}
                 </div>
                 {% if ta_grading_cluster_mode %}
-                    <div class="blue-message w-100" style="margin-top: 5px; margin-bottom: 5px; text-align: center;">
-                        <strong>Clustering Mode Enabled:</strong> The grade you apply here will automatically be applied to all students within this student's cluster. But if this student is in the "Unclustered" group, they will be graded normally.<br>
-                    </div>
+                    {% if is_unclustered %}
+                        <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
+                            Clustering Mode Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
+                        </div>
+                    {% else %}
+                        <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
+                            Clustering Mode Enabled: The grade you apply here will automatically be applied to all students within this student's cluster.
+                        </div>
+                    {% endif %}
                 {% endif %}
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id }}" data-can_verify="{{ can_verify }}" hidden></div>
                 <div id="student-grader" is-student-grader="{{ student_grader }}" hidden></div>

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -64,13 +64,14 @@
                     {% endif %}
                 </div>
                 {% if ta_grading_cluster_mode %}
+                    {% set entity = gradeable.isTeamAssignment() ? "team" : "student" %}
                     {% if not is_clustered %}
                         <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
-                            Cluster Grading Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
+                            Cluster Grading Enabled: This {{ entity }} is in the "Unclustered" group and will be graded normally as an individual.
                         </div>
                     {% else %}
                         <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
-                            Cluster Grading Enabled: The grade you apply here will automatically be applied to all {{ cluster_student_count }} students within this student's cluster.
+                            Cluster Grading Enabled: Any edits you made to this {{ entity }}'s marks will automatically be applied to all {{ cluster_student_count }} {{ entity }}s within this {{ entity }}'s cluster.
                         </div>
                     {% endif %}
                 {% endif %}

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -64,7 +64,7 @@
                     {% endif %}
                 </div>
                 {% if ta_grading_cluster_mode %}
-                    {% if is_unclustered %}
+                    {% if not is_clustered %}
                         <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
                             Cluster Grading Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
                         </div>

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -50,9 +50,10 @@
                     {% endif %}
 
                     {# Silent Edit Checkbox #}
-                    {% if show_silent_edit %}
+                    {% if show_silent_edit and not ta_grading_cluster_mode %}
                         <div class="col-no-gutters">
-                            <input id="silent-edit-id" class="key_to_click" tabindex="0" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/><label for="silent-edit-id">Silent Regrade (don't change who graded)</label>
+                            <input id="silent-edit-id" class="key_to_click" tabindex="0" type="checkbox" title="Edit assigned marks without changing 'Graded By'" onclick="updateCookies()"/>
+                            <label for="silent-edit-id">Silent Regrade (don't change who graded)</label>
                         </div>
                     {% endif %}
                     {# Edit Mode Checkbox #}
@@ -62,6 +63,17 @@
                     </div>
                     {% endif %}
                 </div>
+                {% if ta_grading_cluster_mode %}
+                    {% if is_unclustered %}
+                        <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
+                            Clustering Mode Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
+                        </div>
+                    {% else %}
+                        <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
+                            Clustering Mode Enabled: The grade you apply here will automatically be applied to all students within this student's cluster.
+                        </div>
+                    {% endif %}
+                {% endif %}
                 <div id="grader-info" data-grader_id="{{ grader_id }}" data-verifier_id = "{{ verifier_id }}" data-can_verify="{{ can_verify }}" hidden></div>
                 <div id="student-grader" is-student-grader="{{ student_grader }}" hidden></div>
                 <div class="inner-container" id="grading-box">

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -66,11 +66,11 @@
                 {% if ta_grading_cluster_mode %}
                     {% if is_unclustered %}
                         <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
-                            Clustering Mode Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
+                            Cluster Grading Enabled: This student is in the "Unclustered" group and will be graded normally as an individual.
                         </div>
                     {% else %}
                         <div class="system-message danger" style="position: sticky; top: 0; z-index: 100;">
-                            Clustering Mode Enabled: The grade you apply here will automatically be applied to all students within this student's cluster.
+                            Cluster Grading Enabled: The grade you apply here will automatically be applied to all {{ cluster_student_count }} students within this student's cluster.
                         </div>
                     {% endif %}
                 {% endif %}

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1053,7 +1053,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0, ?string $cluster_name = null) {
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $this->core->getOutput()->addInternalCss('ta-grading.css');
         $isPeerPanel = false;
@@ -1188,7 +1188,7 @@ HTML;
                     <div class="content-item content-item-right">
 HTML;
 
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count, $cluster_name);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1235,7 +1235,7 @@ HTML;
         }
         //If TA grading isn't enabled, the rubric won't actually show up, but the template should be rendered anyway to prevent errors, as the code references the rubric panel
         if (!$isPeerGrader || $isPeerRubric) {
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_unclustered);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count);
         }
         if (!$isPeerGrader || $isPeerSolutions) {
             $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderSolutionTaNotesPanel', $gradeable, $solution_ta_notes, $submitter_itempool_map);
@@ -1354,7 +1354,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0, ?string $cluster_name = null) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if (
@@ -1374,17 +1374,6 @@ HTML;
         $i_am_a_peer = false;
         if ($peer && $this->core->getUser()->getGroup() === 4) {
             $i_am_a_peer = true;
-        }
-
-        $cluster_name = null;
-        $cluster_size = 0;
-        if ($ta_grading_cluster_mode && $clustering_enabled && !$is_unclustered) {
-            $submitter_id = $graded_gradeable->getSubmitter()->getId();
-            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable->getId(), $submitter_id);
-            if ($cluster !== null) {
-                $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
-                $cluster_size = count($cluster->getMembers());
-            }
         }
 
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
@@ -1407,7 +1396,7 @@ HTML;
             "clusters_exist" => $clusters_exist,
             "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
             "cluster_name" => $cluster_name,
-            "cluster_size" => $cluster_size
+            "cluster_size" => $cluster_student_count
         ]);
     }
 
@@ -1761,7 +1750,7 @@ HTML;
      * @param bool $show_silent_edit
      * @return string
      */
-    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
+    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0) {
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
@@ -1827,6 +1816,7 @@ HTML;
                 "has_active_version" => $has_active_version,
                 "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
                 "is_unclustered" => $is_unclustered,
+                "cluster_student_count" => $cluster_student_count,
                 "version_conflict" => $version_conflict,
                 "show_silent_edit" => $show_silent_edit,
                 "show_clear_conflicts" => $show_clear_conflicts,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1053,7 +1053,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0, ?string $cluster_name = null) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_clustered = false, int $cluster_student_count = 0, ?string $cluster_name = null) {
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $this->core->getOutput()->addInternalCss('ta-grading.css');
         $isPeerPanel = false;
@@ -1188,7 +1188,7 @@ HTML;
                     <div class="content-item content-item-right">
 HTML;
 
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count, $cluster_name);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_clustered, $cluster_student_count, $cluster_name);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1235,7 +1235,7 @@ HTML;
         }
         //If TA grading isn't enabled, the rubric won't actually show up, but the template should be rendered anyway to prevent errors, as the code references the rubric panel
         if (!$isPeerGrader || $isPeerRubric) {
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_unclustered, $cluster_student_count);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_clustered, $cluster_student_count);
         }
         if (!$isPeerGrader || $isPeerSolutions) {
             $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderSolutionTaNotesPanel', $gradeable, $solution_ta_notes, $submitter_itempool_map);
@@ -1354,7 +1354,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0, ?string $cluster_name = null) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_clustered = false, int $cluster_student_count = 0, ?string $cluster_name = null) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if (
@@ -1750,7 +1750,7 @@ HTML;
      * @param bool $show_silent_edit
      * @return string
      */
-    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true, int $cluster_student_count = 0) {
+    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_clustered = false, int $cluster_student_count = 0) {
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
@@ -1815,7 +1815,7 @@ HTML;
                 "has_overridden_grades" => $has_overridden_grades,
                 "has_active_version" => $has_active_version,
                 "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
-                "is_unclustered" => $is_unclustered,
+                "is_clustered" => $is_clustered,
                 "cluster_student_count" => $cluster_student_count,
                 "version_conflict" => $version_conflict,
                 "show_silent_edit" => $show_silent_edit,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1053,7 +1053,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $this->core->getOutput()->addInternalCss('ta-grading.css');
         $isPeerPanel = false;
@@ -1188,7 +1188,7 @@ HTML;
                     <div class="content-item content-item-right">
 HTML;
 
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode, $is_unclustered);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1235,7 +1235,7 @@ HTML;
         }
         //If TA grading isn't enabled, the rubric won't actually show up, but the template should be rendered anyway to prevent errors, as the code references the rubric panel
         if (!$isPeerGrader || $isPeerRubric) {
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_unclustered);
         }
         if (!$isPeerGrader || $isPeerSolutions) {
             $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderSolutionTaNotesPanel', $gradeable, $solution_ta_notes, $submitter_itempool_map);
@@ -1354,7 +1354,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if (
@@ -1375,6 +1375,18 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() === 4) {
             $i_am_a_peer = true;
         }
+
+        $cluster_name = null;
+        $cluster_size = 0;
+        if ($ta_grading_cluster_mode && $clustering_enabled && !$is_unclustered) {
+            $submitter_id = $graded_gradeable->getSubmitter()->getId();
+            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable->getId(), $submitter_id);
+            if ($cluster !== null) {
+                $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
+                $cluster_size = count($cluster->getMembers());
+            }
+        }
+
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "anon_mode" => $anon_mode,
             "peer_blind_grading" => $blind_grading,
@@ -1390,7 +1402,12 @@ HTML;
             'discussion_based' => $graded_gradeable->getGradeable()->isDiscussionBased(),
             'submitter' => $graded_gradeable->getSubmitter(),
             'team_assignment' => $gradeable->isTeamAssignment(),
-            'isBlind' => $isBlind
+            'isBlind' => $isBlind,
+            "clustering_enabled" => $clustering_enabled,
+            "clusters_exist" => $clusters_exist,
+            "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
+            "cluster_name" => $cluster_name,
+            "cluster_size" => $cluster_size
         ]);
     }
 
@@ -1744,7 +1761,7 @@ HTML;
      * @param bool $show_silent_edit
      * @return string
      */
-    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader) {
+    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
@@ -1808,6 +1825,8 @@ HTML;
                 "has_submission" => $has_submission,
                 "has_overridden_grades" => $has_overridden_grades,
                 "has_active_version" => $has_active_version,
+                "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
+                "is_unclustered" => $is_unclustered,
                 "version_conflict" => $version_conflict,
                 "show_silent_edit" => $show_silent_edit,
                 "show_clear_conflicts" => $show_clear_conflicts,

--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1053,7 +1053,7 @@ HTML;
 
     //The student not in section variable indicates that an full access grader is viewing a student that is not in their
     //assigned section. canViewWholeGradeable determines whether hidden testcases can be viewed.
-    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading) {
+    public function hwGradingPage(Gradeable $gradeable, GradedGradeable $graded_gradeable, int $display_version, float $progress, bool $show_hidden_cases, bool $can_inquiry, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, int $late_status, int $rollback_submission, $sort, $direction, $from, array $solution_ta_notes, array $submitter_itempool_map, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
         $this->core->getOutput()->addInternalCss('admin-gradeable.css');
         $this->core->getOutput()->addInternalCss('ta-grading.css');
         $isPeerPanel = false;
@@ -1188,7 +1188,7 @@ HTML;
                     <div class="content-item content-item-right">
 HTML;
 
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderNavigationBar', $graded_gradeable, $progress, $gradeable->hasPeerComponent(), $sort, $direction, $from, ($this->core->getUser()->getGroup() === User::GROUP_LIMITED_ACCESS_GRADER && $gradeable->getLimitedAccessBlind() === 2), $anon_mode, $blind_grading, $clustering_enabled, $clusters_exist, $ta_grading_cluster_mode);
             $return .= $this->core->getOutput()->renderTemplate(
                 ['grading', 'ElectronicGrader'],
                 'renderGradingPanelHeader',
@@ -1235,7 +1235,7 @@ HTML;
         }
         //If TA grading isn't enabled, the rubric won't actually show up, but the template should be rendered anyway to prevent errors, as the code references the rubric panel
         if (!$isPeerGrader || $isPeerRubric) {
-            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader);
+            $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderRubricPanel', $graded_gradeable, $display_version, $can_verify, $show_verify_all, $show_silent_edit, $is_peer_grader, $ta_grading_cluster_mode, $is_unclustered);
         }
         if (!$isPeerGrader || $isPeerSolutions) {
             $return .= $this->core->getOutput()->renderTemplate(['grading', 'ElectronicGrader'], 'renderSolutionTaNotesPanel', $gradeable, $solution_ta_notes, $submitter_itempool_map);
@@ -1355,7 +1355,7 @@ HTML;
      * @param string $direction
      * @return string
      */
-    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading) {
+    public function renderNavigationBar(GradedGradeable $graded_gradeable, float $progress, bool $peer, $sort, $direction, $from, $limited_access_blind, $anon_mode, $blind_grading, bool $clustering_enabled = false, bool $clusters_exist = false, bool $ta_grading_cluster_mode = false) {
         $gradeable = $graded_gradeable->getGradeable();
         $isBlind = false;
         if (
@@ -1376,6 +1376,18 @@ HTML;
         if ($peer && $this->core->getUser()->getGroup() === 4) {
             $i_am_a_peer = true;
         }
+
+        $cluster_name = null;
+        $cluster_size = 0;
+        if ($ta_grading_cluster_mode && $clustering_enabled) {
+            $submitter_id = $graded_gradeable->getSubmitter()->getId();
+            $cluster = $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingCluster::class)->findClusterBySubmitter($gradeable->getId(), $submitter_id);
+            if ($cluster !== null) {
+                $cluster_name = $cluster->getClusterName() ?? "Cluster " . $cluster->getId();
+                $cluster_size = count($cluster->getMembers());
+            }
+        }
+
         return $this->core->getOutput()->renderTwigTemplate("grading/electronic/NavigationBar.twig", [
             "anon_mode" => $anon_mode,
             "peer_blind_grading" => $blind_grading,
@@ -1391,7 +1403,12 @@ HTML;
             'discussion_based' => $graded_gradeable->getGradeable()->isDiscussionBased(),
             'submitter' => $graded_gradeable->getSubmitter(),
             'team_assignment' => $gradeable->isTeamAssignment(),
-            'isBlind' => $isBlind
+            'isBlind' => $isBlind,
+            "clustering_enabled" => $clustering_enabled,
+            "clusters_exist" => $clusters_exist,
+            "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
+            "cluster_name" => $cluster_name,
+            "cluster_size" => $cluster_size
         ]);
     }
 
@@ -1724,7 +1741,7 @@ HTML;
      * @param bool $show_silent_edit
      * @return string
      */
-    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader) {
+    public function renderRubricPanel(GradedGradeable $graded_gradeable, int $display_version, bool $can_verify, bool $show_verify_all, bool $show_silent_edit, bool $is_peer_grader, bool $ta_grading_cluster_mode = false, bool $is_unclustered = true) {
         $return = "";
         $student_anon_ids = [];
         $gradeable = $graded_gradeable->getGradeable();
@@ -1788,6 +1805,8 @@ HTML;
                 "has_submission" => $has_submission,
                 "has_overridden_grades" => $has_overridden_grades,
                 "has_active_version" => $has_active_version,
+                "ta_grading_cluster_mode" => $ta_grading_cluster_mode,
+                "is_unclustered" => $is_unclustered,
                 "version_conflict" => $version_conflict,
                 "show_silent_edit" => $show_silent_edit,
                 "show_clear_conflicts" => $show_clear_conflicts,

--- a/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
@@ -1,6 +1,6 @@
 import { buildUrl } from '../../support/utils.js';
 
-describe('Grading Clustering Mode', () => {
+describe('Cluster Grading', () => {
     it('allows opening create modal and toggling cluster view', () => {
         cy.login();
         // Enable clustering at course level

--- a/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
@@ -44,4 +44,13 @@ describe('Grading Clustering Mode', () => {
         cy.get('button').contains('Create Clusters').should('not.exist');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
     });
+    it('hides clustering toggle icon on rubric panel when no clusters exist', () => {
+        cy.login();
+        cy.visit(['sample', 'config']);
+        cy.get('[data-testid="submission-clustering-enabled"]').check();
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=Oith0AebfRyC8xK&sort=id&direction=ASC']);
+
+        // The clustering toggle icon should not exist since clusters are not formed
+        cy.get('#toggle-cluster-mode').should('not.exist');
+    });
 });

--- a/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
@@ -10,19 +10,19 @@ describe('Cluster Grading', () => {
         cy.get('[data-testid="view-sections"]').click();
 
         // Verify initial state
-        cy.get('[data-testid="create-clusters-btn"]').should('be.visible');
+        cy.get('button').contains('Create Clusters').should('be.visible');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
 
         // Modal popup opens on click
-        cy.get('[data-testid="create-clusters-btn"]').click();
-        cy.get('[data-testid="create-clusters-modal"]').should('be.visible');
-        cy.get('[data-testid="create-clusters-form-title"]').contains('Create Clusters');
+        cy.get('button').contains('Create Clusters').click();
+        cy.get('.popup-window').should('be.visible');
+        cy.get('.form-title').contains('Create Clusters');
         cy.get('[data-testid="clustering-algorithm-select"]').should('be.visible');
         cy.get('[data-testid="clustering-algorithm-select"] option').contains('DummySplit').should('be.visible');
 
         // Close modal
-        cy.get('[data-testid="close-button"]:visible').click();
-        cy.get('[data-testid="create-clusters-modal"]:visible').should('not.exist');
+        cy.get('.form-title .close-button:visible').click();
+        cy.get('.popup-window:visible').should('not.exist');
     });
     it('hides clustering options when clustering is disabled', () => {
         cy.login();
@@ -33,7 +33,7 @@ describe('Cluster Grading', () => {
 
         // Verify clustering features are visible
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
-        cy.get('[data-testid="create-clusters-btn"]').should('be.visible');
+        cy.get('button').contains('Create Clusters').should('be.visible');
 
         // Disable clustering at course level
         cy.visit(['sample', 'config']);
@@ -41,7 +41,7 @@ describe('Cluster Grading', () => {
 
         // Check if buttons are hidden on the grading page
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
-        cy.get('[data-testid="create-clusters-btn"]').should('not.exist');
+        cy.get('button').contains('Create Clusters').should('not.exist');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
     });
     it('hides clustering toggle icon on rubric panel when no clusters exist', () => {

--- a/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
@@ -53,4 +53,13 @@ describe('Grading Clustering Mode', () => {
         cy.get('button').contains('Create Clusters').should('not.exist');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
     });
+    it('hides clustering toggle icon on rubric panel when no clusters exist', () => {
+        cy.login();
+        cy.visit(['sample', 'config']);
+        cy.get('[data-testid="submission-clustering-enabled"]').check();
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=Oith0AebfRyC8xK&sort=id&direction=ASC']);
+
+        // The clustering toggle icon should not exist since clusters are not formed
+        cy.get('#toggle-cluster-mode').should('not.exist');
+    });
 });

--- a/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
+++ b/site/cypress/e2e/Cypress-TAGrading/grading_clustering.spec.js
@@ -10,19 +10,19 @@ describe('Cluster Grading', () => {
         cy.get('[data-testid="view-sections"]').click();
 
         // Verify initial state
-        cy.get('button').contains('Create Clusters').should('be.visible');
+        cy.get('[data-testid="create-clusters-btn"]').should('be.visible');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
 
         // Modal popup opens on click
-        cy.get('button').contains('Create Clusters').click();
-        cy.get('.popup-window').should('be.visible');
-        cy.get('.form-title').contains('Create Clusters');
+        cy.get('[data-testid="create-clusters-btn"]').click();
+        cy.get('[data-testid="create-clusters-modal"]').should('be.visible');
+        cy.get('[data-testid="create-clusters-form-title"]').contains('Create Clusters');
         cy.get('[data-testid="clustering-algorithm-select"]').should('be.visible');
         cy.get('[data-testid="clustering-algorithm-select"] option').contains('DummySplit').should('be.visible');
 
         // Close modal
-        cy.get('.form-title .close-button:visible').click();
-        cy.get('.popup-window:visible').should('not.exist');
+        cy.get('[data-testid="close-button"]:visible').click();
+        cy.get('[data-testid="create-clusters-modal"]:visible').should('not.exist');
     });
     it('hides clustering options when clustering is disabled', () => {
         cy.login();
@@ -33,7 +33,7 @@ describe('Cluster Grading', () => {
 
         // Verify clustering features are visible
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
-        cy.get('button').contains('Create Clusters').should('be.visible');
+        cy.get('[data-testid="create-clusters-btn"]').should('be.visible');
 
         // Disable clustering at course level
         cy.visit(['sample', 'config']);
@@ -41,7 +41,7 @@ describe('Cluster Grading', () => {
 
         // Check if buttons are hidden on the grading page
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'details']);
-        cy.get('button').contains('Create Clusters').should('not.exist');
+        cy.get('[data-testid="create-clusters-btn"]').should('not.exist');
         cy.get('[data-testid="group-by-clusters-checkbox"]').should('not.exist');
     });
     it('hides clustering toggle icon on rubric panel when no clusters exist', () => {
@@ -51,6 +51,6 @@ describe('Cluster Grading', () => {
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=Oith0AebfRyC8xK&sort=id&direction=ASC']);
 
         // The clustering toggle icon should not exist since clusters are not formed
-        cy.get('#toggle-cluster-mode').should('not.exist');
+        cy.get('[data-testid="toggle-cluster-mode"]').should('not.exist');
     });
 });

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -136,6 +136,13 @@ aside {
     background-color: var(--subheading-underscore-grey);
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
+.ta-navlink-cont:hover,
+.ta-navlink-cont:hover i,
+.ta-navlink-cont:hover span {
+    color: initial;
+}
+
 .ta-navlink-cont button {
     cursor: pointer;
 }
@@ -173,6 +180,7 @@ button > i.fas:hover {
 
 /* stylelint-disable-next-line no-descending-specificity */
 .ta-navlink-cont {
+    color: var(--text-black);
     position: relative;
     margin-right: 4px;
     border: 2px solid var(--default-border-color);

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -136,13 +136,6 @@ aside {
     background-color: var(--subheading-underscore-grey);
 }
 
-/* stylelint-disable-next-line no-descending-specificity */
-.ta-navlink-cont:hover,
-.ta-navlink-cont:hover i,
-.ta-navlink-cont:hover span {
-    color: initial;
-}
-
 .ta-navlink-cont button {
     cursor: pointer;
 }
@@ -180,17 +173,11 @@ button > i.fas:hover {
 
 /* stylelint-disable-next-line no-descending-specificity */
 .ta-navlink-cont {
-    color: var(--text-black);
     position: relative;
     margin-right: 4px;
     border: 2px solid var(--default-border-color);
     border-radius: 5px;
     box-shadow: var(--default-box-shadow);
-}
-
-.gradeable .peer-version-conflict .indicator,
-.gradeable .peer-version-conflict .indicator i {
-    color: inherit;
 }
 
 #prev-student-navlink i,
@@ -365,7 +352,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern */
 #peer_info_btn {
-    border: 2px solid var(--standard-mediumorchid);
+    border: 2px solid var(--standard-plum-purple);
 }
 
 /* stylelint-disable selector-id-pattern */
@@ -373,7 +360,7 @@ progress::-webkit-progress-value {
 #peer_info_btn.active,
 #peer_info_select option:hover,
 #peer_info_select option:focus {
-    background: var(--standard-mediumorchid);
+    background: var(--standard-plum-purple);
 }
 /* stylelint-enable selector-id-pattern */
 
@@ -630,7 +617,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */
 #peer_info.rubric_panel {
-    border: 5px solid var(--standard-mediumorchid);
+    border: 5px solid var(--standard-plum-purple);
 }
 
 /* stylelint-disable-next-line selector-class-pattern, no-duplicate-selectors */
@@ -760,8 +747,8 @@ progress::-webkit-progress-value {
 }
 
 .icon-selected.fa-users {
-    box-shadow: 0 0 3px 3px var(--standard-mediumorchid);
-    background-color: var(--standard-mediumorchid);
+    box-shadow: 0 0 3px 3px var(--standard-plum-purple);
+    background-color: var(--standard-plum-purple);
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -1059,16 +1046,8 @@ tr.is_publish {
     cursor: default;
 }
 
-.gradeable .component .peer-component-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    font-size: 20px;
-}
-
 .gradeable .peer-border {
-    border: 3px solid var(--standard-mediumorchid);
+    border: 3px solid var(--standard-plum-purple);
 }
 
 .gradeable .component .badge-container.edit-mode {
@@ -1079,52 +1058,6 @@ tr.is_publish {
     color: var(--error-alert-dark-red);
     font-weight: bold;
     font-size: medium;
-}
-
-.gradeable .peer-version-warning {
-    margin: 5px 15px;
-}
-
-.gradeable .peer-version-conflict {
-    color: var(--error-alert-dark-red);
-    border-left: 2px solid var(--error-alert-dark-red);
-    border-right: 2px solid var(--error-alert-dark-red);
-}
-
-.gradeable .peer-version-conflict-top {
-    border-top: 2px solid var(--error-alert-dark-red);
-}
-
-.gradeable .peer-version-conflict-bottom {
-    border-bottom: 2px solid var(--error-alert-dark-red);
-}
-
-.gradeable #peer-grading-table {
-    border-collapse: collapse;
-}
-
-.peer-edit-marks-list {
-    clear: both;
-}
-
-.peer-edit-version-warning {
-    color: var(--error-alert-dark-red);
-    font-weight: bold;
-    clear: both;
-}
-
-.peer-edit-components {
-    margin-top: 15px;
-}
-
-.peer-edit-component:not(:last-child) {
-    margin-bottom: 15px;
-}
-
-.peer-component-save-status {
-    margin-left: 5px;
-    color: var(--standard-dark-green);
-    font-weight: bold;
 }
 
 .gradeable .graded-by {
@@ -1438,6 +1371,43 @@ tr.is_publish {
 
 .gradeable .received-marks-list.container .row .col-no-gutters.indicator {
     justify-content: center;
+}
+
+/* Mark conflict popup */
+
+#mark-conflict-popup div.mark-conflict-row {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+#mark-conflict-popup .mark-conflict-row span {
+    padding: 3px;
+    border-width: 2px;
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+}
+
+#mark-conflict-popup .mark-conflict-row .button-container {
+    width: 150px;
+}
+
+#mark-conflict-popup .mark-conflict-row .button-container input {
+    width: 100%;
+}
+
+#mark-conflict-popup .mark-conflict-row.mark-resolved,
+#mark-conflict-popup .mark-conflict-row.hidden {
+    display: none;
+}
+
+#mark-conflict-popup .conflict-resolve-progress {
+    width: fit-content;
+    margin: 0 auto;
+}
+
+#mark-conflict-popup .mark-conflict-container {
+    margin-top: 25px;
 }
 
 /* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */

--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -180,6 +180,11 @@ button > i.fas:hover {
     box-shadow: var(--default-box-shadow);
 }
 
+.gradeable .peer-version-conflict .indicator,
+.gradeable .peer-version-conflict .indicator i {
+    color: inherit;
+}
+
 #prev-student-navlink i,
 #next-student-navlink i {
     padding: 3px 14px;
@@ -352,7 +357,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern */
 #peer_info_btn {
-    border: 2px solid var(--standard-plum-purple);
+    border: 2px solid var(--standard-mediumorchid);
 }
 
 /* stylelint-disable selector-id-pattern */
@@ -360,7 +365,7 @@ progress::-webkit-progress-value {
 #peer_info_btn.active,
 #peer_info_select option:hover,
 #peer_info_select option:focus {
-    background: var(--standard-plum-purple);
+    background: var(--standard-mediumorchid);
 }
 /* stylelint-enable selector-id-pattern */
 
@@ -617,7 +622,7 @@ progress::-webkit-progress-value {
 
 /* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */
 #peer_info.rubric_panel {
-    border: 5px solid var(--standard-plum-purple);
+    border: 5px solid var(--standard-mediumorchid);
 }
 
 /* stylelint-disable-next-line selector-class-pattern, no-duplicate-selectors */
@@ -747,8 +752,8 @@ progress::-webkit-progress-value {
 }
 
 .icon-selected.fa-users {
-    box-shadow: 0 0 3px 3px var(--standard-plum-purple);
-    background-color: var(--standard-plum-purple);
+    box-shadow: 0 0 3px 3px var(--standard-mediumorchid);
+    background-color: var(--standard-mediumorchid);
 }
 
 /* stylelint-disable-next-line selector-class-pattern */
@@ -1046,8 +1051,16 @@ tr.is_publish {
     cursor: default;
 }
 
+.gradeable .component .peer-component-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    font-size: 20px;
+}
+
 .gradeable .peer-border {
-    border: 3px solid var(--standard-plum-purple);
+    border: 3px solid var(--standard-mediumorchid);
 }
 
 .gradeable .component .badge-container.edit-mode {
@@ -1058,6 +1071,52 @@ tr.is_publish {
     color: var(--error-alert-dark-red);
     font-weight: bold;
     font-size: medium;
+}
+
+.gradeable .peer-version-warning {
+    margin: 5px 15px;
+}
+
+.gradeable .peer-version-conflict {
+    color: var(--error-alert-dark-red);
+    border-left: 2px solid var(--error-alert-dark-red);
+    border-right: 2px solid var(--error-alert-dark-red);
+}
+
+.gradeable .peer-version-conflict-top {
+    border-top: 2px solid var(--error-alert-dark-red);
+}
+
+.gradeable .peer-version-conflict-bottom {
+    border-bottom: 2px solid var(--error-alert-dark-red);
+}
+
+.gradeable #peer-grading-table {
+    border-collapse: collapse;
+}
+
+.peer-edit-marks-list {
+    clear: both;
+}
+
+.peer-edit-version-warning {
+    color: var(--error-alert-dark-red);
+    font-weight: bold;
+    clear: both;
+}
+
+.peer-edit-components {
+    margin-top: 15px;
+}
+
+.peer-edit-component:not(:last-child) {
+    margin-bottom: 15px;
+}
+
+.peer-component-save-status {
+    margin-left: 5px;
+    color: var(--standard-dark-green);
+    font-weight: bold;
 }
 
 .gradeable .graded-by {
@@ -1371,43 +1430,6 @@ tr.is_publish {
 
 .gradeable .received-marks-list.container .row .col-no-gutters.indicator {
     justify-content: center;
-}
-
-/* Mark conflict popup */
-
-#mark-conflict-popup div.mark-conflict-row {
-    margin-top: 5px;
-    margin-bottom: 5px;
-}
-
-#mark-conflict-popup .mark-conflict-row span {
-    padding: 3px;
-    border-width: 2px;
-    margin: 0;
-    display: inline-flex;
-    align-items: center;
-}
-
-#mark-conflict-popup .mark-conflict-row .button-container {
-    width: 150px;
-}
-
-#mark-conflict-popup .mark-conflict-row .button-container input {
-    width: 100%;
-}
-
-#mark-conflict-popup .mark-conflict-row.mark-resolved,
-#mark-conflict-popup .mark-conflict-row.hidden {
-    display: none;
-}
-
-#mark-conflict-popup .conflict-resolve-progress {
-    width: fit-content;
-    margin: 0 auto;
-}
-
-#mark-conflict-popup .mark-conflict-container {
-    margin-top: 25px;
 }
 
 /* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */

--- a/site/vue/src/components/ta_grading/CreateClustersModal.vue
+++ b/site/vue/src/components/ta_grading/CreateClustersModal.vue
@@ -87,8 +87,9 @@ async function submitClustering() {
 <template>
   <button
     v-if="canCreateClustering"
-    class="btn btn-primary create-clusters-btn"
+    class="btn btn-primary"
     data-testid="create-clusters-btn"
+    style="margin-left: auto;"
     @click="toggleModal"
   >
     {{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}
@@ -97,20 +98,18 @@ async function submitClustering() {
   <Teleport to="body">
     <div
       v-if="showModal"
-      class="popup-form popup-form-active"
+      class="popup-form"
+      style="display: block;"
     >
       <div
         class="popup-box"
         @click.self="toggleModal"
       >
         <div
-          data-testid="create-clusters-modal"
-          class="popup-window clustering-modal-window"
+          class="popup-window"
+          style="width: 400px; margin: auto;"
         >
-          <div
-            data-testid="create-clusters-form-title"
-            class="form-title"
-          >
+          <div class="form-title">
             <h1>{{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}</h1>
             <button
               data-testid="close-button"
@@ -122,7 +121,7 @@ async function submitClustering() {
             </button>
           </div>
           <div class="form-body">
-            <p class="clustering-modal-text">
+            <p style="margin-bottom: 15px;">
               Select an algorithm to generate clusters for this gradeable.
             </p>
             <select
@@ -151,13 +150,16 @@ async function submitClustering() {
 
             <p
               v-if="selectedAlgorithm && algorithms[selectedAlgorithm]"
-              class="clustering-modal-desc"
+              style="margin-top: 15px;"
             >
               {{ algorithms[selectedAlgorithm].description }}
             </p>
 
             <div class="form-buttons">
-              <div class="form-button-container clustering-modal-buttons">
+              <div
+                class="form-button-container"
+                style="justify-content: flex-end; display: flex; gap: 10px;"
+              >
                 <a
                   class="btn btn-default close-button key_to_click"
                   tabindex="0"
@@ -184,26 +186,5 @@ async function submitClustering() {
 <style scoped>
 .clustering-select {
     width: 100%;
-}
-.create-clusters-btn {
-    margin-left: auto;
-}
-.popup-form-active {
-    display: block;
-}
-.clustering-modal-window {
-    width: 400px;
-    margin: auto;
-}
-.clustering-modal-text {
-    margin-bottom: 15px;
-}
-.clustering-modal-desc {
-    margin-top: 15px;
-}
-.clustering-modal-buttons {
-    justify-content: flex-end;
-    display: flex;
-    gap: 10px;
 }
 </style>

--- a/site/vue/src/components/ta_grading/CreateClustersModal.vue
+++ b/site/vue/src/components/ta_grading/CreateClustersModal.vue
@@ -87,9 +87,8 @@ async function submitClustering() {
 <template>
   <button
     v-if="canCreateClustering"
-    class="btn btn-primary"
+    class="btn btn-primary create-clusters-btn"
     data-testid="create-clusters-btn"
-    style="margin-left: auto;"
     @click="toggleModal"
   >
     {{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}
@@ -98,18 +97,20 @@ async function submitClustering() {
   <Teleport to="body">
     <div
       v-if="showModal"
-      class="popup-form"
-      style="display: block;"
+      class="popup-form popup-form-active"
     >
       <div
         class="popup-box"
         @click.self="toggleModal"
       >
         <div
-          class="popup-window"
-          style="width: 400px; margin: auto;"
+          data-testid="create-clusters-modal"
+          class="popup-window clustering-modal-window"
         >
-          <div class="form-title">
+          <div
+            data-testid="create-clusters-form-title"
+            class="form-title"
+          >
             <h1>{{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}</h1>
             <button
               data-testid="close-button"
@@ -121,7 +122,7 @@ async function submitClustering() {
             </button>
           </div>
           <div class="form-body">
-            <p style="margin-bottom: 15px;">
+            <p class="clustering-modal-text">
               Select an algorithm to generate clusters for this gradeable.
             </p>
             <select
@@ -150,16 +151,13 @@ async function submitClustering() {
 
             <p
               v-if="selectedAlgorithm && algorithms[selectedAlgorithm]"
-              style="margin-top: 15px;"
+              class="clustering-modal-desc"
             >
               {{ algorithms[selectedAlgorithm].description }}
             </p>
 
             <div class="form-buttons">
-              <div
-                class="form-button-container"
-                style="justify-content: flex-end; display: flex; gap: 10px;"
-              >
+              <div class="form-button-container clustering-modal-buttons">
                 <a
                   class="btn btn-default close-button key_to_click"
                   tabindex="0"
@@ -186,5 +184,26 @@ async function submitClustering() {
 <style scoped>
 .clustering-select {
     width: 100%;
+}
+.create-clusters-btn {
+    margin-left: auto;
+}
+.popup-form-active {
+    display: block;
+}
+.clustering-modal-window {
+    width: 400px;
+    margin: auto;
+}
+.clustering-modal-text {
+    margin-bottom: 15px;
+}
+.clustering-modal-desc {
+    margin-top: 15px;
+}
+.clustering-modal-buttons {
+    justify-content: flex-end;
+    display: flex;
+    gap: 10px;
 }
 </style>

--- a/site/vue/src/components/ta_grading/CreateClustersModal.vue
+++ b/site/vue/src/components/ta_grading/CreateClustersModal.vue
@@ -92,7 +92,7 @@ async function submitClustering() {
     style="margin-left: auto;"
     @click="toggleModal"
   >
-    Create Clusters
+    {{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}
   </button>
 
   <Teleport to="body">
@@ -110,7 +110,7 @@ async function submitClustering() {
           style="width: 400px; margin: auto;"
         >
           <div class="form-title">
-            <h1>Create Clusters</h1>
+            <h1>{{ currentAlgorithm ? 'Re-create Clusters' : 'Create Clusters' }}</h1>
             <button
               data-testid="close-button"
               class="btn btn-default close-button"

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -5,13 +5,25 @@ import PanelSelectorModal from '@/components/ta_grading/PanelSelectorModal.vue';
 import { showSettings } from '../../../../ts/ta-grading-keymap';
 import { exchangeTwoPanels, taLayoutDet, toggleFullScreenMode, getSavedTaLayoutDetails } from '../../../../ts/ta-grading-panels';
 
-const { homeUrl, prevStudentUrl, nextStudentUrl, progress } = defineProps<{
+import Cookies from 'js-cookie';
+
+const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, clustersExist, taGradingClusterMode } = defineProps<{
     homeUrl: string;
     prevStudentUrl: string;
     nextStudentUrl: string;
     progress: number;
+    clusteringEnabled?: boolean;
+    clustersExist?: boolean;
+    taGradingClusterMode?: boolean;
 }>();
-
+const toggleClusteringMode = () => {
+    if (!clustersExist) {
+        return; // Disabled if no clusters
+    }
+    const currentMode = taGradingClusterMode;
+    Cookies.set('ta_grading_cluster_mode', currentMode ? 'false' : 'true', { expires: 1, path: '/' });
+    window.location.reload();
+};
 const emit = defineEmits<{
     'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
 }>();
@@ -35,6 +47,15 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
     button-id="main-page"
     title="Go to the main page"
     :optional-href="homeUrl"
+  />
+
+  <NavigationButton
+    v-if="clusteringEnabled"
+    :on-click="toggleClusteringMode"
+    :visible-icon="taGradingClusterMode ? 'fa-user' : 'fa-users-rectangle'"
+    button-id="toggle-cluster-mode"
+    :title="clustersExist ? (taGradingClusterMode ? 'Clustering Mode: ON (Click to disable)' : 'Clustering Mode: OFF (Click to enable)') : 'No clusters available for this assignment'"
+    :style="!clustersExist ? 'opacity: 0.5; cursor: not-allowed;' : (taGradingClusterMode ? 'color: var(--standard-vibrant-yellow);' : '')"
   />
 
   <NavigationButton

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -7,10 +7,6 @@ import { exchangeTwoPanels, taLayoutDet, toggleFullScreenMode, getSavedTaLayoutD
 
 import Cookies from 'js-cookie';
 
-const emit = defineEmits<{
-    'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
-}>();
-
 const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, clustersExist, taGradingClusterMode } = defineProps<{
     homeUrl: string;
     prevStudentUrl: string;
@@ -19,6 +15,10 @@ const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, cl
     clusteringEnabled?: boolean;
     clustersExist?: boolean;
     taGradingClusterMode?: boolean;
+}>();
+
+const emit = defineEmits<{
+    'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
 }>();
 const toggleClusteringMode = () => {
     if (!clustersExist) {

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -104,7 +104,7 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
     <button
       id="toggle-cluster-mode"
       class="invisible-btn"
-      :title="taGradingClusterMode ? 'Clustering Mode: ON (Click to disable)' : 'Clustering Mode: OFF (Click to enable)'"
+      :title="taGradingClusterMode ? 'Cluster Grading: ON (Click to disable)' : 'Cluster Grading: OFF (Click to enable)'"
       style="display: flex; align-items: center;"
       @click="toggleClusteringMode"
     >
@@ -113,7 +113,7 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
         :class="taGradingClusterMode ? 'fa-chart-diagram' : 'fa-grip'"
       />
       <span style="margin-left: 5px; padding-right: 5px; font-size: 16px; color: var(--text-black);">
-        {{ taGradingClusterMode ? 'Clustering Mode ON' : 'Clustering Mode OFF' }}
+        {{ taGradingClusterMode ? 'Cluster Grading ON' : 'Cluster Grading OFF' }}
       </span>
     </button>
   </span>

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -4,17 +4,29 @@ import NavigationButton from '@/components/ta_grading/NavigationButton.vue';
 import PanelSelectorModal from '@/components/ta_grading/PanelSelectorModal.vue';
 import { showSettings } from '../../../../ts/ta-grading-keymap';
 import { exchangeTwoPanels, taLayoutDet, toggleFullScreenMode, getSavedTaLayoutDetails } from '../../../../ts/ta-grading-panels';
+import Cookies from 'js-cookie';
 
-const { homeUrl, prevStudentUrl, nextStudentUrl, progress } = defineProps<{
+const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, clustersExist, taGradingClusterMode } = defineProps<{
     homeUrl: string;
     prevStudentUrl: string;
     nextStudentUrl: string;
     progress: number;
+    clusteringEnabled?: boolean;
+    clustersExist?: boolean;
+    taGradingClusterMode?: boolean;
 }>();
 
 const emit = defineEmits<{
     'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
 }>();
+const toggleClusteringMode = () => {
+    if (!clustersExist) {
+        return; // Disabled if no clusters
+    }
+    const currentMode = taGradingClusterMode;
+    Cookies.set('ta_grading_cluster_mode', currentMode ? 'false' : 'true', { expires: 1, path: '/' });
+    window.location.reload();
+};
 
 // need to assign because ta-grading-panels-init.ts is not called
 Object.assign(taLayoutDet, getSavedTaLayoutDetails());
@@ -84,6 +96,27 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
     optional-spanid="grading-setting-btn"
     optional-test-id="grading-setting-btn"
   />
+  <span
+    v-if="clusteringEnabled && clustersExist"
+    id="toggle-cluster-mode-cont"
+    class="ta-navlink-cont"
+  >
+    <button
+      id="toggle-cluster-mode"
+      class="invisible-btn"
+      :title="taGradingClusterMode ? 'Clustering Mode: ON (Click to disable)' : 'Clustering Mode: OFF (Click to enable)'"
+      style="display: flex; align-items: center;"
+      @click="toggleClusteringMode"
+    >
+      <i
+        class="fas icon-header icon-streched"
+        :class="taGradingClusterMode ? 'fa-chart-diagram' : 'fa-grip'"
+      />
+      <span style="margin-left: 5px; padding-right: 5px; font-size: 16px; color: var(--text-black);">
+        {{ taGradingClusterMode ? 'Clustering Mode ON' : 'Clustering Mode OFF' }}
+      </span>
+    </button>
+  </span>
   <span
     id="progress-bar-cont"
     class="ta-navlink-cont"

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -4,7 +4,6 @@ import NavigationButton from '@/components/ta_grading/NavigationButton.vue';
 import PanelSelectorModal from '@/components/ta_grading/PanelSelectorModal.vue';
 import { showSettings } from '../../../../ts/ta-grading-keymap';
 import { exchangeTwoPanels, taLayoutDet, toggleFullScreenMode, getSavedTaLayoutDetails } from '../../../../ts/ta-grading-panels';
-import Cookies from 'js-cookie';
 
 const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, clustersExist, taGradingClusterMode } = defineProps<{
     homeUrl: string;
@@ -18,14 +17,13 @@ const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, cl
 
 const emit = defineEmits<{
     'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
+    'toggle-cluster-mode': [];
 }>();
 const toggleClusteringMode = () => {
     if (!clustersExist) {
         return; // Disabled if no clusters
     }
-    const currentMode = taGradingClusterMode;
-    Cookies.set('ta_grading_cluster_mode', currentMode ? 'false' : 'true', { expires: 1, path: '/' });
-    window.location.reload();
+    emit('toggle-cluster-mode');
 };
 
 // need to assign because ta-grading-panels-init.ts is not called
@@ -103,16 +101,16 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
   >
     <button
       id="toggle-cluster-mode"
-      class="invisible-btn"
+      data-testid="toggle-cluster-mode"
+      class="invisible-btn cluster-mode-btn"
       :title="taGradingClusterMode ? 'Cluster Grading: ON (Click to disable)' : 'Cluster Grading: OFF (Click to enable)'"
-      style="display: flex; align-items: center;"
       @click="toggleClusteringMode"
     >
       <i
         class="fas icon-header icon-streched"
         :class="taGradingClusterMode ? 'fa-chart-diagram' : 'fa-grip'"
       />
-      <span style="margin-left: 5px; padding-right: 5px; font-size: 16px; color: var(--text-black);">
+      <span class="cluster-mode-text">
         {{ taGradingClusterMode ? 'Cluster Grading ON' : 'Cluster Grading OFF' }}
       </span>
     </button>
@@ -131,3 +129,16 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
     </span>
   </span>
 </template>
+
+<style scoped>
+.cluster-mode-btn {
+    display: flex;
+    align-items: center;
+}
+.cluster-mode-text {
+    margin-left: 5px;
+    padding-right: 5px;
+    font-size: 16px;
+    color: var(--text-black);
+}
+</style>

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -50,12 +50,12 @@ function selectLayout(layout: { panels: number; isLeftTaller: boolean; twoInRigh
   />
 
   <NavigationButton
-    v-if="clusteringEnabled"
+    v-if="clusteringEnabled && clustersExist"
     :on-click="toggleClusteringMode"
-    :visible-icon="taGradingClusterMode ? 'fa-user' : 'fa-users-rectangle'"
+    :visible-icon="taGradingClusterMode ? 'fa-chart-diagram' : 'fa-timeline'"
     button-id="toggle-cluster-mode"
-    :title="clustersExist ? (taGradingClusterMode ? 'Clustering Mode: ON (Click to disable)' : 'Clustering Mode: OFF (Click to enable)') : 'No clusters available for this assignment'"
-    :style="!clustersExist ? 'opacity: 0.5; cursor: not-allowed;' : (taGradingClusterMode ? 'color: var(--standard-vibrant-yellow);' : '')"
+    :title="taGradingClusterMode ? 'Clustering Mode: ON (Click to disable)' : 'Clustering Mode: OFF (Click to enable)'"
+    :style="taGradingClusterMode ? 'color: var(--standard-vibrant-yellow);' : ''"
   />
 
   <NavigationButton

--- a/site/vue/src/components/ta_grading/TaGradingToolbar.vue
+++ b/site/vue/src/components/ta_grading/TaGradingToolbar.vue
@@ -7,6 +7,10 @@ import { exchangeTwoPanels, taLayoutDet, toggleFullScreenMode, getSavedTaLayoutD
 
 import Cookies from 'js-cookie';
 
+const emit = defineEmits<{
+    'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
+}>();
+
 const { homeUrl, prevStudentUrl, nextStudentUrl, progress, clusteringEnabled, clustersExist, taGradingClusterMode } = defineProps<{
     homeUrl: string;
     prevStudentUrl: string;
@@ -24,9 +28,6 @@ const toggleClusteringMode = () => {
     Cookies.set('ta_grading_cluster_mode', currentMode ? 'false' : 'true', { expires: 1, path: '/' });
     window.location.reload();
 };
-const emit = defineEmits<{
-    'select-layout': [layout: { panels: number; isLeftTaller: boolean; twoInRight: boolean }];
-}>();
 
 // need to assign because ta-grading-panels-init.ts is not called
 Object.assign(taLayoutDet, getSavedTaLayoutDetails());


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This PR essentially adds the cluster-grading feature while adding the necessary UI also. This PR is built on top of #12966 .
### What is the New Behavior?
1) A toggle icon to get the TAs in-and-out of the clustering mode.
2) A persistent banner while TAs are in clustering mode reminding the effect this feature brings in.
3) Any student the TA grades while being in the Clustering mode, the grade applies to all the students within that cluster. But if the student is currently "Unclustered", the student shall be graded individually/ normally.
### What steps should a reviewer take to reproduce or test the bug or new feature?
1) Go to course setting as an Instructor and check the Enable Submission Clustering feature.
2) Go to any gradeable, if clusters have not been formed yet, click on the 'Create Clusters' button.
3) After clicking you would notice that button has changed to "Re-create Clusters".
4) Go to  rubric pannel of any student, you would notice the following things-
<img width="1533" height="567" alt="image" src="https://github.com/user-attachments/assets/8f632ab1-f061-478b-a597-6d3b40577009" />


- Click on the icon to toggle in-and-out of clustering mode. 
- A sticky persistent banner which appears when the clustering mode is enabled.
- You would also notice that the cluster the student belongs to and the number of students in that cluster also appears in the top-right.
- Silent regrading is not allowed.
5) All of these things should be visible only when you are inside cluster-mode.
6) Grade a student while inside clustering mode on any of the rubric component,  verify the exact grade gets applied to all the students within that cluster. And all other necessary things like 'who graded' are also updated.

Conflict check-  (Attempt this in the order mentioned)
1) Login as an instructor on one browser.
2) Go to the details page and note a student who currently has an Active submission and note the Active version. Login as that student on another browser.
3) Go the grading page of that particular student.
4) Change the active version of the student in the student browser.
5) Now as the instructor while being inside Clustering Mode, try to grade any rubric component.
You should notice that after you grade, the grade does not actually apply to all the students within that cluster because the student actually changed the active version (after the clusters were formed intially). Hence that student must be considered as "Unclustered" and graded henceforth.

Currently there is no method for the TA to know what all the students have been skipped in the following manner, but considering how rare it will be, a separate issue will be opened regarding this. But for now this is out-of-scope for this PR.
### Automated Testing & Documentation
Grading_clustering.spec.js has been modified.
### Other information
If you want to delete the cluster already created use-
sudo -u postgres psql -d submitty_f26_sample -c "DELETE FROM ta_grading_clustering_configs WHERE g_id = 'GRADEABLE ID';"