### PR TITLE
[Bugfix:InstructorUI] Clarify prereq score msg

### DIFF
--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -2314,7 +2314,12 @@ class Gradeable extends AbstractModel {
         if ($this->depends_on !== null && $this->depends_on_points !== null) {
             $dependent_gradeable = $this->core->getQueries()->getGradeableConfig($this->depends_on);
             $dependent_gradeable_points = strval($this->depends_on_points);
-            return ($dependent_gradeable->getTitle() . " first with a score of " . $dependent_gradeable_points . " point(s)");
+            $autograding_config = $dependent_gradeable->getAutogradingConfig();
+            $max_points = $autograding_config !== null ? $autograding_config->getTotalNonHiddenNonExtraCredit() : $this->depends_on_points;
+            $score_phrase = ($this->depends_on_points < $max_points)
+                ? $dependent_gradeable_points . " or more point(s)"
+                : $dependent_gradeable_points . " point(s)";
+            return ($dependent_gradeable->getTitle() . " first with a score of " . $score_phrase);
         }
         else {
             return '';

--- a/site/tests/app/models/gradeable/GradeableTester.php
+++ b/site/tests/app/models/gradeable/GradeableTester.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace tests\app\models\gradeable;
+
+use app\models\gradeable\AutogradingConfig;
+use app\models\gradeable\Gradeable;
+use app\libraries\GradeableType;
+use app\models\gradeable\GradeableUtils;
+use tests\BaseUnitTest;
+
+class GradeableTester extends BaseUnitTest {
+    private function buildGradeable($core, ?string $depends_on, ?int $depends_on_points): Gradeable {
+        $timezone = new \DateTimeZone('America/New_York');
+        $details = [
+            'id' => 'lesson_02',
+            'title' => 'lesson_02',
+            'instructions_url' => '',
+            'ta_instructions' => '',
+            'type' => GradeableType::ELECTRONIC_FILE,
+            'grader_assignment_method' => 0,
+            'min_grading_group' => 3,
+            'syllabus_bucket' => 'homework',
+            'autograding_config_path' => '/path/to/autograding',
+            'vcs' => false,
+            'using_subdirectory' => false,
+            'vcs_subdirectory' => '',
+            'vcs_partial_path' => '',
+            'vcs_host_type' => GradeableUtils::VCS_TYPE_NONE,
+            'team_assignment' => false,
+            'team_size_max' => 1,
+            'ta_grading' => true,
+            'student_view' => true,
+            'student_view_after_grades' => false,
+            'student_download' => true,
+            'student_submit' => true,
+            'has_due_date' => true,
+            'has_release_date' => true,
+            'peer_grading' => false,
+            'peer_grade_set' => false,
+            'late_submission_allowed' => true,
+            'precision' => 0.5,
+            'grade_inquiry_allowed' => true,
+            'grade_inquiry_per_component_allowed' => true,
+            'discussion_based' => false,
+            'discussion_thread_ids' => '',
+            'ta_view_start_date' => new \DateTime('1000-01-01', $timezone),
+            'grade_start_date' => new \DateTime('9997-01-01', $timezone),
+            'grade_due_date' => new \DateTime('9997-01-01', $timezone),
+            'grade_released_date' => new \DateTime('9998-01-01', $timezone),
+            'team_lock_date' => new \DateTime('1001-01-01', $timezone),
+            'submission_open_date' => new \DateTime('1000-01-01', $timezone),
+            'submission_due_date' => new \DateTime('1001-01-01', $timezone),
+            'late_days' => 2,
+            'grade_inquiry_start_date' => new \DateTime('9998-01-01', $timezone),
+            'grade_inquiry_due_date' => new \DateTime('9998-01-01', $timezone),
+            'allowed_minutes' => null,
+            'depends_on' => $depends_on,
+            'depends_on_points' => $depends_on_points,
+            'allow_custom_marks' => true,
+            'any_manual_grades' => false,
+            'score_notifications_sent' => 0,
+            'release_notifications_sent' => false
+        ];
+        return new Gradeable($core, $details);
+    }
+
+    private function mockDependentGradeable(string $title, int $max_points) {
+        // getTotalNonHiddenNonExtraCredit() is only declared via a @method docblock
+        // (dispatched through AbstractModel::__call), so createMock() can't see it as
+        // a mockable method. addMethods() explicitly adds it to the generated mock.
+        $autograding_config = $this->getMockBuilder(AutogradingConfig::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getTotalNonHiddenNonExtraCredit'])
+            ->getMock();
+        $autograding_config->method('getTotalNonHiddenNonExtraCredit')->willReturn($max_points);
+
+        $dependent = $this->createMock(Gradeable::class);
+        $dependent->method('getTitle')->willReturn($title);
+        $dependent->method('getAutogradingConfig')->willReturn($autograding_config);
+
+        return $dependent;
+    }
+
+    public function testGetPrerequisiteBelowMaxPointsShowsOrMore() {
+        $dependent = $this->mockDependentGradeable('Lesson 01: Types Variables', 10);
+        $core = $this->createMockCore([], [], ['getGradeableConfig' => $dependent]);
+
+        $gradeable = $this->buildGradeable($core, 'lesson_01', 6);
+
+        $this->assertEquals(
+            'Lesson 01: Types Variables first with a score of 6 or more point(s)',
+            $gradeable->getPrerequisite()
+        );
+    }
+
+    public function testGetPrerequisiteAtMaxPointsShowsExactScore() {
+        $dependent = $this->mockDependentGradeable('Lesson 01: Types Variables', 6);
+        $core = $this->createMockCore([], [], ['getGradeableConfig' => $dependent]);
+
+        $gradeable = $this->buildGradeable($core, 'lesson_01', 6);
+
+        $this->assertEquals(
+            'Lesson 01: Types Variables first with a score of 6 point(s)',
+            $gradeable->getPrerequisite()
+        );
+    }
+
+    public function testGetPrerequisiteNoAutogradingConfigFallsBackToExactScore() {
+        $dependent = $this->createMock(Gradeable::class);
+        $dependent->method('getTitle')->willReturn('Lesson 01: Types Variables');
+        $dependent->method('getAutogradingConfig')->willReturn(null);
+        $core = $this->createMockCore([], [], ['getGradeableConfig' => $dependent]);
+
+        $gradeable = $this->buildGradeable($core, 'lesson_01', 6);
+
+        $this->assertEquals(
+            'Lesson 01: Types Variables first with a score of 6 point(s)',
+            $gradeable->getPrerequisite()
+        );
+    }
+
+    public function testGetPrerequisiteReturnsEmptyStringWhenNoDependency() {
+        $core = $this->createMockCore();
+        $gradeable = $this->buildGradeable($core, null, null);
+
+        $this->assertEquals('', $gradeable->getPrerequisite());
+    }
+}


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #13198

When a gradeable has a prerequisite with a minimum score set below the prerequisite's maximum autograding points, the lock message implies students must score *exactly* that many points (e.g. "...with a score of 6 point(s)"), when in fact any score of 6 or higher unlocks the gradeable. This is misleading and can cause student confusion.

### What is the New Behavior?
`Gradeable::getPrerequisite()` now compares the required unlock score against the prerequisite gradeable's max non-hidden, non-extra-credit autograding points (the same value already used to compute the "Out of X Maximum Autograding Points" hint on the Edit Gradeable page). If the required score is less than that max, the message now reads "...with a score of 6 or more point(s)." If the required score equals the max, the message is unchanged ("...with a score of 6 point(s)."), since there's no ambiguity in that case. Also added a null-guard around `getAutogradingConfig()`, which can return `null` if the config fails to load from disk.

**Before:**
> Please complete Cpp Hidden Tests first with a score of 6 point(s).

**After (min < max):**
<img width="1118" height="392" alt="clipboard (1)" src="https://github.com/user-attachments/assets/b39f7acc-9dc8-4373-86ff-325cee4ed4bb" />
> Please complete Cpp Hidden Tests first with a score of 6 or more point(s).

**After (min = max):**
<img width="1058" height="397" alt="clipboard" src="https://github.com/user-attachments/assets/61670960-ce11-42a0-887e-a3b19ae2e6ec" />
> Please complete Cpp Hidden Tests first with a score of 10 point(s).

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. On any gradeable's Submissions/Autograding tab, set a **Previous Gradeable** prerequisite.
2. Note the "Out of X Maximum Autograding Points" hint shown for that prerequisite.
3. Set **Autograder Points Required to Unlock** to a value *less than* that max — save, then view the course homepage as a student who hasn't met the threshold. The locked gradeable's alert should read "...first with a score of N or more point(s)."
4. Repeat with the unlock points set *equal to* the max — confirm the alert reads "...with a score of N point(s)." with no "or more."
5. Confirm no PHP warnings appear if the prerequisite gradeable's autograding config fails to load.

### Automated Testing & Documentation
Added `site/tests/app/models/gradeable/GradeableTester.php` covering `getPrerequisite()`: below-max (shows "or more"), at-max (shows exact score), no-autograding-config fallback, and no-dependency (empty string). No prior test coverage existed for prerequisite-gradeable messaging. No documentation updates needed, this is a UI copy fix.

### Other information
Not a breaking change. No migrations needed. No security concerns.<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->
