### PR TITLE
[Bugfix:InstructorUI] Fix Peer Graders List

### DIFF
--- a/site/app/views/grading/ElectronicGraderView.php
+++ b/site/app/views/grading/ElectronicGraderView.php
@@ -1940,6 +1940,19 @@ HTML;
                 );
             }
         }
+        $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
+        foreach ($gradeable->getComponents() as $component) {
+            if (!$component->isPeerComponent()) {
+                continue;
+            }
+            $container = $ta_graded_gradeable->getGradedComponentContainer($component);
+            foreach ($container->getGradedComponents() as $gc) {
+                $grader = $gc->getGrader();
+                if ($grader !== null) {
+                    $peers_to_list[] = $grader->getId();
+                }
+            }
+        }
         $peers_to_list = array_values(array_unique($peers_to_list));
         $components_details_array = [];
         $component_scores = [];
@@ -1952,17 +1965,23 @@ HTML;
             "version_conflicts" => []
         ];
         foreach ($peers_to_list as $peer) {
-            $peer_user = $this->core->getQueries()->getUsersById([$peer])[$peer];
-            $peer_names[$peer] = $peer_user->getDisplayedGivenName() . ' ' . $peer_user->getDisplayedFamilyName() . ' (' . $peer . ')';
+            $users = $this->core->getQueries()->getUsersById([$peer]);
+            if (isset($users[$peer])) {
+                $peer_user = $users[$peer];
+                $peer_names[$peer] = $peer_user->getDisplayedGivenName() . ' ' . $peer_user->getDisplayedFamilyName() . ' (' . $peer . ')';
+            }
         }
-        $ta_graded_gradeable = $graded_gradeable->getOrCreateTaGradedGradeable();
         foreach ($gradeable->getComponents() as $component) {
             if (!$component->isPeerComponent()) {
                 continue;
             }
             $component_id = $component->getId();
             foreach ($peers_to_list as $peer) {
-                $peer_user = $this->core->getQueries()->getUsersById([$peer])[$peer];
+                $users = $this->core->getQueries()->getUsersById([$peer]);
+                if (!isset($users[$peer])) {
+                    continue;
+                }
+                $peer_user = $users[$peer];
                 $graded_component = $ta_graded_gradeable->getGradedComponent($component, $peer_user);
                 if ($graded_component === null) {
                     continue;


### PR DESCRIPTION
## Problem
The Edit Peer Components popup on the peer grading panel previously only populated peer graders who are currently assigned in the active Peer Matrix. If a peer grader recorded grades and was subsequently removed from the matrix, or if a TA entered peer grades, their entries were missing from the grader dropdown and their grades could not be viewed or edited.

## Solution
- Collected all graders with existing recorded grades across peer component containers in `ElectronicGraderView::editPeerComponentsForm`.
- Merged them into `$peers_to_list` alongside active matrix assignees so all recorded peer grades are accessible in the dropdown.
- Handled user lookups defensively.

Fixes #13149