### PR TITLE
[Bugfix:InstructorUI] Peer Matrix Popup

### DIFF
--- a/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
+++ b/site/app/templates/admin/admin_gradeable/rubric/ElectronicFileRubric.twig
@@ -66,7 +66,7 @@
         }
         loadTemplates().then(function() {
             reloadInstructorEditRubric($('#g_id').val(), $('#gradeable_rubric').attr('data-notebook'), JSON.parse($('#gradeable_rubric').attr('data-itempool-options'))).then( function() {
-                const componentContainer = document.querySelector('.component-container');
+                const componentContainer = document.querySelector('#grading-box');
                 if (componentContainer) {
                     const observer = new MutationObserver(() => {
                         let yesPeer = ($('.peer-component-container').length == 0) ? false : true;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Closes Issue #13141 

### What is the New Behavior?
Now when adding a Peer Component, Peer Matrix tab pops up instead of having to refresh the page.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Navigate to Edit Gradeable for any electronic gradeable.
2. Add a peer grading component to the rubric.
3. Save the gradeable.
4. Observe that the Peer Matrix tab now appears without the need to reload

### Automated Testing & Documentation
N/A

### Other information
N/A
