### PR TITLE
[Dependency] Add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency] "
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
@@ -21,6 +23,8 @@ updates:
       prefix: "[Dependency] "
       prefix-development: "[DevDependency] "
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 7
   - package-ecosystem: pip
     directories:
       - "/.setup/pip/"
@@ -32,6 +36,8 @@ updates:
     commit-message:
       prefix: "[Dependency] "
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -43,3 +49,5 @@ updates:
     commit-message:
       prefix: "[DevDependency] "
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Supply-chain attacks typically take a few days to be detected and mitigated.  It's now considered [best-practice](https://github.blog/security/supply-chain-security/the-case-for-a-cooldown-why-dependabot-now-waits-before-issuing-version-updates/) to wait a few days after a release before updating.  GitHub recently added a default 3-day cooldown period, but we should wait longer than that.

### What is the New Behavior?
This PR increases the Dependabot cooldown from the 3-day default to 7 days.