### PR TITLE
Fix checkpoint gradeable grader and date display

### DIFF
--- a/site/public/js/simple-grading.js
+++ b/site/public/js/simple-grading.js
@@ -4,7 +4,7 @@
 function updateVisibility() {
     const showGraders = $('#show-graders').is(':checked');
     const showDates = $('#show-dates').is(':checked');
-    $('.cell-grade').each(() => {
+    $('.cell-grade').each(function () {
         const graderElement = $(this).find('.simple-grade-grader');
         const dateElement = $(this).find('.simple-grade-date');
         if (showGraders && graderElement.text().trim() !== '') {


### PR DESCRIPTION
## Description

Fixes an issue where grader names and grading dates were not displayed correctly for checkpoint gradeables when "Show Graders" or "Show Dates Graded" was enabled.

### Changes

* Changed the jQuery `.each()` callback from an arrow function to a regular function.
* This ensures `this` correctly refers to the current `.cell-grade` element.

### Testing

* Manually tested the Simple Grading interface with a checkpoint gradeable.
* Verified that enabling "Show Graders" displays the grader.
* Verified that enabling "Show Dates Graded" displays the grading date.
* Ran `node --check site/public/js/simple-grading.js`.
* Ran `git diff --cached --check`.

Closes #13305
<img width="1920" height="1024" alt="image" src="https://github.com/user-attachments/assets/dd43f192-b557-406f-9d30-84069ec3daf9" />

