### PR TITLE
[Bugfix:System] fix create_course /var/submitty/config

### DIFF
--- a/.setup/set_config_permissions.py
+++ b/.setup/set_config_permissions.py
@@ -33,7 +33,7 @@ parser.add_argument('--worker', action='store_true', default=False,
 args = parser.parse_args()
 
 SUBMITTY_INSTALL_DIR = args.install_dir
-SUBMITTY_DIRECTORY_DIR = '/var/submitty/config'
+SUBMITTY_DIRECTORY_DIR = '/var/local/submitty/config'
 SUBMITTY_DIRECTORY_JSON = os.path.join(SUBMITTY_DIRECTORY_DIR, 'submitty.json')
 
 os.makedirs(SUBMITTY_DIRECTORY_DIR, exist_ok=True)

--- a/sbin/create_course.sh
+++ b/sbin/create_course.sh
@@ -12,7 +12,7 @@ fi
 ########################################################################################################################
 ########################################################################################################################
 
-CONF_DIR="/var/submitty/config"
+CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../config
 SUBMITTY_INSTALL_DIR=$(jq -r '.submitty_install_dir' "${CONF_DIR}/submitty.json")
 CONF_DIR="$SUBMITTY_INSTALL_DIR/config"
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The `submitty_install` process was updated in PR #12438 
I encountered an issue where, on main, running submitty_install would then prevent me from creating courses in the future. I tracked it down to what appear to be issues with the config paths in these two files.
<img width="1056" height="292" alt="image" src="https://github.com/user-attachments/assets/00924bf6-f305-4547-8aa0-dc678841951a" />


### What is the New Behavior?
1) in set_config_permissions.py, SUBMITTY_DIRECTORY_DIR has been updated from /var/submitty/config to /var/local/submitty/config

2) in create_course .sh, the Update Install Process PR hardcoded the directory to /var/submitty/config , and has now been updated to hardcode the path to /var/local/submitty/config

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On main:
- run `submitty_install`
- login as instructor and attempt to create a new course, it will say it has been queued for creation but never actually appear.
- you can verify the course was not created by doing, in the vm, `cd /var/local/submitty/courses/f26` and running `ls`. 

2. On the new branch:
- run `submitty_install`
- login as instructor and create a new course, this time it should work.
- you can verify information about the course by doing, in the vm, `cd /var/local/submitty/courses/f26`

### Automated Testing & Documentation
Course creation is not tested on CI except for by sync_notifications.spec.js
New tests are being added in #13111 . 

### Other information
This PR has an incorrect approach to fixing the issue and will be closed upon the completion of PR #13143 .
