### PR TITLE
[Bugfix:Testing] save status in forum

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2588,6 +2588,9 @@ class Gradeable extends AbstractModel {
 
     public function setDiscussionBased(bool $discussion_based): void {
         $this->discussion_based = $discussion_based;
+        if (!$discussion_based) {
+            $this->discussion_thread_id = [];
+        }
         $this->modified = true;
     }
 

--- a/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableCreate.twig
@@ -164,7 +164,7 @@
                         <legend>Is there a discussion component for this assignment?</legend>
                         <input type="radio" id="yes_discussion" name="discussion_based" value="true" class="bool_val auto_save date-related" data-testid="yes-discussion"
                                 {{ action != 'new' and gradeable.isDiscussionBased() ? 'checked' : '' }} /> <label for="yes_discussion">Yes</label>
-                        <input type="radio" id="no_discussion" name="discussion_based" value="false" class="bool_val auto_save date-related"
+                        <input type="radio" id="no_discussion" name="discussion_based" value="false" class="bool_val auto_save date-related" data-testid="no-discussion"
                                 {{ not (action != 'new' and gradeable.isDiscussionBased()) ? 'checked' : '' }} /> <label for="no_discussion">No</label>
 
                         <div class="discussion_id_wrapper">

--- a/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
@@ -1,6 +1,14 @@
 describe('test for discussion post panel', () => {
-    it('Enable discussion form and post', () => {
+    before(() => {
         cy.login();
+        // Reset the gradeable to the expected state
+        cy.visit(['sample', 'gradeable', 'grading_homework', 'update']);
+        // toggle between options to trigger the save status
+        cy.get('[data-testid="yes-discussion"]').click();
+        cy.get('[data-testid="no-discussion"]').click();
+        cy.get('[data-testid="save-status"]', { timeout: 30000 }).should('contain', 'All Changes Saved');    });
+
+    it('Enable discussion form and post', () => {
         cy.visit(['sample', 'config']);
         cy.get('[data-testid="forum-enabled"]').should('be.checked');
 

--- a/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
@@ -3,18 +3,23 @@ describe('test for discussion post panel', () => {
         cy.login();
         cy.visit(['sample', 'config']);
         cy.get('[data-testid="forum-enabled"]').should('be.checked');
+
         cy.visit(['sample', 'gradeable', 'grading_homework', 'update']);
         cy.get('[data-testid="yes-discussion"]').click();
         cy.get('[data-testid="yes-discussion"]').should('be.checked');
+        cy.get('[data-testid="save-status"]', { timeout: 30000 }).should('contain', 'All Changes Saved');
+
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=L1LdxbPPN5GiLb4&sort=id&direction=ASC']);
         cy.get('[data-testid="discussion-browser-btn"]').type('{D}');
         cy.get('[data-testid="posts-list"]').should('contain', 'Discussion Posts');
         cy.get('[data-testid="posts-list"]').should('contain', 'No thread id specified.');
         cy.get('[data-testid="posts-list"]').should('not.contain', 'Go to thread');
+
         cy.visit(['sample', 'gradeable', 'grading_homework', 'update']);
         cy.get('[data-testid="discussion-thread-id"]').type('1,2,3');
         cy.get('[data-testid="discussion-thread-id"]').type('{enter}');
         cy.get('[data-testid="save-status"]', { timeout: 30000 }).should('contain', 'All Changes Saved');
+
         cy.visit(['sample', 'gradeable', 'grading_homework', 'grading', 'grade?who_id=L1LdxbPPN5GiLb4&sort=id&direction=ASC']);
         cy.get('[data-testid="posts-list"]').should('contain', 'No posts for thread id: 1');
         cy.get('[data-testid="create-post-head"]').first().should('contain', '(2) Homework 1 print clarification');

--- a/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/discussion_post.spec.js
@@ -6,7 +6,8 @@ describe('test for discussion post panel', () => {
         // toggle between options to trigger the save status
         cy.get('[data-testid="yes-discussion"]').click();
         cy.get('[data-testid="no-discussion"]').click();
-        cy.get('[data-testid="save-status"]', { timeout: 30000 }).should('contain', 'All Changes Saved');    });
+        cy.get('[data-testid="save-status"]', { timeout: 30000 }).should('contain', 'All Changes Saved');
+    });
 
     it('Enable discussion form and post', () => {
         cy.visit(['sample', 'config']);


### PR DESCRIPTION
### Why is this Change Important & Necessary?
the discussion_post.spec.js is flaky due to a race condition between the save status of the discussion forum setting in the gradeable and the next login command. 

### What is the New Behavior?
The cypress spec has been updated to check the save status when enabling the discussion forum posts on the testing gradeable, which implicitly calls a timeout. 

### What steps should a reviewer take to reproduce or test the bug or new feature?
Observe that the spec now consistently passes locally and on CI

### Automated Testing & Documentation
yes

### Other information
This PR was created in part to test PR #13039 
This PR also fixes an issue where switching from 'yes' to 'no' for the discussion forum option on a gradeable would not clear the typed thread ids.
