### PR TITLE
[Bugfix:TAGrading] Fix Image Annotation View

### DIFF
--- a/site/ts/ImageAnnotationEmbedded.ts
+++ b/site/ts/ImageAnnotationEmbedded.ts
@@ -87,12 +87,16 @@ const emptyState: AnnotationState = {
 };
 
 function createEditorWrapper(): HTMLElement {
-    const editorWrapper = document.createElement('div');
-    editorWrapper.id = 'global-annotation-editor-wrapper';
+    let editorWrapper = document.getElementById('global-annotation-editor-wrapper');
+    if (!editorWrapper) {
+        editorWrapper = document.createElement('div');
+        editorWrapper.id = 'global-annotation-editor-wrapper';
+        document.body.appendChild(editorWrapper);
+    }
+    editorWrapper.innerHTML = '';
     if (annotationManager.globalAnnotationEditor) {
         editorWrapper.appendChild(annotationManager.globalAnnotationEditor);
     }
-    document.body.appendChild(editorWrapper);
     editorWrapper.style.display = 'flex';
     return editorWrapper;
 }

--- a/site/ts/ta-grading-panels.ts
+++ b/site/ts/ta-grading-panels.ts
@@ -176,15 +176,17 @@ function updatePanelLayoutModes() {
     $('.panel-instructions').remove();
     setMultiPanelModeVisiblities();
     for (const panelIdx in panelsBucket) {
-        const panelCont = document.querySelector(
-            panelsBucket[panelIdx],
-        )?.childNodes;
-        if (!panelCont) {
+        const panelEl = document.querySelector(panelsBucket[panelIdx]);
+        if (!panelEl) {
             continue;
         }
         // Move all the panels from the left and right buckets to the main panels-container
-        for (let idx = 0; idx < panelCont.length; idx++) {
-            document.querySelector('.panels-container')!.append(panelCont[idx]);
+        const children = Array.from(panelEl.childNodes);
+        const panelsContainer = document.querySelector('.panels-container');
+        if (panelsContainer) {
+            for (const child of children) {
+                panelsContainer.append(child);
+            }
         }
     }
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes #13170

In multi-panel grading mode with an annotateable image open, switching or updating another panel caused the image annotation view to duplicate/multiply across the grading interface. This was caused by:
1. Indexing into a live `childNodes` `NodeList` during DOM mutation in `updatePanelLayoutModes`, causing skipped child elements to remain in intermediate layout buckets.
2. `createEditorWrapper` in `ImageAnnotationEmbedded.ts` appending duplicate wrapper elements to `document.body`.

### What is the New Behavior?
1. `updatePanelLayoutModes` converts `panelEl.childNodes` to a static array using `Array.from(panelEl.childNodes)` before restoration to `.panels-container`, preventing skipped elements and stale layout containers.
2. `createEditorWrapper` reuses or cleanly clears any existing `#global-annotation-editor-wrapper` instead of creating multiple wrappers on `document.body`.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Open a gradeable with an annotateable image component in multi-panel grading mode.
2. Open the image annotation viewer in one of the panels.
3. Switch or rearrange the layout of another panel.
4. Verify that the image annotation view does not duplicate or multiply across panels.

### Automated Testing & Documentation
Existing TA grading TypeScript tests pass cleanly. No documentation updates required.

### Other information
This is not a breaking change and does not require database migrations.