### PR TITLE
[Bugfix:Testing] fix db check with /var/local/submitty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,9 +619,9 @@ jobs:
 
       - name: Setup Databases and Courses for main
         run: | # migrate main according to dumped master database (assume it is correct)
-          sudo mkdir -p /var/submitty
-          sudo rm -rf /var/submitty/config
-          sudo ln -sfn ${MAIN_INSTALL_PATH}/config /var/submitty/config
+          sudo mkdir -p /var/local/submitty
+          sudo rm -rf /var/local/submitty/config
+          sudo ln -sfn ${MAIN_INSTALL_PATH}/config /var/local/submitty/config
 
           python3 ${MAIN_REPO_PATH}/Submitty/migration/run_migrator.py -e master migrate --initial
 
@@ -638,8 +638,8 @@ jobs:
 
       - name: Setup Databases and Courses for Current Branch
         run: |
-          sudo rm -rf /var/submitty/config
-          sudo ln -sfn ${PR_INSTALL_PATH}/config /var/submitty/config
+          sudo rm -rf /var/local/submitty/config
+          sudo ln -sfn ${PR_INSTALL_PATH}/config /var/local/submitty/config
 
           python3 ${PR_REPO_PATH}/Submitty/migration/run_migrator.py -e master migrate --initial
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
In PR #12438 , PR #13104 , PR #13143 , we had left some changes in to ci.yml that had the DB check using the config directory of `/var/submitty/config`. The DB check needed to be updated to use `/var/local/submitty/config`. 

### What is the New Behavior?
ci.yml has been updated to use the directory `/var/local/submitty/config` instead of `/var/submitty/config`. It is now consistent with the rest of the changes in the prior PRs mentioned above.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Observe that the CI db check is passing on main.

### Automated Testing & Documentation


### Other information
This is not a breaking change.
