### PR TITLE
[Bugfix:System] Added existence check for session secret

### DIFF
--- a/.setup/set_config_permissions.py
+++ b/.setup/set_config_permissions.py
@@ -64,12 +64,13 @@ FIRST_UNTRUSTED_UID, FIRST_UNTRUSTED_GID = get_ids('untrusted00')
 DAEMON_UID, DAEMON_GID = get_ids(DAEMON_USER)
 
 if not args.worker:
-    # Set secrets session token
-    config = OrderedDict()
-    CHARACTERS = string.ascii_letters + string.digits
-    config['session'] = ''.join(secrets.choice(CHARACTERS) for _ in range(64))
-    with open(SECRETS_PHP_JSON, 'w') as json_file:
-        json.dump(config, json_file, indent=2)
+    # Set secrets session token, skip if it already exists so we don't invalidate log in sessions.
+    if not os.path.exists(SECRETS_PHP_JSON):
+        config = OrderedDict()
+        CHARACTERS = string.ascii_letters + string.digits
+        config['session'] = ''.join(secrets.choice(CHARACTERS) for _ in range(64))
+        with open(SECRETS_PHP_JSON, 'w') as json_file:
+            json.dump(config, json_file, indent=2)
 
     # Change file permissions
     for file in [WORKERS_JSON, CONTAINERS_JSON]:


### PR DESCRIPTION
### Why is this Change Important & Necessary?
When [PR#13143](https://github.com/Submitty/Submitty/pull/13143) was merged, it introduced a bug where the user's session token would be cleared each time `submitty_install` is run. This would log out all users, which we do not want. This was happening because each time submitty_install is ran, it calls set_config_permissions, which overwrites the secrets_php json file without checking if it already exists (credit to claude for finding the cause).

### What is the New Behavior?
After a submitty_install, the user you were logged in as should still be logged in.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Make sure you are logged in
2. Run `submitty_install`
3. Verify you are still logged in

### Automated Testing & Documentation
Tested manually

### Other information
This is not a breaking change. No migrations. No known security concerns.