### PR TITLE
[Bugfix:System] Fix autograding cli build

### DIFF
--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -2,6 +2,22 @@
 # HELPER FUNCTION FOR INSTALLING INDIVIDUAL HOMEWORKS
 ##########################################################################
 
+##########################################################################
+# Check if this function is being run by daemon/root
+##########################################################################
+
+function is_daemon_or_root {
+    if [[ "$UID" -eq 0 ]]; then
+        return 0
+    fi
+    # the daemon user's name is installation specific, so read it from the config.
+    # stderr is discarded because submitty_users.json is not readable by
+    # instructors -- which itself means this is not the daemon.
+    local daemon_user
+    daemon_user=$(jq -r '.daemon_user // empty' "${SUBMITTY_INSTALL_DIR}/config/submitty_users.json" 2>/dev/null)
+    [[ -n "$daemon_user" && "$(whoami)" == "$daemon_user" ]]
+}
+
 function clean_homework {
     # which assignment to cleanup
     semester="$1"
@@ -179,7 +195,7 @@ function build_homework {
     fi
 
     # if this script is run by root or the submitty_daemon user, then run the set allowed minutes script
-    if [[ "$UID" -eq 0 || "$(whoami)" == "submitty_daemon" ]]; then
+    if is_daemon_or_root; then
         # Add allowed minutes in database from config if exists
         python3 "${SUBMITTY_INSTALL_DIR}/bin/set_allowed_mins.py" "${hw_build_path}/complete_config.json" "${semester}" "${course}" "${assignment}"
         set_minutes="$?"
@@ -245,9 +261,9 @@ function build_homework {
 
     # only the daemon (or root) can read database.json, so skip this for
     # instructor command line builds
-    if [[ "$UID" -eq 0 || "$(whoami)" == "submitty_daemon" ]]; then
-        # insert the gradeable data into the db
-        "$SUBMITTY_INSTALL_DIR"/bin/insert_build_data.py "$hw_config" "$assignment" "$semester" "$course"
+    if is_daemon_or_root; then
+    # insert the gradeable data into the db
+    "$SUBMITTY_INSTALL_DIR"/bin/insert_build_data.py "$hw_config" "$assignment" "$semester" "$course"
     else
         echo -e "\nWARNING:  Autograding testcase data was not inserted into the database.  To update it, this gradeable must be rebuilt by the daemon (via the web interface) or the build script must be run as root."
     fi

--- a/bin/build_homework_function.sh
+++ b/bin/build_homework_function.sh
@@ -243,12 +243,13 @@ function build_homework {
     # generate queue file for generated_output
     "$SUBMITTY_INSTALL_DIR"/bin/make_generated_output.py "$hw_source" "$assignment" "$semester" "$course"
 
-    # if this script is run by root or the submitty_daemon user, then run the set allowed minutes script
-    if [[ "$UID" -eq 0 ]]; then
+    # only the daemon (or root) can read database.json, so skip this for
+    # instructor command line builds
+    if [[ "$UID" -eq 0 || "$(whoami)" == "submitty_daemon" ]]; then
         # insert the gradeable data into the db
         "$SUBMITTY_INSTALL_DIR"/bin/insert_build_data.py "$hw_config" "$assignment" "$semester" "$course"
     else
-        echo -e "\nWARNING:  To insert the autograding data to the database, the build_homework_function script must be run as sudo."
+        echo -e "\nWARNING:  Autograding testcase data was not inserted into the database.  To update it, this gradeable must be rebuilt by the daemon (via the web interface) or the build script must be run as root."
     fi
 
     fix_permissions "$hw_config" "$hw_bin_path" "$hw_build_path" "$course_dir" "$assignment" "$course_group"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Described in [PR#12134](https://github.com/Submitty/Submitty/pull/12134), we had some changes that broke instructor command line builds of homework assignments. This had to due with the permissions of whoever was running the script.

### What is the New Behavior?
A check has been added to see if the person calling the `build_homework_function.sh` is root or the daemon. If they are not, the scripts that require database access will not be run.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Check out the branch and run `submitty_install`
2. Go to any gradeable with autograding (c system calls has some)
3. Click the pencil icon and from the submissions/autograding tab, click rebuild
4. You should see in the log that there were testcases inserted into the database
5. ssh into the VM as instructor with `ssh -p 2222 instructor@127.0.0.1`
6. Follow the instructions for command line builds [here](https://submitty.org/instructor/assignment_preparation/index#builddebug-all-grading-configurations), test rebuilding the home with the command line (the c system calls id is `grades_released_homework_autota`)
7. you should see some warnings as the homework builds, which is what should happen

### Automated Testing & Documentation
This feature is not covered by E2E tests.

### Other information
Not a breaking change.
No migrations.
Not a security concern.
