### PR TITLE
[Testing:Developer] Add YAML lint

### DIFF
--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     poppler-utils \
     libzbar0 \
     shellcheck \
+    yamllint \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -26,6 +26,7 @@ HELP_MESSAGE="
     js-unit   : run js unit tests with jest [option: --api] # if run on host with --api, the VM must be up
     css-lint  : css-stylelint [option: --fix]
     shell-lint: run ShellCheck
+    yaml-lint : run yamllint
     py-flake8 : run flake8 [option: specific_file.py]
     py-pylint : run pylint [option: specific_file.py]
     py-lint   : py-flake8 & py-pylint [option: specific_file.py]
@@ -154,6 +155,10 @@ run_shell_lint() {
     run_in_container /home/submitty python3 run_shellcheck.py
 }
 
+run_yaml_lint() {
+    run_in_container /home/submitty yamllint .
+}
+
 run_php_unit() {
     parse_args "${@:2}"
     run_in_container /home/submitty/site php vendor/bin/phpunit "${ARGS[@]}"
@@ -223,6 +228,9 @@ case "${1:-}" in
         ;;
     shell-lint)
         run_shell_lint
+        ;;
+    yaml-lint)
+        run_yaml_lint
         ;;
     py-flake8)
         run_py_flake8 "$@"


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #13300. The `submitty_test` utility should expose the YAML lint command already used by CI.

### What is the New Behavior?

`submitty_test yaml-lint` runs `yamllint .` from the repository root inside the test container. The container now installs `yamllint`, matching the existing CI dependency.

### What steps should a reviewer take to reproduce or test the bug or new feature?

Build or refresh the test container, then run:

```bash
submitty_test yaml-lint
```

The command should lint the repository using its existing YAML lint configuration.

### Automated Testing & Documentation

Ran `yamllint .`, validated `.setup/SUBMITTY_TEST.sh` with `bash -n`, and exercised the command dispatch with a traced Docker shim. The new command is included in the utility help text.

### Other information

This is not a breaking change, requires no migration, and introduces no new security-sensitive behavior.