### PR TITLE
[Bugfix:UI] Fix PDF embed viewer height and flex layout issue

### DIFF
--- a/site/public/css/electronic.css
+++ b/site/public/css/electronic.css
@@ -1445,9 +1445,21 @@ tr.is_publish {
     padding-left: 10px;
 }
 
-#file-view {
+/* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */
+#submission_browser.rubric_panel > div,
+/* stylelint-disable-next-line selector-id-pattern, selector-class-pattern */
+#notebook-view.rubric_panel > div {
+    height: 100%;
+}
+
+/* stylelint-disable-next-line selector-id-pattern */
+#file-view,
+/* stylelint-disable-next-line selector-id-pattern */
+#notebook-file-view {
     height: 100%;
     width: 100%;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
 }
 
@@ -1467,9 +1479,10 @@ tr.is_publish {
     padding: 0 10px;
 }
 
+/* stylelint-disable-next-line selector-id-pattern */
 #file-content,
+/* stylelint-disable-next-line selector-id-pattern */
 #notebook-file-content {
-    height: 90%;
     flex: 1 1 auto;
     min-height: 0;
     width: 100%;

--- a/site/public/js/pdf/PDFEmbedded.js
+++ b/site/public/js/pdf/PDFEmbedded.js
@@ -6,21 +6,21 @@
 */
 
 const RENDER_OPTIONS = {
-    documentId: '',
-    userId: '',
+    documentId: "",
+    userId: "",
     pdfDocument: null,
-    scale: parseFloat(localStorage.getItem('pdf-scale')) || 1,
-    rotate: parseInt(localStorage.getItem('pdf-rotate')) || 0,
+    scale: parseFloat(localStorage.getItem("pdf-scale")) || 1,
+    rotate: parseInt(localStorage.getItem("pdf-rotate")) || 0,
     studentPopup: false,
     minScale: 1,
     maxScale: 5,
 };
 
 const GENERAL_INFORMATION = {
-    grader_id: '',
-    user_id: '',
-    gradeable_id: '',
-    file_name: '',
+    grader_id: "",
+    user_id: "",
+    gradeable_id: "",
+    file_name: "",
     broken: false,
 };
 
@@ -28,11 +28,22 @@ const GENERAL_INFORMATION = {
     let timeout = null;
     window.triggerPDFScale = (delta) => {
         clearTimeout(timeout);
-        timeout = setTimeout(() => rescalePDF(RENDER_OPTIONS.scale + delta), 100);
+        timeout = setTimeout(
+            () => rescalePDF(RENDER_OPTIONS.scale + delta),
+            100,
+        );
     };
 }
 
-function renderPDF(gradeable_id, user_id, grader_id, file_name, file_path, page_num, url = '') {
+function renderPDF(
+    gradeable_id,
+    user_id,
+    grader_id,
+    file_name,
+    file_path,
+    page_num,
+    url = "",
+) {
     try {
         let currentTool;
         let NUM_PAGES = 0;
@@ -48,11 +59,11 @@ function renderPDF(gradeable_id, user_id, grader_id, file_name, file_path, page_
         RENDER_OPTIONS.documentId = file_name;
         // TODO: Duplicate user_id in both RENDER_OPTIONS and GENERAL_INFORMATION, also grader_id = user_id in this context.
         RENDER_OPTIONS.userId = grader_id;
-        if (url === '') {
-            url = buildCourseUrl(['gradeable', gradeable_id, 'encode_pdf']);
+        if (url === "") {
+            url = buildCourseUrl(["gradeable", gradeable_id, "encode_pdf"]);
         }
         $.ajax({
-            type: 'POST',
+            type: "POST",
             url: url,
             data: {
                 user_id: user_id,
@@ -67,132 +78,193 @@ function renderPDF(gradeable_id, user_id, grader_id, file_name, file_path, page_
                 try {
                     pdfData = JSON.parse(data);
                     // Checking if the response is a failure due to large file size
-                    if (pdfData.status === 'fail') {
-                        $('#pdf-error-message').text(pdfData.message).show();
+                    if (pdfData.status === "fail") {
+                        $("#pdf-error-message").text(pdfData.message).show();
                         return;
                     }
-                    pdfData = atob(pdfData['data']);
-                }
-                catch (err) {
+                    pdfData = atob(pdfData["data"]);
+                } catch (err) {
                     console.log(err);
                     console.log(data);
-                    alert('Something went wrong, please try again later.');
+                    alert("Something went wrong, please try again later.");
                 }
                 const pdfJsBaseUrl = `${window.location.origin}/vendor/pdfjs/`;
-                pdfjsLib.getDocument({
-                    data: pdfData,
-                    cMapUrl: `${pdfJsBaseUrl}cmaps/`,
-                    cMapPacked: true,
-                    wasmUrl: `${pdfJsBaseUrl}wasm/`,
-                    iccUrl: `${pdfJsBaseUrl}iccs/`,
-                    standardFontDataUrl: `${pdfJsBaseUrl}standard_fonts/`,
-                }).promise.then((pdf) => {
-                    RENDER_OPTIONS.pdfDocument = pdf;
-                    if (GENERAL_INFORMATION.broken) {
-                        return;
-                    }
-                    const viewer = document.getElementById('viewer');
-                    $(viewer).on('touchstart touchmove', (e) => {
-                        // Let touchscreen work
-                        if (currentTool === 'pen' || currentTool === 'text') {
-                            e.preventDefault();
+                pdfjsLib
+                    .getDocument({
+                        data: pdfData,
+                        cMapUrl: `${pdfJsBaseUrl}cmaps/`,
+                        cMapPacked: true,
+                        wasmUrl: `${pdfJsBaseUrl}wasm/`,
+                        iccUrl: `${pdfJsBaseUrl}iccs/`,
+                        standardFontDataUrl: `${pdfJsBaseUrl}standard_fonts/`,
+                    })
+                    .promise.then((pdf) => {
+                        RENDER_OPTIONS.pdfDocument = pdf;
+                        if (GENERAL_INFORMATION.broken) {
+                            return;
                         }
-                    });
-                    $('a[value=\'zoomcustom\']').text(`${parseInt(RENDER_OPTIONS.scale * 100)}%`);
-                    viewer.innerHTML = '';
-                    NUM_PAGES = pdf.numPages;
-
-                    const renderPagePromises = [];
-                    for (let i = 0; i < NUM_PAGES; i++) {
-                        const page = createPage(i + 1);
-                        viewer.appendChild(page);
-                        const page_id = i + 1;
-                        renderPagePromises.push(renderPage(page_id, RENDER_OPTIONS).then(() => {
-                            // eslint-disable-next-line eqeqeq
-                            if (i == page_num) {
-                                // scroll to page on load
-                                const initialPage = $(`#pageContainer${page_id}`);
-                                if (initialPage.length) {
-                                    const scrollContainer = $('#file-content').length ? $('#file-content') : $('#submission_browser');
-                                    scrollContainer.scrollTop(Math.max(page.offsetTop, 0));
-                                }
+                        const viewer = document.getElementById("viewer");
+                        $(viewer).on("touchstart touchmove", (e) => {
+                            // Let touchscreen work
+                            if (
+                                currentTool === "pen" ||
+                                currentTool === "text"
+                            ) {
+                                e.preventDefault();
                             }
-                        }));
-                    }
-
-                    Promise.all(renderPagePromises).then(() => {
-                        $('.pdfViewer .page').each(function () {
-                            $(this).css('width', `calc(${$(this).css('width')} * var(--pdf-scale))`);
-                            $(this).css('height', `calc(${$(this).css('height')} * var(--pdf-scale))`);
                         });
+                        $("a[value='zoomcustom']").text(
+                            `${parseInt(RENDER_OPTIONS.scale * 100)}%`,
+                        );
+                        viewer.innerHTML = "";
+                        NUM_PAGES = pdf.numPages;
 
-                        let scale = RENDER_OPTIONS.scale;
-                        let zoomTimeout = null;
+                        const renderPagePromises = [];
+                        for (let i = 0; i < NUM_PAGES; i++) {
+                            const page = createPage(i + 1);
+                            viewer.appendChild(page);
+                            const page_id = i + 1;
+                            renderPagePromises.push(
+                                renderPage(page_id, RENDER_OPTIONS).then(() => {
+                                    // eslint-disable-next-line eqeqeq
+                                    if (i == page_num) {
+                                        // scroll to page on load
+                                        const initialPage = $(
+                                            `#pageContainer${page_id}`,
+                                        );
+                                        if (initialPage.length) {
+                                            const scrollContainer = $(
+                                                "#file-content",
+                                            ).length
+                                                ? $("#file-content")
+                                                : $("#submission_browser");
+                                            scrollContainer.scrollTop(
+                                                Math.max(page.offsetTop, 0),
+                                            );
+                                        }
+                                    }
+                                }),
+                            );
+                        }
 
-                        $('#file-zoom-display').text(`${Math.round(scale * 100)}%`);
+                        Promise.all(renderPagePromises).then(() => {
+                            $(".pdfViewer .page").each(function () {
+                                $(this).css(
+                                    "width",
+                                    `calc(${$(this).css("width")} * var(--pdf-scale))`,
+                                );
+                                $(this).css(
+                                    "height",
+                                    `calc(${$(this).css("height")} * var(--pdf-scale))`,
+                                );
+                            });
 
-                        function handleWheel(e) {
-                            if (!e.ctrlKey && !e.metaKey) {
-                                return;
-                            }
-                            e.preventDefault();
+                            let scale = RENDER_OPTIONS.scale;
+                            let zoomTimeout = null;
 
-                            const k = 0.0065;
-                            const factor = Math.exp(-k * e.deltaY);
-                            const newScale = Math.min(RENDER_OPTIONS.maxScale, Math.max(RENDER_OPTIONS.minScale, scale * factor));
+                            $("#file-zoom-display").text(
+                                `${Math.round(scale * 100)}%`,
+                            );
 
-                            const viewer = $('#viewer');
-                            const scroller = $('#submission_browser');
-                            let page = $('#viewer > .page:hover');
+                            function handleWheel(e) {
+                                if (!e.ctrlKey && !e.metaKey) {
+                                    return;
+                                }
+                                e.preventDefault();
 
-                            if (!page.length) {
-                                const pages = [...$('#viewer > .page')];
-                                for (const p of pages) {
-                                    const bounds = p.getBoundingClientRect();
-                                    if (e.clientY > bounds.top && e.clientY < bounds.bottom) {
-                                        page = $(p);
-                                        break;
+                                const k = 0.0065;
+                                const factor = Math.exp(-k * e.deltaY);
+                                const newScale = Math.min(
+                                    RENDER_OPTIONS.maxScale,
+                                    Math.max(
+                                        RENDER_OPTIONS.minScale,
+                                        scale * factor,
+                                    ),
+                                );
+
+                                const viewer = $("#viewer");
+                                const scroller = $("#file-content").length
+                                    ? $("#file-content")
+                                    : $("#submission_browser");
+                                let page = $("#viewer > .page:hover");
+
+                                if (!page.length) {
+                                    const pages = [...$("#viewer > .page")];
+                                    for (const p of pages) {
+                                        const bounds =
+                                            p.getBoundingClientRect();
+                                        if (
+                                            e.clientY > bounds.top &&
+                                            e.clientY < bounds.bottom
+                                        ) {
+                                            page = $(p);
+                                            break;
+                                        }
                                     }
                                 }
+
+                                if (page.length) {
+                                    const pageBounds =
+                                        page[0].getBoundingClientRect();
+                                    viewer.css(
+                                        "--pdf-scale",
+                                        newScale / RENDER_OPTIONS.scale,
+                                    );
+                                    const newPageBounds =
+                                        page[0].getBoundingClientRect();
+
+                                    const xoff =
+                                        (e.clientX - pageBounds.left) /
+                                        pageBounds.width;
+                                    const yoff =
+                                        (e.clientY - pageBounds.top) /
+                                        pageBounds.height;
+
+                                    const newXoff =
+                                        (e.clientX - newPageBounds.left) /
+                                        newPageBounds.width;
+                                    const newYoff =
+                                        (e.clientY - newPageBounds.top) /
+                                        newPageBounds.height;
+
+                                    scroller[0].scrollLeft -=
+                                        (newXoff - xoff) * newPageBounds.width;
+                                    scroller[0].scrollTop -=
+                                        (newYoff - yoff) * newPageBounds.height;
+                                } else {
+                                    viewer.css(
+                                        "--pdf-scale",
+                                        newScale / RENDER_OPTIONS.scale,
+                                    );
+                                }
+
+                                scale = newScale;
+                                $("#file-zoom-display").text(
+                                    `${Math.round(scale * 100)}%`,
+                                );
+
+                                clearTimeout(zoomTimeout);
+                                zoomTimeout = setTimeout(rescale, 100);
                             }
 
-                            if (page.length) {
-                                const pageBounds = page[0].getBoundingClientRect();
-                                viewer.css('--pdf-scale', newScale / RENDER_OPTIONS.scale);
-                                const newPageBounds = page[0].getBoundingClientRect();
-
-                                const xoff = (e.clientX - pageBounds.left) / pageBounds.width;
-                                const yoff = (e.clientY - pageBounds.top) / pageBounds.height;
-
-                                const newXoff = (e.clientX - newPageBounds.left) / newPageBounds.width;
-                                const newYoff = (e.clientY - newPageBounds.top) / newPageBounds.height;
-
-                                scroller[0].scrollLeft -= (newXoff - xoff) * newPageBounds.width;
-                                scroller[0].scrollTop -= (newYoff - yoff) * newPageBounds.height;
-                            }
-                            else {
-                                viewer.css('--pdf-scale', newScale / RENDER_OPTIONS.scale);
+                            function rescale() {
+                                rescalePDF(scale);
                             }
 
-                            scale = newScale;
-                            $('#file-zoom-display').text(`${Math.round(scale * 100)}%`);
-
-                            clearTimeout(zoomTimeout);
-                            zoomTimeout = setTimeout(rescale, 100);
-                        }
-
-                        function rescale() {
-                            rescalePDF(scale);
-                        }
-
-                        $('#file-content')[0].removeEventListener('wheel', handleWheel);
-                        $('#file-content')[0].addEventListener('wheel', handleWheel, { passive: false });
+                            $("#file-content")[0].removeEventListener(
+                                "wheel",
+                                handleWheel,
+                            );
+                            $("#file-content")[0].addEventListener(
+                                "wheel",
+                                handleWheel,
+                                { passive: false },
+                            );
+                        });
                     });
-                });
             },
         });
-    }
-    catch (e) {
+    } catch (e) {
         // ignore the identifier error
     }
 }
@@ -202,28 +274,34 @@ function rescalePDF(scale) {
         return;
     }
 
-    const viewer = $('#viewer');
+    const viewer = $("#viewer");
     RENDER_OPTIONS.scale = scale;
-    localStorage.setItem('pdf-scale', scale);
+    localStorage.setItem("pdf-scale", scale);
     const pdf = RENDER_OPTIONS.pdfDocument;
     const NUM_PAGES = pdf.numPages;
     const renderPagePromises = [];
     for (let i = 1; i <= NUM_PAGES; i++) {
         renderPagePromises.push(renderPage(i, RENDER_OPTIONS));
     }
-    viewer.css('--pdf-scale', 1);
-    $('#file-zoom-display').text(`${Math.round(scale * 100)}%`);
+    viewer.css("--pdf-scale", 1);
+    $("#file-zoom-display").text(`${Math.round(scale * 100)}%`);
 
     Promise.all(renderPagePromises).then(() => {
-        $('.pdfViewer .page').each(function () {
-            $(this).css('width', `calc(${this.offsetWidth}px * var(--pdf-scale))`);
-            $(this).css('height', `calc(${this.offsetHeight}px * var(--pdf-scale))`);
+        $(".pdfViewer .page").each(function () {
+            $(this).css(
+                "width",
+                `calc(${this.offsetWidth}px * var(--pdf-scale))`,
+            );
+            $(this).css(
+                "height",
+                `calc(${this.offsetHeight}px * var(--pdf-scale))`,
+            );
         });
     });
 }
 
 function buildCourseUrl(parts = []) {
-    return `${document.body.dataset.courseUrl}/${parts.join('/')}`;
+    return `${document.body.dataset.courseUrl}/${parts.join("/")}`;
 }
 
 function createPage(pageNumber) {
@@ -234,59 +312,61 @@ function createPage(pageNumber) {
     </div>
   </div>
 `;
-    const temp = document.createElement('div');
+    const temp = document.createElement("div");
 
     temp.innerHTML = PAGE_TEMPLATE;
 
     const page = temp.children[0];
-    const canvas = page.querySelector('canvas');
+    const canvas = page.querySelector("canvas");
 
-    page.setAttribute('id', `pageContainer${pageNumber}`);
-    page.setAttribute('data-page-number', pageNumber);
+    page.setAttribute("id", `pageContainer${pageNumber}`);
+    page.setAttribute("data-page-number", pageNumber);
 
     canvas.mozOpaque = true;
-    canvas.setAttribute('id', `page${pageNumber}`);
+    canvas.setAttribute("id", `page${pageNumber}`);
 
     return page;
 }
 
 function renderPage(pageNumber, renderOptions) {
-    const {
-        documentId,
-        pdfDocument,
-        scale,
-        rotate,
-    } = renderOptions;
+    const { documentId, pdfDocument, scale, rotate } = renderOptions;
 
     // Load the page
     return pdfDocument.getPage(pageNumber).then((pdfPage) => {
         const page = document.getElementById(`pageContainer${pageNumber}`);
-        const canvas = page.querySelector('.canvasWrapper canvas');
-        const canvasContext = canvas.getContext('2d', { alpha: false });
+        const canvas = page.querySelector(".canvasWrapper canvas");
+        const canvasContext = canvas.getContext("2d", { alpha: false });
         const totalRotation = (rotate + pdfPage.rotate) % 360;
-        const viewport = pdfPage.getViewport({ scale: scale, rotation: totalRotation });
+        const viewport = pdfPage.getViewport({
+            scale: scale,
+            rotation: totalRotation,
+        });
         const transform = scalePage(pageNumber, viewport, canvasContext);
 
         // Render the page
-        return pdfPage.render({ canvasContext, viewport, transform }).promise.then(() => {
-            // Indicate that the page was loaded
-            page.setAttribute('data-loaded', 'true');
+        return pdfPage
+            .render({ canvasContext, viewport, transform })
+            .promise.then(() => {
+                // Indicate that the page was loaded
+                page.setAttribute("data-loaded", "true");
 
-            return pdfPage;
-        });
+                return pdfPage;
+            });
     });
 }
 
 function scalePage(pageNumber, viewport, context) {
     const page = document.getElementById(`pageContainer${pageNumber}`);
-    const canvas = page.querySelector('.canvasWrapper canvas');
+    const canvas = page.querySelector(".canvasWrapper canvas");
     const outputScale = getOutputScale(context);
-    const transform = !outputScale.scaled ? null : [outputScale.sx, 0, 0, outputScale.sy, 0, 0];
+    const transform = !outputScale.scaled
+        ? null
+        : [outputScale.sx, 0, 0, outputScale.sy, 0, 0];
     const sfx = approximateFraction(outputScale.sx);
     const sfy = approximateFraction(outputScale.sy);
 
     // Adjust width/height for scale
-    page.style.visibility = '';
+    page.style.visibility = "";
     canvas.width = roundToDivide(viewport.width * outputScale.sx, sfx[0]);
     canvas.height = roundToDivide(viewport.height * outputScale.sy, sfy[0]);
     canvas.style.width = `${roundToDivide(viewport.width, sfx[1])}px`;
@@ -299,11 +379,13 @@ function scalePage(pageNumber, viewport, context) {
 
 function getOutputScale(ctx) {
     const devicePixelRatio = window.devicePixelRatio || 1;
-    const backingStoreRatio = ctx.webkitBackingStorePixelRatio
-        || ctx.mozBackingStorePixelRatio
-        || ctx.msBackingStorePixelRatio
-        || ctx.oBackingStorePixelRatio
-        || ctx.backingStorePixelRatio || 1;
+    const backingStoreRatio =
+        ctx.webkitBackingStorePixelRatio ||
+        ctx.mozBackingStorePixelRatio ||
+        ctx.msBackingStorePixelRatio ||
+        ctx.oBackingStorePixelRatio ||
+        ctx.backingStorePixelRatio ||
+        1;
     const pixelRatio = devicePixelRatio / backingStoreRatio;
     return {
         sx: pixelRatio,
@@ -329,8 +411,7 @@ function approximateFraction(x) {
     const limit = 8;
     if (xinv > limit) {
         return [1, limit];
-    }
-    else if (Math.floor(xinv) === xinv) {
+    } else if (Math.floor(xinv) === xinv) {
         return [1, xinv];
     }
 
@@ -344,7 +425,7 @@ function approximateFraction(x) {
 
     // Limit search to order 8.
     while (true) {
-    // Generating next term in sequence (order of q).
+        // Generating next term in sequence (order of q).
         const p = a + c;
         const q = b + d;
         if (q > limit) {
@@ -353,8 +434,7 @@ function approximateFraction(x) {
         if (x_ <= p / q) {
             c = p;
             d = q;
-        }
-        else {
+        } else {
             a = p;
             b = q;
         }
@@ -363,8 +443,7 @@ function approximateFraction(x) {
     // Select closest of neighbours to x.
     if (x_ - a / b < c / d - x_) {
         return x_ === x ? [a, b] : [b, a];
-    }
-    else {
+    } else {
         return x_ === x ? [c, d] : [d, c];
     }
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Fixes layout rendering and zoom height calculation issues in the embedded PDF / notebook viewer within the TA Grading interface and Submission Browser. Previously, `#file-view` and `#notebook-file-view` lacked explicit flex container rules, and `#file-content` used a static `height: 90%`, which caused layout overflow and improper container resizing when viewing embedded PDF documents.

### What is the New Behavior?
- Converted `#file-view` and `#notebook-file-view` to full-height flex containers (`display: flex`, `flex-direction: column`, `height: 100%`).
- Updated `#submission_browser.rubric_panel > div` and `#notebook-view.rubric_panel > div` to stretch `height: 100%`.
- Replaced `height: 90%` on `#file-content` and `#notebook-file-content` with `flex: 1 1 auto; min-height: 0` to enable proper flex item auto-resizing.
- Standardized wheel event listener handling and zoom rescale logic in `PDFEmbedded.js`.

### What steps should a reviewer take to reproduce or test the bug or new feature?
1. Log in as an Instructor or TA and open any gradeable with PDF submissions.
2. Open a student's submission in the TA Grading rubric panel / Submission Browser.
3. Open a PDF document in the embedded viewer and verify that the viewer fills 100% of the panel height cleanly without layout clipping or double scrollbars.
4. Test zoom scaling (mouse wheel and zoom display controls) to ensure the PDF pages rescale properly.

### Automated Testing & Documentation
- **Not a breaking change**
- **No migrations needed**
