### PR TITLE
[Bugfix:Autograding] force dwarf4 for autograding C++ 

### DIFF
--- a/grading/CMakeLists.txt
+++ b/grading/CMakeLists.txt
@@ -33,6 +33,9 @@ file (
   "${allowed_autograding_commands_headers}${allowed_autograding_commands_default_definition}${allowed_autograding_commands_default_obj}${end_definition}${allowed_autograding_commands_custom_definition}${allowed_autograding_commands_custom_obj}${end_definition}"
 )
 
+# HOPEFULLY THIS IS ONLY A TEMPORARY WORKAROUND
+add_compile_options(-gdwarf-4)
+
 ###################################################################################
 # source files
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
We had a compilation error requiring this additional CMake flag.
It might be related to our stale operating system (Ubuntu 22.04) and/or outdated C++.

### What is the New Behavior?
Compilation is now successful.

### Other information
This edit should probably be reverted in the future when other upgrades are completed.