### PR TITLE
[SECURITY][Bugfix:Developer] Pass content to GHA command via env vars

### DIFF
--- a/.github/workflows/notify_issues.yml
+++ b/.github/workflows/notify_issues.yml
@@ -13,8 +13,12 @@ jobs:
     steps:
       - name: Send notification to Zulip
         if: github.event.label.name == 'good first issue'
+        env:
+          ZULIP_AUTHENTICATION: ${{ secrets.ZULIP_AUTHENTICATION }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
+          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u "$ZULIP_AUTHENTICATION" --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
           --data-urlencode 'topic=Available Good First Issue' --data-urlencode \
-          'content=A good first issue has been posted. View here: [${{ github.event.issue.title }}](https://github.com/Submitty/Submitty/issues/${{ github.event.issue.number }}).
-          View a list of all good first issues here: [Good First Issues](https://github.com/Submitty/Submitty/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)'
+          "content=A good first issue has been posted. View here: [$ISSUE_TITLE](https://github.com/Submitty/Submitty/issues/$ISSUE_NUMBER).
+          View a list of all good first issues here: [Good First Issues](https://github.com/Submitty/Submitty/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
GitHub Actions template expressions are evaluated when jobs start.  It's best-practice to expand these templates as environment variable declarations to avoid script injection attacks.  In this case, it was possible to execute a script injection attack via carefully crafted issue titles.

### What is the New Behavior?
The security issue has been remediated.