### PR TITLE
[Refactor:Forum] Migrate UserInfoBlock to Vue

### DIFF
--- a/site/app/templates/forum/CreatePost.twig
+++ b/site/app/templates/forum/CreatePost.twig
@@ -95,31 +95,27 @@
         }
     } only %}
 
-    <span class="post-action-container">
+    <div class="post-action-container">
 
-        {% if userGroup <= 2 and post.author.id != current_user %}
-            <a class="post-email-toggle key_to_click" tabindex = "0" onClick='$(this).next().toggle();' title="Show/Hide email address" aria-label="Show/Hide email address"><i class="fas fa-envelope"></i></a>
-            <a href="mailto:{{ author_email }}" style="display: none;">{{ author_email }}</a>
-        {% endif %}
-
-        {% if userGroup <= 2 %}
-            <a class="post-user-info key_to_click" tabindex = "0" onClick='changeName(this.parentNode, {{ post_user_info.info_name }}, {{ post_user_info.visible_user_json}}, {{ post_user_info.jscriptAnonFix}})' title="Show full user information" aria-label="Show full user information"><i class="fas fa-eye"></i></a>
-        {% endif %}
-
-        <span class="last-edit" data-testid="last-edit">
-            {% if post_user_info.is_OP == true and first == false %}
-			    <strong class="post_user_id" data-testid="post-user-id" title="Original Poster"><span class="author-name">{{ visible_username }}</span> <span style="color: var(--standard-medium-vibrant-blue);"><strong>OP</strong></span></strong>
-            {% else %}
-                <strong class="post_user_id" data-testid="post-user-id"><span class="author-name">{{ visible_username }}</span></strong>
-            {% endif %}
-            {% if post_user_info.pronouns and post_user_info.display_pronouns and visible_username !="Anonymous" %}
-                <strong class="post_user_pronouns" data-testid="post-user-pronouns">({{post_user_info.pronouns}})</strong>
-            {% endif %}
-			{{ post_date }}
-            {% if edit_date is not null %}
-                (<i>Last edit at {{ edit_date }}</i>)
-            {% endif %}
-        </span>
+        {% include "Vue.twig" with {
+            type: "component",
+            name: "forum/UserInfoBlock",
+            style: "display: inline;",
+            args: {
+                username: visible_username,
+                fullName: post_user_info.full_name,
+                isAnonymous: post_user_info.is_anonymous,
+                isOP: post_user_info.is_OP and not first,
+                pronouns: post_user_info.pronouns,
+                showPronouns: post_user_info.pronouns and post_user_info.display_pronouns and visible_username != 'Anonymous',
+                postDate: post_date,
+                editDate: edit_date,
+                authorEmail: author_email,
+                showEmailToggle: userGroup <= 2 and post.author.id != current_user,
+                showUserInfoToggle: userGroup <= 2,
+            },
+            events: {},
+        } only %}
 
         <a class="pinned-thread key_to_click" tabindex="0" data-testid="thread-dropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Options">
             <i class="fas fa-ellipsis-v"></i>
@@ -136,7 +132,7 @@
             {% endif %}
         </div>
 
-    </span>
+    </div>
     </div>
 
     {% if post_attachment.exist == true %}

--- a/site/app/views/forum/ForumThreadView.php
+++ b/site/app/views/forum/ForumThreadView.php
@@ -822,6 +822,8 @@ class ForumThreadView extends AbstractView {
             "info_name" => json_encode($author_display_info["given_name"] . " " . $author_display_info["family_name"] . " (" . $post->getAuthor()->getId() . ")"),
             "visible_user_json" => json_encode($visible_username),
             "jscriptAnonFix" => json_encode($post->isAnonymous() ? 'true' : 'false'),
+            "full_name" => $author_display_info["given_name"] . " " . $author_display_info["family_name"] . " (" . $post->getAuthor()->getId() . ")",
+            "is_anonymous" => $post->isAnonymous(),
             "pronouns" => trim($author_display_info["pronouns"]),
             "display_pronouns" => $author_display_info["display_pronouns"],
             "is_OP" => ($post->getAuthor()->getId() === $first_post->getAuthor()->getId()) && ($post->isAnonymous() === $first_post->isAnonymous()),

--- a/site/cypress/component/UserInfoBlock.cy.js
+++ b/site/cypress/component/UserInfoBlock.cy.js
@@ -1,0 +1,127 @@
+import UserInfoBlock from '@/components/forum/UserInfoBlock.vue';
+
+const defaultProps = {
+    username: 'User 1',
+    fullName: 'User One (user1)',
+    isAnonymous: false,
+    isOP: false,
+    pronouns: 'She/Her',
+    showPronouns: true,
+    postDate: 'Jan 1, 2026',
+    editDate: null,
+    authorEmail: 'user1@example.com',
+    showEmailToggle: false,
+    showUserInfoToggle: false,
+};
+
+describe('UserInfoBlock', () => {
+    it('renders the identity block and omits the toggles when disabled', () => {
+        cy.mount(UserInfoBlock, { props: defaultProps });
+        cy.get('[data-testid="last-edit"]').should('exist');
+        cy.get('[data-testid="author-name"]').should('have.text', 'User 1');
+        cy.get('[data-testid="post-user-id"]').should('contain', 'User 1');
+        cy.get('[data-testid="email-toggle"]').should('not.exist');
+        cy.get('[data-testid="author-email"]').should('not.exist');
+        cy.get('[data-testid="user-info-toggle"]').should('not.exist');
+    });
+
+    it('shows the OP badge with title when isOP and hides it otherwise', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, isOP: true } });
+        cy.get('[data-testid="post-user-id"]').should('contain', 'OP');
+        cy.get('[data-testid="post-user-id"]').should('have.attr', 'title', 'Original Poster');
+
+        cy.mount(UserInfoBlock, { props: defaultProps });
+        cy.get('[data-testid="post-user-id"]').should('not.contain', 'OP');
+        cy.get('[data-testid="post-user-id"]').should('not.have.attr', 'title');
+    });
+
+    it('renders pronouns when showPronouns and omits them otherwise', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, pronouns: 'They/Them' } });
+        cy.get('[data-testid="post-user-pronouns"]').should('have.text', '(They/Them)');
+
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, showPronouns: false } });
+        cy.get('[data-testid="post-user-pronouns"]').should('not.exist');
+    });
+
+    it('renders the post date and the last edit indicator when present', () => {
+        cy.mount(UserInfoBlock, { props: defaultProps });
+        cy.get('[data-testid="last-edit"]').should('contain', 'Jan 1, 2026');
+        cy.get('[data-testid="last-edit"]').should('not.contain', 'Last edit at');
+
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, editDate: 'Feb 2, 2026' } });
+        cy.get('[data-testid="last-edit"]').should('contain', 'Last edit at Feb 2, 2026');
+    });
+
+    it('renders the identity line with the same spacing as the original Twig markup', () => {
+        cy.mount(UserInfoBlock, {
+            props: { ...defaultProps, isOP: true, editDate: 'Feb 2, 2026' },
+        });
+        cy.get('[data-testid="last-edit"]').should(
+            'have.text',
+            'User 1 OP (She/Her) Jan 1, 2026 (Last edit at Feb 2, 2026)',
+        );
+    });
+
+    it('reveals the mailto link only after clicking the email toggle', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, showEmailToggle: true } });
+        cy.get('[data-testid="author-email"]').should('not.be.visible');
+        cy.get('[data-testid="email-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-email"]').should('be.visible');
+        cy.get('[data-testid="author-email"]').should('have.attr', 'href', 'mailto:user1@example.com');
+        cy.get('[data-testid="email-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-email"]').should('not.be.visible');
+    });
+
+    it('toggles between the visible username and the full name with the eye icon', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, showUserInfoToggle: true } });
+        cy.get('[data-testid="author-name"]').should('have.text', 'User 1');
+        cy.get('[data-testid="user-info-toggle-icon"]').should('have.class', 'fa-eye');
+        cy.get('[data-testid="user-info-toggle"]').should('have.attr', 'title', 'Show full user information');
+
+        cy.get('[data-testid="user-info-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-name"]').should('have.text', 'User One (user1)');
+        cy.get('[data-testid="user-info-toggle-icon"]').should('have.class', 'fa-eye-slash');
+        cy.get('[data-testid="user-info-toggle"]').should('have.attr', 'title', 'Hide full user information');
+
+        cy.get('[data-testid="user-info-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-name"]').should('have.text', 'User 1');
+        cy.get('[data-testid="user-info-toggle-icon"]').should('have.class', 'fa-eye');
+    });
+
+    it('applies the anonymous revealed styling only while revealed', () => {
+        cy.mount(UserInfoBlock, {
+            props: { ...defaultProps, showUserInfoToggle: true, isAnonymous: true },
+        });
+        cy.get('[data-testid="author-name"]').should('not.have.class', 'user-info-anon-revealed');
+        cy.get('[data-testid="user-info-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-name"]').should('have.class', 'user-info-anon-revealed');
+        cy.get('[data-testid="user-info-toggle"]').click({ force: true });
+        cy.get('[data-testid="author-name"]').should('not.have.class', 'user-info-anon-revealed');
+    });
+
+    it('keyboard activation (Enter and Space) toggles the user info reveal', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, showUserInfoToggle: true } });
+        cy.get('[data-testid="user-info-toggle"]').focus();
+        cy.get('[data-testid="user-info-toggle"]').type('{enter}');
+        cy.get('[data-testid="author-name"]').should('have.text', 'User One (user1)');
+        cy.get('[data-testid="user-info-toggle"]').type(' ');
+        cy.get('[data-testid="author-name"]').should('have.text', 'User 1');
+    });
+
+    it('keyboard activation (Enter) toggles the email link', () => {
+        cy.mount(UserInfoBlock, { props: { ...defaultProps, showEmailToggle: true } });
+        cy.get('[data-testid="email-toggle"]').focus();
+        cy.get('[data-testid="email-toggle"]').type('{enter}');
+        cy.get('[data-testid="author-email"]').should('be.visible');
+    });
+
+    it('has accessible markup on the interactive toggles', () => {
+        cy.mount(UserInfoBlock, {
+            props: { ...defaultProps, showEmailToggle: true, showUserInfoToggle: true },
+        });
+        cy.get('[data-testid="email-toggle"]').should('have.attr', 'title').and('not.be.empty');
+        cy.get('[data-testid="email-toggle"]').should('have.attr', 'aria-label').and('not.be.empty');
+        cy.get('[data-testid="user-info-toggle"]').should('have.attr', 'title').and('not.be.empty');
+        cy.get('[data-testid="user-info-toggle"]').should('have.attr', 'aria-label').and('not.be.empty');
+    });
+});

--- a/site/vue/src/components/forum/UserInfoBlock.vue
+++ b/site/vue/src/components/forum/UserInfoBlock.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+interface Props {
+    username: string;
+    fullName: string;
+    isAnonymous: boolean;
+    isOP: boolean;
+    pronouns: string;
+    showPronouns: boolean;
+    postDate: string;
+    editDate: string | null;
+    authorEmail: string;
+    showEmailToggle: boolean;
+    showUserInfoToggle: boolean;
+}
+
+const props = defineProps<Props>();
+
+const emailVisible = ref(false);
+const nameRevealed = ref(false);
+
+const displayName = computed(() => (nameRevealed.value ? props.fullName : props.username));
+const eyeIconClass = computed(() => (nameRevealed.value ? 'fas fa-eye-slash' : 'fas fa-eye'));
+const eyeTitle = computed(() => (nameRevealed.value ? 'Hide full user information' : 'Show full user information'));
+const nameClasses = computed(() => ({ 'user-info-anon-revealed': props.isAnonymous && nameRevealed.value }));
+</script>
+
+<template>
+  <span class="user-info-block">
+    <a
+      v-if="props.showEmailToggle"
+      class="post-email-toggle"
+      data-testid="email-toggle"
+      tabindex="0"
+      title="Show/Hide email address"
+      aria-label="Show/Hide email address"
+      @click="emailVisible = !emailVisible"
+      @keydown.enter.prevent="emailVisible = !emailVisible"
+      @keydown.space.prevent="emailVisible = !emailVisible"
+    >
+      <i class="fas fa-envelope" />
+    </a>
+    <a
+      v-if="props.showEmailToggle"
+      v-show="emailVisible"
+      :href="`mailto:${props.authorEmail}`"
+      data-testid="author-email"
+    >
+      {{ props.authorEmail }}
+    </a>
+    <a
+      v-if="props.showUserInfoToggle"
+      class="post-user-info"
+      data-testid="user-info-toggle"
+      tabindex="0"
+      :title="eyeTitle"
+      :aria-label="eyeTitle"
+      @click="nameRevealed = !nameRevealed"
+      @keydown.enter.prevent="nameRevealed = !nameRevealed"
+      @keydown.space.prevent="nameRevealed = !nameRevealed"
+    >
+      <i
+        :class="eyeIconClass"
+        data-testid="user-info-toggle-icon"
+      />
+    </a>
+    <span
+      class="last-edit"
+      data-testid="last-edit"
+    >
+      <strong
+        class="post_user_id"
+        data-testid="post-user-id"
+        :title="props.isOP ? 'Original Poster' : undefined"
+      ><span
+        class="author-name"
+        data-testid="author-name"
+        :class="nameClasses"
+      >{{ displayName }}</span> <span
+        v-if="props.isOP"
+        style="color: var(--standard-medium-vibrant-blue);"
+      ><strong>OP</strong></span></strong> <strong
+        v-if="props.showPronouns"
+        class="post_user_pronouns"
+        data-testid="post-user-pronouns"
+      >({{ props.pronouns }})</strong> {{ props.postDate }} <template v-if="props.editDate !== null">(<i>Last edit at {{ props.editDate }}</i>)</template>
+    </span>
+  </span>
+</template>
+
+<style scoped>
+.user-info-anon-revealed {
+    color: var(--standard-medium-gray);
+    font-style: italic;
+}
+</style>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In the ongoing migration of Submitty's UI from legacy Twig + jQuery to Vue.js, in this PR we migrate the UserInfoBlock in Forum/Discussion to vue.

### What is the New Behavior?
- The behaviour should be exactly the same on main

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Login as any User
2. Goto the threads in the Discussion Forum
3. See the UserDataInfo in Post Box
4. Try to toggle the eye/mail/etc

### Automated Testing & Documentation
- Added Cypress component tests for the Vue component

### Other information
- Not a breaking change
- No Migrations needed
