### PR TITLE
[Bugfix:InstructorUI] Short answer fix

### DIFF
--- a/site/cypress/e2e/Cypress-Gradeable/notebook_builder.spec.js
+++ b/site/cypress/e2e/Cypress-Gradeable/notebook_builder.spec.js
@@ -1,0 +1,21 @@
+describe('Notebook Builder: Short Answer cell', () => {
+    beforeEach(() => {
+        cy.login('instructor');
+        cy.visit(['sample', 'notebook_builder', 'notebook_filesubmission', 'edit']);
+    });
+
+    it('renders a Short Answer cell when added to an existing notebook', () => {
+        // Regression test for #13234: a typo in short-answer-widget.js (codemirror_langauges vs
+        // codemirror_languages) caused an uncaught TypeError in render(), silently preventing the
+        // Short Answer cell from appearing in the notebook builder's edit view.
+        cy.get('[data-testid="short-answer"]').click();
+
+        cy.get('.short-answer-widget').should('be.visible');
+        cy.get('.short-answer-widget .filename-input').should('exist');
+        cy.get('.short-answer-widget .answer-type').should('exist');
+
+        // The language dropdown should be populated (Default plus at least one CodeMirror mode),
+        // which only happens if builder_data.codemirror_languages was read correctly.
+        cy.get('.short-answer-widget .answer-type option').should('have.length.greaterThan', 1);
+    });
+});

--- a/site/public/js/notebook_builder/builders/abstract-builder.js
+++ b/site/public/js/notebook_builder/builders/abstract-builder.js
@@ -104,8 +104,14 @@ class AbstractBuilder {
                 }
 
                 if (widget) {
-                    widget.load(cell);
-                    this.widgetAdd(widget);
+                    try {
+                        widget.load(cell);
+                        this.widgetAdd(widget);
+                    }
+                    catch (error) {
+                        console.error(`Failed to load notebook cell of type "${cell.type}":`, error);
+                        displayErrorMessage(`An error occurred loading a "${cell.type}" cell.  Check browser developer console for details.`);
+                    }
                 }
             });
         }

--- a/site/public/js/notebook_builder/widgets/short-answer-widget.js
+++ b/site/public/js/notebook_builder/widgets/short-answer-widget.js
@@ -89,7 +89,7 @@ class ShortAnswerWidget extends Widget {
             };
 
             if (answer_type_selector.value !== 'Default') {
-                codebox_config.mode = builder_data.codemirror_langauges[answer_type_selector.value];
+                codebox_config.mode = builder_data.codemirror_languages[answer_type_selector.value];
                 codebox_config.lineNumbers = true;
             }
 
@@ -155,7 +155,7 @@ class ShortAnswerWidget extends Widget {
      */
     getTypeOptions() {
         let all_modes = ['Default'];
-        all_modes = all_modes.concat(Object.keys(builder_data.codemirror_langauges));
+        all_modes = all_modes.concat(Object.keys(builder_data.codemirror_languages));
 
         let result = '';
         all_modes.forEach((mode) => {


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Fixes #13234. 

Short Answer cells never appeared in the Notebook Builder's edit view (instructor-facing), even though they rendered correctly on the student submission page. Root cause: `short-answer-widget.js` referenced a misspelled property, `builder_data.codemirror_langauges`, while the controller and template correctly set `builder_data.codemirror_languages`. The resulting `undefined` access threw an uncaught `TypeError` inside `render()`, silently aborting the widget's DOM insertion — both when adding a new Short Answer cell and when reloading a saved notebook config that contains one.

### What is the New Behavior?

- Corrected the property name in `short-answer-widget.js` (two occurrences), so the language dropdown and code box render as expected.
- `AbstractBuilder.load()` now wraps each cell's `load()`/`widgetAdd()` call in a try/catch, so a single malformed or unexpectedly-erroring cell surfaces a visible error message instead of silently aborting that cell (and, in the worst case, every cell after it in the same load pass).

### What steps should a reviewer take to reproduce or test?

1. As an instructor, go to a gradeable's Notebook Builder (Submissions/Autograding tab → "Start New" or "Edit Existing").
2. Click "Short Answer" under "Add New Notebook Cell".
3. Before this fix: nothing appears. After this fix: the Short Answer cell renders with its Type dropdown, Height/Filename fields, and initial-value code box.
4. Save the notebook, reload the edit page, and confirm the Short Answer cell(s) persist and render correctly.

### Automated Testing & Documentation

Added `site/cypress/e2e/Cypress-Gradeable/notebook_builder.spec.js`, which adds a Short Answer cell in the notebook builder and asserts it renders (container visible, filename input and type dropdown present, dropdown populated with more than the default option). This test would have failed against the pre-fix code, since the widget never reached the DOM.

### Other information
<img width="1325" height="631" alt="Screenshot (4163)" src="https://github.com/user-attachments/assets/bc128338-f9cf-4301-8b5a-a06070373ada" />

No config or migration changes required — this is a client-side JS fix only.

