### PR TITLE
[Bugfix:InstructorUI] Grades Released Date Fix

### DIFF
--- a/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
+++ b/site/app/templates/admin/admin_gradeable/AdminGradeableDates.twig
@@ -58,7 +58,7 @@
             <br />
         </div>
     </div>
-    <div id="release_container" class="due_date_date" {{ gradeable.hasDueDate() ? '' : 'hidden' }}>
+    <div id="release_container">
         <div {% if not electronic %}hidden{% endif %} id="release_toggle_container">
             <fieldset>
                 <legend>Will this assignment have a grades released date? (Not having a release date will let students see their grade immediately)</legend>

--- a/site/public/js/admin-gradeable-updates.js
+++ b/site/public/js/admin-gradeable-updates.js
@@ -211,19 +211,15 @@ function updateDueDate() {
     const cont = $('#due_date_container');
     const cont1 = $('#late_days_options_container');
     const cont2 = $('#manual_grading_container');
-    const cont3 = $('#release_container');
     if ($('#has_due_date_no').is(':checked')) {
         cont.hide();
         cont1.hide();
         cont2.hide();
-        cont3.hide();
-        $('#has_release_date_no').prop('checked', true);
     }
     else {
         cont.show();
         cont1.show();
         cont2.show();
-        cont3.show();
     }
     onHasDueDate();
 }


### PR DESCRIPTION
### What is the current behavior?
In the Edit Gradeable dates panel for electronic file submissions, answering **No** to *'Will this assignment have a due date?'* automatically forces *'Will this assignment have a grades released date?'* to No and hides the release container and date picker.

For courses with paper exams scanned and uploaded by instructor/TAs or assignments without a student submission deadline, there is no due date, but instructors still need to hold back grades and release them on a specific future date.

### What is the new behavior?
- Decouples the grades release date toggle/container from the due date setting.
- Removes the `due_date_date` class and conditional `hidden` attribute from `#release_container` in `AdminGradeableDates.twig`.
- Removes the forced hiding and reset of `#has_release_date_no` from `updateDueDate()` in `admin-gradeable-updates.js`.
- Allows instructors to set **No** on due date while setting **Yes** with a designated date on grades released date.

Fixes #13197

### Other information?
Tested toggling between due date yes/no and release date yes/no in the instructor gradeable edit interface.