### PR TITLE
[Bugfix:Notifications] Fix no-due-date alerts

### DIFF
--- a/sbin/send_notification.py
+++ b/sbin/send_notification.py
@@ -136,6 +136,7 @@ def construct_notifications(term, course, pending, notification_type):
             "title": notification.get('g_title'),
             "depends_on": notification.get('depends_on'),
             "submission_due_date": notification.get('submission_due_date'),
+            "has_due_date": notification.get('has_due_date'),
             "team_id": notification.get('team_id'),
             "user_id": notification.get('user_id'),
             "user_email": notification.get('user_email'),
@@ -160,13 +161,23 @@ def construct_notifications(term, course, pending, notification_type):
         # Notification-related content
         if notification_type == "gradeable_release":
             email_subject = f"Submissions Open: {gradeable['title']}"
-            notification_content = (
-                f"{email_subject} | Due {format_timestamp(gradeable['submission_due_date'])}"
-            )
+            notification_content = email_subject
+            if gradeable['has_due_date']:
+                notification_content += (
+                    f" | Due {format_timestamp(gradeable['submission_due_date'])}"
+                )
+
             email_body = (
                 f"Submissions are now being accepted for \"{gradeable['title']}\" in course "
                 f"{get_full_course_name(term, course)}.\n\n"
-                f"Deadline: {format_timestamp(gradeable['submission_due_date'])}\n"
+            )
+
+            if gradeable['has_due_date']:
+                email_body += (
+                    f"Deadline: {format_timestamp(gradeable['submission_due_date'])}\n"
+                )
+
+            email_body += (
                 f"Late Days: {gradeable['remaining_late_days']} remaining, "
                 f"{gradeable['max_late_days']} allowed"
             )
@@ -374,6 +385,7 @@ def send_pending_notifications():
                 g.g_title AS g_title,
                 eg.eg_depends_on AS depends_on,
                 eg.eg_submission_due_date AS submission_due_date,
+                eg.eg_has_due_date AS has_due_date,
                 u.user_id AS user_id,
                 u.user_email AS user_email,
                 COALESCE(ns.all_gradeable_releases, TRUE) AS site_enabled,
@@ -439,7 +451,9 @@ def send_pending_notifications():
                         AND n.content ILIKE '%' || 'Submissions Open: ' || g.g_title || '%'
                     )
                 )
-            GROUP BY g.g_id, g.g_title, eg.eg_submission_due_date, u.user_id, u.user_email,
+            GROUP BY g.g_id, g.g_title,
+             eg.eg_submission_due_date,eg.eg_has_due_date,
+             u.user_id, u.user_email,
                 ns.all_gradeable_releases, ns.all_gradeable_releases_email, eg.eg_late_days,
                 eg.eg_depends_on, ldc.late_days_remaining
             """), {

--- a/sbin/send_notification.py
+++ b/sbin/send_notification.py
@@ -384,7 +384,11 @@ def send_pending_notifications():
                 g.g_id AS g_id,
                 g.g_title AS g_title,
                 eg.eg_depends_on AS depends_on,
-                eg.eg_submission_due_date AS submission_due_date,
+                CASE
+                    WHEN eg.eg_has_due_date IS TRUE
+                    THEN eg.eg_submission_due_date
+                    ELSE NULL
+                END AS submission_due_date,
                 eg.eg_has_due_date AS has_due_date,
                 u.user_id AS user_id,
                 u.user_email AS user_email,
@@ -413,7 +417,10 @@ def send_pending_notifications():
                 AND eg.eg_student_submit IS TRUE
                 AND eg.eg_release_notifications_sent IS FALSE
                 AND eg.eg_submission_open_date <= NOW()
-                AND eg.eg_submission_due_date >= NOW()
+                AND (
+                eg.eg_has_due_date IS FALSE
+                OR eg.eg_submission_due_date >= NOW()
+                )
                 AND (
                     eg.eg_depends_on IS NULL
                     OR (


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #13202

Currently, gradeable release notifications include a due date even when the gradeable does not have a due date. This results in incorrect information being displayed to users.
This change ensures that the due date is only included in gradeable release notifications and emails when the gradeable has a due date.

### What is the New Behavior?
Gradeable release notifications now display the due date only when the gradeable has a due date.

For gradeables without a due date:
- The notification does not display a "Due" date.
- The email does not display a "Deadline".

For gradeables with a due date, the existing due date behavior remains unchanged.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Create or use a gradeable that has a due date and enable gradeable release notifications.
2. Verify that the notification includes the due date.
3. Create or use a gradeable without a due date and enable gradeable release notifications.
4. Verify that the notification does not include a "Due" date.
5. Verify that the email does not include a "Deadline".
6. Run the following Python lint check:

   ./.setup/SUBMITTY_TEST.sh py-lint sbin/send_notification.py

### Automated Testing & Documentation
The modified Python file was tested using Submitty's Python linting checks.

The following check was run:

./.setup/SUBMITTY_TEST.sh py-lint sbin/send_notification.py

No documentation changes are required for this bug fix.

### Other information
This is not a breaking change.

This PR does not include database migrations.

There are no security concerns related to this change.
