### PR TITLE
[Bugfix:SubminiPolls] poll updateTimer setInterval inc time

### DIFF
--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -461,6 +461,7 @@ describe('Test cases revolving around polls functionality', () => {
 
         cy.contains('Poll Cypress Test').siblings(':nth-child(8)').click();
         cy.get('[data-testid="timer"]').should('be.visible');
+        // this timeout is set to 30 seconds because Cypress needs to wait for the poll to end.
         cy.get('[data-testid="timer"]', { timeout: 30000 }).should('contain', 'Poll Ended');
         cy.go('back');
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().should('not.be.checked');

--- a/site/cypress/e2e/Cypress-Feature/polls.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/polls.spec.js
@@ -461,7 +461,7 @@ describe('Test cases revolving around polls functionality', () => {
 
         cy.contains('Poll Cypress Test').siblings(':nth-child(8)').click();
         cy.get('[data-testid="timer"]').should('be.visible');
-        cy.get('[data-testid="timer"]', { timeout: 20000 }).should('contain', 'Poll Ended');
+        cy.get('[data-testid="timer"]', { timeout: 30000 }).should('contain', 'Poll Ended');
         cy.go('back');
         cy.contains('Poll Cypress Test').siblings(':nth-child(6)').children().should('not.be.checked');
 

--- a/site/public/js/polls.js
+++ b/site/public/js/polls.js
@@ -244,7 +244,7 @@ function updateTimer(endDate) {
         timerDisplayElement.text(`${hoursUpdated}:${minutesUpdated}:${secondsUpdated}`);
     }
 
-    const timerId = setInterval(tick, 20);
+    const timerId = setInterval(tick, 500);
 }
 
 function toggle_section(section_id) {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Aims to deflake the poll spec. 
Polls spec is flaky waiting for a poll to end, when I test locally there are about 10 seconds left. The timer is set to 20 seconds. I thought that it might be because of how often the updateTimer function is running on an interval, so I increased the interval.


### What is the New Behavior?
The updateTimer function in polls.js has had the interval increased from 20 ms to 500 ms. This will hopefully make the timer more stable, while still keeping the poll timer visible to the student in sync / accurate.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. verify that poll timers still work as intended:
- create a poll as instructor (add a response, expected release date, appropriate timer)
- set the time
- login as student and answer the poll
- you should see the timer tick down 1 second per second.
2. verify that polls.spec.js passes locally and on CI

### Automated Testing & Documentation
yes

### Other information
DO NOT MERGE YET
This PR was created in part to test PR #13039 
