### PR TITLE
[Bugfix:TAGrading] Null active_graders TypeError

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -9378,9 +9378,9 @@ WHERE current_state IN
                     'late_day_exceptions' => $late_day_exceptions,
                     'reasons_for_exceptions' => $reasons_for_exceptions
                 ],
-                json_decode($row['ag_graders'], true),
-                json_decode($row['ag_timestamps'], true),
-                json_decode($row['ag_graders_names'], true)
+                json_decode($row['ag_graders'] ?? '[]', true),
+                json_decode($row['ag_timestamps'] ?? '[]', true),
+                json_decode($row['ag_graders_names'] ?? '[]', true)
             );
             $ta_graded_gradeable = null;
             $auto_graded_gradeable = null;


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Instructors accessing certain archived courses hit a fatal TypeError, blocking access entirely (viewing old gradeables, reusing content, writing recommendation letters based on past student work).

Fixes #13189

### What is the New Behavior?
GradedGradeable::__construct() now receives an empty array instead of null when the ag_graders/ag_timestamps/ag_graders_names JSON aggregation has no rows to aggregate (i.e. the gradeable has zero gradeable_component rows). Previously, gradeables with zero gradeable_component rows caused the LEFT JOIN LATERAL aggregation to return NULL instead of an empty JSON object; json_decode(null, true) then returned null, which failed the array type-hint on GradedGradeable::__construct(), causing a fatal TypeError.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Locally, delete all gradeable_component rows for any gradeable (e.g. `DELETE FROM gradeable_component WHERE g_id = 'some_gradeable';`)
2. Load that gradeable's grading page as an instructor on main — reproduces the fatal TypeError
3. Apply this fix and reload — page loads without error
4. Restore the deleted gradeable_component rows

### Automated Testing & Documentation
No new automated test added; this is a narrow null-coalescing fix on an existing query path. Manually reproduced and verified as described above.

### Other information
Root cause: the LEFT JOIN LATERAL subquery in DatabaseQueries.php (~line 9170) aggregates over gradeable_component rows; when a gradeable has none, the subquery returns zero rows, so the outer join yields NULL for these three columns instead of an empty JSON object. Not a breaking change; no migration needed; no security concerns.