### PR TITLE
[Testing:Developer] Add shell lint

### DIFF
--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     unzip \
     poppler-utils \
     libzbar0 \
+    shellcheck \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -25,6 +25,7 @@ HELP_MESSAGE="
     js-lint   : eslint [option: --fix]
     js-unit   : run js unit tests with jest [option: --api] # if run on host with --api, the VM must be up
     css-lint  : css-stylelint [option: --fix]
+    shell-lint: run ShellCheck
     py-flake8 : run flake8 [option: specific_file.py]
     py-pylint : run pylint [option: specific_file.py]
     py-lint   : py-flake8 & py-pylint [option: specific_file.py]
@@ -149,6 +150,10 @@ run_css_style() {
     fi
 }
 
+run_shell_lint() {
+    run_in_container /home/submitty python3 run_shellcheck.py
+}
+
 run_php_unit() {
     parse_args "${@:2}"
     run_in_container /home/submitty/site php vendor/bin/phpunit "${ARGS[@]}"
@@ -215,6 +220,9 @@ case "${1:-}" in
         ;;
     css-lint)
         run_css_style "$@"
+        ;;
+    shell-lint)
+        run_shell_lint
         ;;
     py-flake8)
         run_py_flake8 "$@"


### PR DESCRIPTION
### Why is this Change Important & Necessary?

The `submitty_test` utility should expose the ShellCheck linting command already used by CI, so developers can run it through the same local test interface as the other linters.

Closes #13295.

### What is the New Behavior?

`submitty_test shell-lint` runs the existing `run_shellcheck.py` wrapper from the repository root inside the test container. The container now installs ShellCheck so the command has the same required executable as CI. The help output lists the new option.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Run `submitty_test --help` and confirm `shell-lint` is listed.
2. Run `submitty_test shell-lint`.
3. Confirm the existing ShellCheck wrapper checks the repository shell scripts and returns its exit status.

Locally, I ran `bash -n .setup/SUBMITTY_TEST.sh`, checked the help output, and exercised the dispatch with a mocked Docker executable. The resulting container command was `python3 run_shellcheck.py` with `/home/submitty` as its working directory.

### Automated Testing & Documentation

The existing ShellCheck CI job remains the authoritative lint test. This change only exposes that existing wrapper through `submitty_test`; no user-facing documentation or separate automated suite is needed.

### Other information

This is not a breaking change, has no migration, and introduces no new security-sensitive behavior. Developed with assistance from OpenAI Codex.