### PR TITLE
[Testing:Testing] Add registration date test

### DIFF
--- a/site/app/templates/admin/users/UserForm.twig
+++ b/site/app/templates/admin/users/UserForm.twig
@@ -109,7 +109,7 @@
         </label>
         <label for="user_date_registered" class="full-width">
             Registration date:
-            <input class="readonly" type="text" id="user_date_registered" readonly="readonly" value="N/A">
+            <input class="readonly" type="text" id="user_date_registered" data-testid="user-date-registered" readonly="readonly" value="N/A">
         </label>
         <fieldset id="user-form-assigned-sections" class="full-width" hidden>
             <legend style="font-weight:bold;font-size:16pt">Assigned Registration Sections for Grading</legend>

--- a/site/cypress/e2e/Cypress-Feature/registration.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/registration.spec.js
@@ -94,15 +94,26 @@ describe('Tests for self registering for courses', () => {
         cy.login('instructor2');
         cy.visit(['testing', 'users']);
         cy.get('[data-testid="edit-student-gutmal-button"]').click();
+        cy.get('#user_date_registered')
+            .should('have.attr', 'readonly')
+            .invoke('val')
+            .should((value) => {
+                expect(value).to.not.equal('N/A');
+                expect(value).to.not.equal('');
+            });
         cy.get('[data-testid="registration-section-dropdown"]').select('Not Registered');
-        cy.get('[data-testid="submit-user-form-button"]').click();
+
         cy.intercept(
             {
                 url: `/courses/${getCurrentSemester()}/testing/user_information`,
                 times: 1,
             },
         ).as('userInformation');
+
+        cy.get('[data-testid="submit-user-form-button"]').click();
+
         cy.get('[data-testid="popup-message"]').should('contain', 'User \'gutmal\' updated');
+
         cy.wait('@userInformation');
         cy.logout();
         cy.login('gutmal');

--- a/site/cypress/e2e/Cypress-Feature/registration.spec.js
+++ b/site/cypress/e2e/Cypress-Feature/registration.spec.js
@@ -94,7 +94,7 @@ describe('Tests for self registering for courses', () => {
         cy.login('instructor2');
         cy.visit(['testing', 'users']);
         cy.get('[data-testid="edit-student-gutmal-button"]').click();
-        cy.get('#user_date_registered')
+        cy.get('[data-testid="user-date-registered"]')
             .should('have.attr', 'readonly')
             .invoke('val')
             .should((value) => {


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Partially addresses #13032 by adding Cypress end-to-end test coverage for the registration date feature introduced in #13011.
The test verifies that the registration date is correctly displayed and populated for students after self-registration.

### What is the New Behavior?
The Cypress test verifies that:
* The registration date field is present in the instructor's Edit Student form (`#edit-user-form`).
* The registration date field is read-only.
* The registration date field is populated after a student self-registers.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Run the Submitty Cypress Feature tests.
2. Log in as an instructor (`instructor2`).
3. Navigate to the testing users page (`/courses/<term>/testing/users`).
4. Open the Edit Student form for student `gutmal`.
5. Verify that the registration date field is present, read-only, and displays the correct registration date.

### Automated Testing & Documentation
This PR adds Cypress end-to-end coverage for the registration date feature in `site/cypress/e2e/Cypress-Feature/registration.spec.js`.
No additional documentation updates required.

### Other information
This change does not introduce breaking changes, database migrations, or security concerns.