### PR TITLE
[Refactor:Forum] Migrate AddcategoryForm to Vue

### DIFF
--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -34,27 +34,19 @@
         <div>
 
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
-        <span  style="float: right;">
-                <input id="new_category_text" aria-label="New Category" placeholder="New Category" style="resize:none;" type="text" name="new_category" maxlength="50" onkeyup="checkInputMaxLength($(this))" />
+        {% include 'Vue.twig' with {
+            type: 'component',
+            name: 'forum/AddCategoryForm',
+            style: 'float: right;',
+            args: {
+                csrfToken: csrf_token,
+            },
+            events: {
+                'add-category': '(event) => { addNewCategory(event.name, event.visibleDate, event.csrfToken); }',
+                'max-length': '(event) => { alert("Maximum input length reached!"); }'
+            }
+        } %}
 
-                
-                <input class="date_picker flatpickr-input active" placeholder="YYYY-MM-DD" name="visible_date" id="category_visible_date" type="text">
-                <script>
-
-                    flatpickr('.date_picker', {
-                        allowInput: true,
-                        dateFormat: "Y-m-d",
-                        onReady: (a, b, fp) => {
-                            fp.calendarContainer.firstChild.childNodes[1].firstChild.firstChild.setAttribute('aria-label', 'Month');
-                        }
-                    });
-            
-                </script>
-
-                <button type="button" title="Add new category" onclick="addNewCategory('{{ csrf_token }}');" style="margin-left:10px;" class="btn btn-primary btn-sm" tabindex="0">
-                    <i class="fas fa-plus-circle fa-1x"></i> Add category
-                </button>
-            </span>
         <pre>(Drag to re-order)</pre><br>
         {% if categories|length == 0 %}
             <span class='category-list-no-element' style="margin-left: 1em;" >

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -37,7 +37,6 @@
         {% include 'Vue.twig' with {
             type: 'component',
             name: 'forum/AddCategoryForm',
-            style: 'float: right;',
             args: {
                 csrfToken: csrf_token,
             },

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -38,8 +38,7 @@
             type: 'component',
             name: 'forum/AddCategoryForm',
             events: {
-                'add-category': '(event) => { addNewCategory(event.name, event.visibleDate); }',
-                'max-length': '(event) => { alert("Maximum input length reached!"); }'
+                'add-category': '(event) => { addNewCategory(event.name, event.visibleDate); }'
             }
         } %}
 

--- a/site/app/templates/forum/ShowCategories.twig
+++ b/site/app/templates/forum/ShowCategories.twig
@@ -37,11 +37,8 @@
         {% include 'Vue.twig' with {
             type: 'component',
             name: 'forum/AddCategoryForm',
-            args: {
-                csrfToken: csrf_token,
-            },
             events: {
-                'add-category': '(event) => { addNewCategory(event.name, event.visibleDate, event.csrfToken); }',
+                'add-category': '(event) => { addNewCategory(event.name, event.visibleDate); }',
                 'max-length': '(event) => { alert("Maximum input length reached!"); }'
             }
         } %}

--- a/site/cypress/component/AddCategoryForm.cy.js
+++ b/site/cypress/component/AddCategoryForm.cy.js
@@ -1,0 +1,78 @@
+import AddCategoryForm from '@/components/forum/AddCategoryForm.vue';
+import { mountWithEmitSpy } from '../support/component_test_utils';
+
+const defaultProps = { csrfToken: 'test-csrf-token' };
+
+describe('AddCategoryForm', () => {
+    it('renders the name input, date input, and add button', () => {
+        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.get('[data-testid="add-category-name-input"]').should('exist');
+        cy.get('[data-testid="add-category-date-input"]').should('exist');
+        cy.get('[data-testid="add-category-button"]').should('contain', 'Add category');
+    });
+
+    it('has accessible markup: aria-labels, placeholder, and button title', () => {
+        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.get('[data-testid="add-category-name-input"]').should('have.attr', 'aria-label', 'New Category');
+        cy.get('[data-testid="add-category-date-input"]').should('have.attr', 'aria-label', 'Visible Date');
+        cy.get('[data-testid="add-category-date-input"]').should('have.attr', 'placeholder', 'YYYY-MM-DD');
+        cy.get('[data-testid="add-category-button"]').should('have.attr', 'title', 'Add new category');
+    });
+
+    it('emits add-category with name, visibleDate, and csrfToken on click', () => {
+        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
+        cy.get('[data-testid="add-category-name-input"]').type('Homework Help');
+        cy.get('[data-testid="add-category-button"]').click();
+        cy.get('@eventHandler').should('have.been.calledOnceWith', {
+            name: 'Homework Help',
+            visibleDate: '',
+            csrfToken: 'test-csrf-token',
+        });
+    });
+
+    it('includes the selected visible date in the add-category payload', () => {
+        const pad = (n) => String(n).padStart(2, '0');
+        const today = `${new Date().getFullYear()}-${pad(new Date().getMonth() + 1)}-${pad(new Date().getDate())}`;
+
+        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
+        cy.get('[data-testid="add-category-name-input"]').type('Dated Category');
+        cy.get('[data-testid="add-category-date-input"]').click();
+        // flatpickr renders its calendar into the document body, so its own DOM is
+        // selected by flatpickr's class
+        cy.get('.flatpickr-day.today').click();
+        cy.get('[data-testid="add-category-date-input"]').should('have.value', today);
+        cy.get('[data-testid="add-category-button"]').click();
+        cy.get('@eventHandler').should('have.been.calledOnceWith', {
+            name: 'Dated Category',
+            visibleDate: today,
+            csrfToken: 'test-csrf-token',
+        });
+    });
+
+    it('emits max-length when the name input reaches 50 characters', () => {
+        mountWithEmitSpy(AddCategoryForm, 'max-length', defaultProps);
+        cy.get('[data-testid="add-category-name-input"]').type('a'.repeat(50));
+        cy.get('@eventHandler').should('have.been.calledOnce');
+    });
+
+    it('does not emit max-length below 50 characters', () => {
+        mountWithEmitSpy(AddCategoryForm, 'max-length', defaultProps);
+        cy.get('[data-testid="add-category-name-input"]').type('Short name');
+        cy.get('@eventHandler').should('not.have.been.called');
+    });
+
+    it('keyboard activation (Enter) on the button emits add-category', () => {
+        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
+        cy.get('[data-testid="add-category-name-input"]').type('Keyboard Category');
+        cy.get('[data-testid="add-category-button"]').focus();
+        cy.get('[data-testid="add-category-button"]').type('{enter}');
+        cy.get('@eventHandler').should('have.been.calledOnce');
+    });
+
+    it('does not throw when no event handlers are provided', () => {
+        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.get('[data-testid="add-category-name-input"]').type('No Handlers');
+        cy.get('[data-testid="add-category-button"]').click();
+        cy.get('[data-testid="add-category-form"]').should('exist');
+    });
+});

--- a/site/cypress/component/AddCategoryForm.cy.js
+++ b/site/cypress/component/AddCategoryForm.cy.js
@@ -45,16 +45,22 @@ describe('AddCategoryForm', () => {
         });
     });
 
-    it('emits max-length when the name input reaches 50 characters', () => {
-        mountWithEmitSpy(AddCategoryForm, 'max-length');
+    it('alerts when the name input reaches 50 characters', () => {
+        cy.window().then((win) => {
+            cy.stub(win, 'alert').as('alertStub');
+        });
+        cy.mount(AddCategoryForm);
         cy.get('[data-testid="add-category-name-input"]').type('a'.repeat(50));
-        cy.get('@eventHandler').should('have.been.calledOnce');
+        cy.get('@alertStub').should('have.been.calledOnceWith', 'Maximum input length reached!');
     });
 
-    it('does not emit max-length below 50 characters', () => {
-        mountWithEmitSpy(AddCategoryForm, 'max-length');
-        cy.get('[data-testid="add-category-name-input"]').type('Short name');
-        cy.get('@eventHandler').should('not.have.been.called');
+    it('does not alert below 50 characters', () => {
+        cy.window().then((win) => {
+            cy.stub(win, 'alert').as('alertStub');
+        });
+        cy.mount(AddCategoryForm);
+        cy.get('[data-testid="add-category-name-input"]').type('a'.repeat(49));
+        cy.get('@alertStub').should('not.have.been.called');
     });
 
     it('does not throw when no event handlers are provided', () => {

--- a/site/cypress/component/AddCategoryForm.cy.js
+++ b/site/cypress/component/AddCategoryForm.cy.js
@@ -61,14 +61,6 @@ describe('AddCategoryForm', () => {
         cy.get('@eventHandler').should('not.have.been.called');
     });
 
-    it('keyboard activation (Enter) on the button emits add-category', () => {
-        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
-        cy.get('[data-testid="add-category-name-input"]').type('Keyboard Category');
-        cy.get('[data-testid="add-category-button"]').focus();
-        cy.get('[data-testid="add-category-button"]').type('{enter}');
-        cy.get('@eventHandler').should('have.been.calledOnce');
-    });
-
     it('does not throw when no event handlers are provided', () => {
         cy.mount(AddCategoryForm, { props: defaultProps });
         cy.get('[data-testid="add-category-name-input"]').type('No Handlers');

--- a/site/cypress/component/AddCategoryForm.cy.js
+++ b/site/cypress/component/AddCategoryForm.cy.js
@@ -1,32 +1,29 @@
 import AddCategoryForm from '@/components/forum/AddCategoryForm.vue';
 import { mountWithEmitSpy } from '../support/component_test_utils';
 
-const defaultProps = { csrfToken: 'test-csrf-token' };
-
 describe('AddCategoryForm', () => {
     it('renders the name input, date input, and add button', () => {
-        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.mount(AddCategoryForm);
         cy.get('[data-testid="add-category-name-input"]').should('exist');
         cy.get('[data-testid="add-category-date-input"]').should('exist');
         cy.get('[data-testid="add-category-button"]').should('contain', 'Add category');
     });
 
     it('has accessible markup: aria-labels, placeholder, and button title', () => {
-        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.mount(AddCategoryForm);
         cy.get('[data-testid="add-category-name-input"]').should('have.attr', 'aria-label', 'New Category');
         cy.get('[data-testid="add-category-date-input"]').should('have.attr', 'aria-label', 'Visible Date');
         cy.get('[data-testid="add-category-date-input"]').should('have.attr', 'placeholder', 'YYYY-MM-DD');
         cy.get('[data-testid="add-category-button"]').should('have.attr', 'title', 'Add new category');
     });
 
-    it('emits add-category with name, visibleDate, and csrfToken on click', () => {
-        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
+    it('emits add-category with name and visibleDate on click', () => {
+        mountWithEmitSpy(AddCategoryForm, 'add-category');
         cy.get('[data-testid="add-category-name-input"]').type('Homework Help');
         cy.get('[data-testid="add-category-button"]').click();
         cy.get('@eventHandler').should('have.been.calledOnceWith', {
             name: 'Homework Help',
             visibleDate: '',
-            csrfToken: 'test-csrf-token',
         });
     });
 
@@ -34,7 +31,7 @@ describe('AddCategoryForm', () => {
         const pad = (n) => String(n).padStart(2, '0');
         const today = `${new Date().getFullYear()}-${pad(new Date().getMonth() + 1)}-${pad(new Date().getDate())}`;
 
-        mountWithEmitSpy(AddCategoryForm, 'add-category', defaultProps);
+        mountWithEmitSpy(AddCategoryForm, 'add-category');
         cy.get('[data-testid="add-category-name-input"]').type('Dated Category');
         cy.get('[data-testid="add-category-date-input"]').click();
         // flatpickr renders its calendar into the document body, so its own DOM is
@@ -45,24 +42,23 @@ describe('AddCategoryForm', () => {
         cy.get('@eventHandler').should('have.been.calledOnceWith', {
             name: 'Dated Category',
             visibleDate: today,
-            csrfToken: 'test-csrf-token',
         });
     });
 
     it('emits max-length when the name input reaches 50 characters', () => {
-        mountWithEmitSpy(AddCategoryForm, 'max-length', defaultProps);
+        mountWithEmitSpy(AddCategoryForm, 'max-length');
         cy.get('[data-testid="add-category-name-input"]').type('a'.repeat(50));
         cy.get('@eventHandler').should('have.been.calledOnce');
     });
 
     it('does not emit max-length below 50 characters', () => {
-        mountWithEmitSpy(AddCategoryForm, 'max-length', defaultProps);
+        mountWithEmitSpy(AddCategoryForm, 'max-length');
         cy.get('[data-testid="add-category-name-input"]').type('Short name');
         cy.get('@eventHandler').should('not.have.been.called');
     });
 
     it('does not throw when no event handlers are provided', () => {
-        cy.mount(AddCategoryForm, { props: defaultProps });
+        cy.mount(AddCategoryForm);
         cy.get('[data-testid="add-category-name-input"]').type('No Handlers');
         cy.get('[data-testid="add-category-button"]').click();
         cy.get('[data-testid="add-category-form"]').should('exist');

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1534,7 +1534,7 @@ function showHistory(post_id) {
     });
 }
 
-function addNewCategory(newCategory, visibleDate, csrf_token) {
+function addNewCategory(newCategory, visibleDate) {
     const url = buildCourseUrl(['forum', 'categories', 'new']);
     $.ajax({
         url: url,
@@ -1543,7 +1543,7 @@ function addNewCategory(newCategory, visibleDate, csrf_token) {
             newCategory: newCategory,
             visibleDate: visibleDate,
             rank: $('[id^="categorylistitem-').length,
-            csrf_token: csrf_token,
+            csrf_token: csrfToken,
         },
         success: function (data) {
             try {

--- a/site/public/js/forum.js
+++ b/site/public/js/forum.js
@@ -1534,9 +1534,7 @@ function showHistory(post_id) {
     });
 }
 
-function addNewCategory(csrf_token) {
-    const newCategory = $('#new_category_text').val();
-    const visibleDate = $('#category_visible_date').val();
+function addNewCategory(newCategory, visibleDate, csrf_token) {
     const url = buildCourseUrl(['forum', 'categories', 'new']);
     $.ajax({
         url: url,
@@ -1561,7 +1559,6 @@ function addNewCategory(csrf_token) {
                 return;
             }
             displaySuccessMessage(`Successfully created category ${escapeSpecialChars(newCategory)}.`);
-            $('#new_category_text').val('');
             // Create new item in #ui-category-list using dummy category
             const category_id = json['data']['new_id'];
             const category_color_code = '#000080';

--- a/site/vue/src/components/forum/AddCategoryForm.vue
+++ b/site/vue/src/components/forum/AddCategoryForm.vue
@@ -2,14 +2,8 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import flatpickr from 'flatpickr';
 
-interface Props {
-    csrfToken: string;
-}
-
-const props = defineProps<Props>();
-
 const emit = defineEmits<{
-    'add-category': [payload: { name: string; visibleDate: string; csrfToken: string }];
+    'add-category': [payload: { name: string; visibleDate: string }];
     'max-length': [];
 }>();
 
@@ -25,7 +19,6 @@ function onAddCategory() {
     emit('add-category', {
         name: name.value,
         visibleDate: visibleDate.value,
-        csrfToken: props.csrfToken,
     });
 }
 

--- a/site/vue/src/components/forum/AddCategoryForm.vue
+++ b/site/vue/src/components/forum/AddCategoryForm.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import flatpickr from 'flatpickr';
+
+interface Props {
+    csrfToken: string;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    'add-category': [payload: { name: string; visibleDate: string; csrfToken: string }];
+    'max-length': [];
+}>();
+
+const MAX_NAME_LENGTH = 50;
+
+const name = ref('');
+const visibleDate = ref('');
+const dateInput = ref<HTMLInputElement | null>(null);
+
+let flatpickrInstance: ReturnType<typeof flatpickr> | null = null;
+
+function onAddCategory() {
+    emit('add-category', {
+        name: name.value,
+        visibleDate: visibleDate.value,
+        csrfToken: props.csrfToken,
+    });
+}
+
+function onNameKeyup() {
+    if (name.value.length >= MAX_NAME_LENGTH) {
+        emit('max-length');
+    }
+}
+
+onMounted(() => {
+    if (dateInput.value) {
+        flatpickrInstance = flatpickr(dateInput.value, {
+            allowInput: true,
+            dateFormat: 'Y-m-d',
+            onChange: (selectedDates, dateStr) => {
+                visibleDate.value = dateStr;
+            },
+            onReady: (selectedDates, dateStr, instance) => {
+                const monthNav = instance.calendarContainer.firstChild?.childNodes[1]?.firstChild?.firstChild as Element | null;
+                monthNav?.setAttribute('aria-label', 'Month');
+            },
+        });
+    }
+});
+
+onBeforeUnmount(() => {
+    if (flatpickrInstance && !Array.isArray(flatpickrInstance)) {
+        flatpickrInstance.destroy();
+    }
+    flatpickrInstance = null;
+});
+</script>
+
+<template>
+  <span
+    class="add-category-form"
+    data-testid="add-category-form"
+  >
+    <input
+      v-model="name"
+      data-testid="add-category-name-input"
+      aria-label="New Category"
+      placeholder="New Category"
+      style="resize:none;"
+      type="text"
+      name="new_category"
+      :maxlength="MAX_NAME_LENGTH"
+      @keyup="onNameKeyup"
+    >
+    <input
+      ref="dateInput"
+      data-testid="add-category-date-input"
+      aria-label="Visible Date"
+      placeholder="YYYY-MM-DD"
+      class="date_picker flatpickr-input active"
+      name="visible_date"
+      type="text"
+    >
+    <button
+      type="button"
+      data-testid="add-category-button"
+      title="Add new category"
+      style="margin-left:10px;"
+      class="btn btn-primary btn-sm"
+      tabindex="0"
+      @click="onAddCategory"
+    >
+      <i class="fas fa-plus-circle fa-1x" /> Add category
+    </button>
+  </span>
+</template>

--- a/site/vue/src/components/forum/AddCategoryForm.vue
+++ b/site/vue/src/components/forum/AddCategoryForm.vue
@@ -19,7 +19,7 @@ const name = ref('');
 const visibleDate = ref('');
 const dateInput = ref<HTMLInputElement | null>(null);
 
-let flatpickrInstance: ReturnType<typeof flatpickr> | null = null;
+let flatpickrInstance: flatpickr.Instance | null = null;
 
 function onAddCategory() {
     emit('add-category', {
@@ -52,9 +52,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-    if (flatpickrInstance && !Array.isArray(flatpickrInstance)) {
-        flatpickrInstance.destroy();
-    }
+    flatpickrInstance?.destroy();
     flatpickrInstance = null;
 });
 </script>
@@ -66,10 +64,10 @@ onBeforeUnmount(() => {
   >
     <input
       v-model="name"
+      class="add-category-name-input"
       data-testid="add-category-name-input"
       aria-label="New Category"
       placeholder="New Category"
-      style="resize:none;"
       type="text"
       name="new_category"
       :maxlength="MAX_NAME_LENGTH"
@@ -86,10 +84,9 @@ onBeforeUnmount(() => {
     >
     <button
       type="button"
+      class="btn btn-primary btn-sm add-category-button"
       data-testid="add-category-button"
       title="Add new category"
-      style="margin-left:10px;"
-      class="btn btn-primary btn-sm"
       tabindex="0"
       @click="onAddCategory"
     >
@@ -97,3 +94,17 @@ onBeforeUnmount(() => {
     </button>
   </span>
 </template>
+
+<style scoped>
+.add-category-form {
+    float: right;
+}
+
+.add-category-name-input {
+    resize: none;
+}
+
+.add-category-button {
+    margin-left: 10px;
+}
+</style>

--- a/site/vue/src/components/forum/AddCategoryForm.vue
+++ b/site/vue/src/components/forum/AddCategoryForm.vue
@@ -4,7 +4,6 @@ import flatpickr from 'flatpickr';
 
 const emit = defineEmits<{
     'add-category': [payload: { name: string; visibleDate: string }];
-    'max-length': [];
 }>();
 
 const MAX_NAME_LENGTH = 50;
@@ -24,7 +23,7 @@ function onAddCategory() {
 
 function onNameKeyup() {
     if (name.value.length >= MAX_NAME_LENGTH) {
-        emit('max-length');
+        alert('Maximum input length reached!');
     }
 }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
This is part of the ongoing forum migration from jQuery+Twig to Vue. The Add Category Form is on the Manage Categories page was one of the leaf components still using inline script in twig/jQuery

### What is the New Behavior?
No user-visible behavior change - the form looks and works identically

https://github.com/user-attachments/assets/d7811596-f956-4ddb-b427-51d5da30d840

### What steps should a reviewer take to reproduce or test the bug or new feature?
Login as any user: 
- Go to manage categories in Discussion Forum
-  Typing a name, picking a date, and clicking "Add category" creates the category and reloads the page
- Typing 50 characters into the name field triggers the max-length alert
- The per-category features (edit description/date/color, delete, drag-to-reorder) still work
### Automated Testing & Documentation
- Added Cypress Component Testing

### Other information
- Not a breaking change
- No migration needed
