### PR TITLE
[Refactor:System] Remove PDF Dir Def

### DIFF
--- a/site/app/libraries/Access.php
+++ b/site/app/libraries/Access.php
@@ -257,14 +257,6 @@ class Access {
                 "path.write" => "path.write.submissions",
             ]
         ];
-        $this->directories["annotated_pdfs"] = [
-            "base" => $this->core->getConfig()->getCoursePath() . "/annotated_pdfs",
-            "subparts" => ["gradeable", "submitter", "version"],
-            "permissions" => [
-                "path.read" => "path.read.submissions",
-                "path.write" => "path.write.submissions",
-            ]
-        ];
 
         $this->directories["community_events"] = [
             "base" => $this->core->getConfig()->getSubmittyPath() . "/community_events",


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Partially addresses #13158

In #13042 and #13098, legacy PDF annotation features were phased out in favor of image annotation. However, `Access.php` still retained the unused `annotated_pdfs` directory definition inside `loadDirectories()`. Removing this leftover configuration cleans up legacy directory mappings and prevents confusion in path access management.

### What is the New Behavior?
The unused `annotated_pdfs` entry in `$this->directories` within `Access.php` is removed. Path checks through `Access.php` no longer reference the deprecated directory.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Check out this branch and ensure Submitty services start normally.
2. Log in as an instructor and navigate to any course gradable.
3. Access student submissions, grading interfaces, and files.
4. Verify that access controls, file views, and submissions load with zero errors.

### Automated Testing & Documentation
- Covered by existing PHP unit tests and site integration test suites.
- No new documentation updates are required on submitty.org as this is internal cleanup of deprecated configuration.

### Other information
- **Relation to #13158:** This PR **partially addresses** #13158. Specifically, it resolves the `Access.php -> loadDirectories()` cleanup item identified in issue #13158. It is **not** the last PR needed to fully close #13158, as additional legacy references remain in sample course configs (`sample.yml`, `development.yml`), Cypress tests (`verify_development_courses.spec.js`), and sample course generator utilities (`create_or_generate.py`, `course_create_gradeables.py`, `gradeable.py`) which are being tracked separately.
- Not a breaking change.
- No database migrations required.
- No security concerns.
