### PR TITLE
Unify frontend table CSS for details table

### DIFF
--- a/site/app/templates/grading/electronic/Details.twig
+++ b/site/app/templates/grading/electronic/Details.twig
@@ -221,7 +221,7 @@
     {{ table_sort.table_sort_manager('details-table') }}
 
     {# This is a data table #}
-    <table id="details-table" data-testid="details-table" class="table table-striped table-bordered persist-area table-text-left" data-details-base-path="{{ details_base_path }}">
+    <table id="details-table" data-testid="details-table" class="table table-striped table-bordered persist-area table-text-left mobile-table" data-details-base-path="{{ details_base_path }}">
         <caption />
         {# Table header #}
         <thead>

--- a/site/public/css/details.css
+++ b/site/public/css/details.css
@@ -124,16 +124,6 @@ tbody tr:not(.info) > td:nth-child(1)::after {
 }
 
 @media (max-width: 950px) {
-    table.table,
-    .table thead,
-    .table tbody,
-    .table th,
-    .table td,
-    .table tr {
-        display: block;
-        border: none;
-    }
-
     /* Hide table headers */
     #details-table thead tr {
         background: none;


### PR DESCRIPTION
## Description

This pull request addresses **Submitty issue #13163: Unify Frontend Table CSS** by standardizing the mobile styling for the `details-table`.

The `details-table` previously contained page-specific responsive table CSS that duplicated styling already provided by the shared `mobile-table` class. This change reuses the existing shared styling and removes the duplicate CSS.

### Changes

* Added the shared `mobile-table` class to `details-table`.
* Removed duplicated mobile responsive table styling from `details.css`.
* Reused the existing responsive table styling from `table.css`.

### Testing

* Ran Stylelint on `site/public/css/details.css`.
* Ran `git diff --check`.
* Verified that the changes are limited to the `details-table` template and its CSS.

Related to #13163
