### PR TITLE
[Bugfix:TAGrading] Fix Rubric Header Score round off issue

### DIFF
--- a/site/cypress/component/RubricHeaderScore.cy.js
+++ b/site/cypress/component/RubricHeaderScore.cy.js
@@ -3,7 +3,7 @@ import RubricHeaderScore from '../../vue/src/components/ta_grading/RubricHeaderS
 describe('RubricHeaderScore', () => {
     it('renders score / max_value as integers', () => {
         cy.mount(RubricHeaderScore, { props: { totalScore: 7.5, maxValue: 10 } });
-        cy.get('[data-testid="grading-total"]').should('contain', '8 / 10');
+        cy.get('[data-testid="grading-total"]').should('contain', '7.5 / 10');
     });
 
     it('renders minus sign when totalScore is null (ungraded)', () => {

--- a/site/vue/src/components/ta_grading/RubricHeaderScore.vue
+++ b/site/vue/src/components/ta_grading/RubricHeaderScore.vue
@@ -23,11 +23,14 @@ function getBadgeStyle(earned: number | null, total: number): string {
 
 const badgeClass = getBadgeStyle(props.totalScore, props.maxValue);
 
-// Round to full integers to match the badge's pre-refactor visual style
+function formatScore(value: number): string {
+    return (Math.round(value * 1000) / 1000).toString();
+}
+
 const displayScore = props.totalScore !== null
-    ? Math.round(props.totalScore).toString()
+    ? formatScore(props.totalScore)
     : '\u2212';
-const displayMax = Math.round(props.maxValue).toString();
+const displayMax = formatScore(props.maxValue);
 </script>
 
 <template>


### PR DESCRIPTION
### Why is this Change Important & Necessary?
The Rubric header score badge in the manual grading rubric showed the wrong score when a gradeable has fractional precision (e.g. 0.25). It happened because the migrated RubricHeaderScore.vue component replaced the original Twig rendering.

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

### What steps should a reviewer take to reproduce or test the bug or new feature?

### Automated Testing & Documentation
- Updated the component tests

### Other information
- Not a Breaking change
- No migrations needed
