### PR TITLE
[Bugfix:TAGrading] Peer Grader Halflight Fix

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -487,7 +487,7 @@
                         {% endif %}
                     {% elseif info.graded_groups[index] == "peer-right-half" %}
                         {# Indicates Component graded only by current user #}
-                        <div title="{{ title }}" class="grading-circle grader-peer-right-half"></div>
+                        <div title="{{ title }}" class="grading-circle grader-4"></div>
                     {% elseif info.graded_groups[index] == 4 %}
                         <div title="{{ title }}" class="grading-circle grader-{{ info.graded_groups[index] }}"></div>
                     {% endif %}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Peer graders should not be seeing half stoplights. There was a bug where peer graders were seeing the right half stoplight when they are the only one's who graded a student instead of the full stoplight.

### What is the New Behavior?
Peer graders now only see full stoplight or nothing at all
Before:
<img width="952" height="72" alt="image" src="https://github.com/user-attachments/assets/0f77b625-cc9e-4223-89ca-a43898bb23dc" />

After:
<img width="953" height="65" alt="image" src="https://github.com/user-attachments/assets/5956e29f-fcb9-488b-b7d7-63dae178428f" />


### What steps should a reviewer take to reproduce or test the bug or new feature?
1. as student, peer grade another student on Released Peer PDF Homework
2. as instructor, remove instructor peer grade from the graded student
3.  as student, verify you see full stoplight for graded student on details page

### Automated Testing & Documentation
No testing added

### Other information
Not a breaking change
No migrations
Not a security concern
