### PR TITLE
[Refactor:System] Remove all shell=True arguments

### DIFF
--- a/.github/bin/label_abandoned_prs.py
+++ b/.github/bin/label_abandoned_prs.py
@@ -3,8 +3,8 @@ import subprocess
 import datetime
 from datetime import timedelta
 
-pr_json = "gh pr list -L 1000 --json updatedAt,labels,number,comments,reviews"
-terminal_output = subprocess.check_output(pr_json, shell=True, text=True)
+pr_json = ['gh', 'pr', 'list', '-L', '1000', '--json', 'updatedAt,labels,number,comments,reviews']
+terminal_output = subprocess.check_output(pr_json, text=True)
 json_output = json.loads(terminal_output)
 
 eastern = datetime.timezone(datetime.timedelta(hours=-5))

--- a/.setup/bin/reset_system.py
+++ b/.setup/bin/reset_system.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import glob
 import os
 import pwd
+import re
 import shutil
 import subprocess
 import tempfile
@@ -116,8 +117,9 @@ def main():
                   "xargs -I \"@@\" dropdb -h localhost -U submitty_dbuser \"@@\"")
         del os.environ['PGPASSWORD']
 
-        psql_version = subprocess.check_output("psql -V | egrep -o '[0-9]{1,}\.[0-9]{1,}'",
-                                               shell=True).strip()
+        psql_version_output = subprocess.check_output(["psql", "-V"], text=True)
+        psql_version_match = re.search(r"[0-9]+\.[0-9]+", psql_version_output)
+        psql_version = psql_version_match.group(0) if psql_version_match else ""
 
         try:
             shutil.move('/etc/postgresql/' + str(psql_version) + '/main/pg_hba.conf.backup', '/etc/postgresql/' + str(psql_version) + '/main/pg_hba.conf')

--- a/.setup/bin/sample_courses/models/course/course_create_gradeables.py
+++ b/.setup/bin/sample_courses/models/course/course_create_gradeables.py
@@ -104,7 +104,13 @@ class Course_create_gradeables:
             if gradeable.is_repository:
                 # generate the repos for the vcs gradeable
                 print(f"generating repositories for gradeable {gradeable.id}")
-                subprocess.check_call(f"sudo {SUBMITTY_INSTALL_DIR}/bin/generate_repos.py {self.semester} {self.code} {gradeable.id}", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, shell=True)
+                subprocess.check_call(
+                    [
+                        "sudo", f"{SUBMITTY_INSTALL_DIR}/bin/generate_repos.py",
+                        str(self.semester), str(self.code), str(gradeable.id),
+                    ],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
+                )
 
             gradeable_annotation_path = os.path.join(self.course_path, "annotations", gradeable.id)
 


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Using the `.check_call()` family of arguments with `shell=True` is dangerous because it opens the door to shell injection if input is not sanitized.

### What is the New Behavior?
In preparation for the addition of new static analysis tools rules, this PR removes all cases of this dangerous pattern outside of migrations.  While doing so, I fixed an issue in `reset_system.py` where the return value was always a binary string instead of text, leading to the subsequent `.move()` command turning into a no-op.