### PR TITLE
[Bugfix:System] Add worker arg for submitty_install

### DIFF
--- a/.setup/INSTALL_SUBMITTY_HELPER.sh
+++ b/.setup/INSTALL_SUBMITTY_HELPER.sh
@@ -185,9 +185,14 @@ popd > /dev/null
 
 echo -e "\nBeginning installation of Submitty\n"
 
-python3 "${SUBMITTY_REPOSITORY}/.setup/generate_configs.py"
-python3 "${SUBMITTY_REPOSITORY}/.setup/set_config_permissions.py"
-python3 "${SUBMITTY_REPOSITORY}/.setup/validate_configs.py"
+COMMAND=""
+if [ ${IS_WORKER} == 1 ]; then
+    COMMAND=--worker
+fi
+
+python3 "${SUBMITTY_REPOSITORY}/.setup/generate_configs.py" ${COMMAND}
+python3 "${SUBMITTY_REPOSITORY}/.setup/set_config_permissions.py" ${COMMAND}
+python3 "${SUBMITTY_REPOSITORY}/.setup/validate_configs.py" ${COMMAND}
 
 /bin/bash "${SUBMITTY_REPOSITORY}/.setup/install_submitty/setup_directories.sh" "$@" "config=${SUBMITTY_CONFIG_DIR:?}"
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Addresses  #13181, which was generally broken by #12438. Workers weren't tested enough prior to merge, so this change is to fix it. 

### What is the New Behavior?
A worker arg in the INSTALL_SUBMITTY_HELPER script for the newly created python scripts.

### What steps should a reviewer take to reproduce or test the bug or new feature?
Follow steps of #13181 on main, then on this branch and it should be fixed. 

### Automated Testing & Documentation
No tests currently test workers
