### PR TITLE
[Bugfix:TAGrading] editPeerComponent Clear Conflict Text

### DIFF
--- a/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
+++ b/site/app/templates/grading/electronic/EditPeerComponentsForm.twig
@@ -31,7 +31,7 @@
 			{% endfor %}
 	    	<button type="button" class="btn btn-danger" data-peer-id="{{peer}}" data-testid="clear-peer-marks-btn" onclick="clearPeerMarks( '{{submitter_id}}', '{{gradeable_id}}', '{{peer}}', '{{csrf_token}}')">Delete All Grading by Peer Grader {{peer}} for Student {{submitter_id}}'s Submission</button>
             {% if peer_has_version_conflict %}
-	    		<button type="button" class="btn clear-peer-version-conflicts" data-peer-id="{{peer}}" data-testid="resolve-peer-version-conflicts-btn" onclick="resolvePeerVersionConflicts('{{submitter_id}}', '{{gradeable_id}}', '{{peer}}', '{{csrf_token}}')">Clear Version Conflicts</button>
+	    		<button type="button" class="btn clear-peer-version-conflicts" data-peer-id="{{peer}}" data-testid="resolve-peer-version-conflicts-btn" onclick="resolvePeerVersionConflicts('{{submitter_id}}', '{{gradeable_id}}', '{{peer}}', '{{csrf_token}}')">Clear Version Conflicts For Peer Grader {{peer}}</button>
 	    	{% endif %}
 	    	</br>
             <div class="peer-edit-components">


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Clear Version conflict button on editPeerComponentForm should specify what peer grader's conflicts are being cleared.

### What is the New Behavior?
Before:
<img width="560" height="560" alt="image" src="https://github.com/user-attachments/assets/e158b9a7-7c0d-4f8e-bc9a-a5fd600a07b1" />

After:
<img width="560" height="557" alt="image" src="https://github.com/user-attachments/assets/5cd381b2-bc10-4b87-80fb-b706cd5310ec" />

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Grade a student as a peer grader on a gradeable with a peer component
2. Create a version conflict for graded student by making a new submission as them
3. As an instructor, visit editPeerComponentForm and observe change


### Automated Testing & Documentation
No automated testing

### Other information
Not a breaking change
No migrations
Not a security risk
