### PR TITLE
[Testing:Developer] Don't interpolate GH vars in run blocks

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -163,7 +163,10 @@ runs:
       shell: bash
 
     - name: Set up sample course
-      run: sudo -E env "PATH=$PATH" python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/setup_sample_courses.py ${{ inputs.flags }} ${{ inputs.courses }}
+      env:
+        SETUP_FLAGS: ${{ inputs.flags }}
+        SETUP_COURSES: ${{ inputs.courses }}
+      run: sudo -E env "PATH=$PATH" python3 /usr/local/submitty/GIT_CHECKOUT/Submitty/.setup/bin/setup_sample_courses.py ${SETUP_FLAGS} ${SETUP_COURSES}
       shell: bash
 
     - name: Set up test suite

--- a/.github/workflows/bump_repo.yml
+++ b/.github/workflows/bump_repo.yml
@@ -19,10 +19,13 @@ jobs:
           python-version: 3.11
       - name: Update version
         id: update-version
+        env:
+          REPO_NAME: ${{ github.event.client_payload.repo_name }}
+          REPO_TAG: ${{ github.event.client_payload.tag }}
         run: >
           python3 .setup/bin/update_repo_version.py
-          -r ${{ github.event.client_payload.repo_name }}
-          -v ${{ github.event.client_payload.tag }}
+          -r "$REPO_NAME"
+          -v "$REPO_TAG"
           >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: Submitty/peter-evans-create-pull-request@v23.07.00

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,7 +505,7 @@ jobs:
       - name: Find Merge Base
         run: |
           echo MBASE=$(git --git-dir ${PR_REPO_PATH}/Submitty/.git merge-base               \
-                       -a origin/main ${{ github.sha }}) >> $GITHUB_ENV
+                       -a origin/main "$GITHUB_SHA") >> $GITHUB_ENV
 
       - name: Checkout main Branch
         uses: actions/checkout@v7
@@ -551,6 +551,9 @@ jobs:
           sudo useradd -p $(openssl passwd -1 submitty_dbuser) submitty_dbuser
 
       - name: Configure Submitty
+        env:
+          MAIN_POSTGRES_PORT: ${{ job.services.postgres-main.ports['5432'] }}
+          BRANCH_POSTGRES_PORT: ${{ job.services.postgres-branch.ports['5432'] }}
         run: |
           configure_submitty() {
             # $1->INSTALL_PATH, $2->DATA_PATH, $3->REPO_PATH, $4->DB_PORT
@@ -581,22 +584,25 @@ jobs:
           }
 
           configure_submitty "${MAIN_INSTALL_PATH}" "${MAIN_DATA_PATH}"                     \
-            "${MAIN_REPO_PATH}"     "${{  job.services.postgres-main.ports['5432']  }}"
+            "${MAIN_REPO_PATH}"     "${MAIN_POSTGRES_PORT}"
           configure_submitty "${PR_INSTALL_PATH}"   "${PR_DATA_PATH}"                       \
-            "${PR_REPO_PATH}"       "${{ job.services.postgres-branch.ports['5432'] }}"
+            "${PR_REPO_PATH}"       "${BRANCH_POSTGRES_PORT}"
 
       - name: Create Databases
+        env:
+          MAIN_POSTGRES_PORT: ${{ job.services.postgres-main.ports['5432'] }}
+          BRANCH_POSTGRES_PORT: ${{ job.services.postgres-branch.ports['5432'] }}
         run: |
-          psql -d postgres -h localhost -U postgres -p ${{ job.services.postgres-main.ports['5432'] }} \
+          psql -d postgres -h localhost -U postgres -p "$MAIN_POSTGRES_PORT" \
             -c "CREATE ROLE submitty_dbuser WITH SUPERUSER CREATEDB CREATEROLE LOGIN PASSWORD 'submitty_dbuser'"\
             -c "CREATE ROLE submitty_course_dbuser WITH LOGIN PASSWORD 'submitty_course_dbuser'"
-          psql -d postgres -h localhost -U submitty_dbuser -p ${{  job.services.postgres-main.ports['5432']  }} \
+          psql -d postgres -h localhost -U submitty_dbuser -p "$MAIN_POSTGRES_PORT" \
             -c "CREATE DATABASE submitty"
 
-          psql -d postgres -h localhost -U postgres        -p ${{ job.services.postgres-branch.ports['5432'] }} \
+          psql -d postgres -h localhost -U postgres        -p "$BRANCH_POSTGRES_PORT" \
             -c "CREATE ROLE submitty_dbuser WITH SUPERUSER CREATEDB CREATEROLE LOGIN PASSWORD 'submitty_dbuser'"\
             -c "CREATE ROLE submitty_course_dbuser WITH LOGIN PASSWORD 'submitty_course_dbuser'"
-          psql -d postgres -h localhost -U submitty_dbuser -p ${{ job.services.postgres-branch.ports['5432'] }} \
+          psql -d postgres -h localhost -U submitty_dbuser -p "$BRANCH_POSTGRES_PORT" \
             -c "CREATE DATABASE submitty"
 
       - name: Create Database Dumper
@@ -649,16 +655,19 @@ jobs:
           sudo chmod -vR 777 ${PR_DATA_PATH}/courses
 
       - name: Dump Migrated Databases
+        env:
+          MAIN_POSTGRES_PORT: ${{ job.services.postgres-main.ports['5432'] }}
+          BRANCH_POSTGRES_PORT: ${{ job.services.postgres-branch.ports['5432'] }}
         run: |
           ./dbdump.sh "submitty"                "${GITHUB_WORKSPACE}/dumped/main/master.sql"\
-            "${{  job.services.postgres-main.ports['5432']  }}"
+            "${MAIN_POSTGRES_PORT}"
           ./dbdump.sh "submitty_${M}${Y}_blank" "${GITHUB_WORKSPACE}/dumped/main/course.sql"\
-            "${{  job.services.postgres-main.ports['5432']  }}"
+            "${MAIN_POSTGRES_PORT}"
 
           ./dbdump.sh "submitty"                "${GITHUB_WORKSPACE}/dumped/branch/master.sql"\
-            "${{ job.services.postgres-branch.ports['5432'] }}"
+            "${BRANCH_POSTGRES_PORT}"
           ./dbdump.sh "submitty_${M}${Y}_blank" "${GITHUB_WORKSPACE}/dumped/branch/course.sql"\
-            "${{ job.services.postgres-branch.ports['5432'] }}"
+            "${BRANCH_POSTGRES_PORT}"
 
       - name: Compare Migrated master Databases
         if: always()
@@ -1063,16 +1072,16 @@ jobs:
 
       - name: Update database values
         run: |
-            tmp=$(mktemp) && jq --arg v "localhost" '.database_host = $v' "${{ github.WORKSPACE }}/.setup/data/configs/database.json" > "$tmp" && mv "$tmp" "${{ github.WORKSPACE }}/.setup/data/configs/database.json"
-            tmp=$(mktemp) && jq --arg v "DatabaseAuthentication" '.authentication_method = $v' "${{ github.WORKSPACE }}/.setup/data/configs/authentication.json" > "$tmp" && mv "$tmp" "${{ github.WORKSPACE }}/.setup/data/configs/authentication.json"
-            tmp=$(mktemp) && jq --arg v "http://localhost" '.submission_url = $v' "${{ github.WORKSPACE }}/.setup/data/configs/submitty.json" > "$tmp" && mv "$tmp" "${{ github.WORKSPACE }}/.setup/data/configs/submitty.json"
-            tmp=$(mktemp) && jq --arg v "http://localhost/cgi-bin" '.cgi_url = $v' "${{ github.WORKSPACE }}/.setup/data/configs/submitty.json" > "$tmp" && mv "$tmp" "${{ github.WORKSPACE }}/.setup/data/configs/submitty.json"
+            tmp=$(mktemp) && jq --arg v "localhost" '.database_host = $v' "${GITHUB_WORKSPACE}/.setup/data/configs/database.json" > "$tmp" && mv "$tmp" "${GITHUB_WORKSPACE}/.setup/data/configs/database.json"
+            tmp=$(mktemp) && jq --arg v "DatabaseAuthentication" '.authentication_method = $v' "${GITHUB_WORKSPACE}/.setup/data/configs/authentication.json" > "$tmp" && mv "$tmp" "${GITHUB_WORKSPACE}/.setup/data/configs/authentication.json"
+            tmp=$(mktemp) && jq --arg v "http://localhost" '.submission_url = $v' "${GITHUB_WORKSPACE}/.setup/data/configs/submitty.json" > "$tmp" && mv "$tmp" "${GITHUB_WORKSPACE}/.setup/data/configs/submitty.json"
+            tmp=$(mktemp) && jq --arg v "http://localhost/cgi-bin" '.cgi_url = $v' "${GITHUB_WORKSPACE}/.setup/data/configs/submitty.json" > "$tmp" && mv "$tmp" "${GITHUB_WORKSPACE}/.setup/data/configs/submitty.json"
 
       - name: Run ansible script
         shell: bash
         run: |
           cd .setup/ansible
-          ansible-playbook --private-key /home/runner/.ssh/id_rsa -e 'ansible_user=runner submitty_install_config_location=${{ github.WORKSPACE }}/.setup/data/configs/ submitty_install_submitty_version=${{ github.sha }} submitty_install_github_url=https://github.com/${{ github.repository }}.git' -i inventory/submitty playbooks/submitty_install.yml
+          ansible-playbook --private-key /home/runner/.ssh/id_rsa -e "ansible_user=runner submitty_install_config_location=${GITHUB_WORKSPACE}/.setup/data/configs/ submitty_install_submitty_version=${GITHUB_SHA} submitty_install_github_url=https://github.com/${GITHUB_REPOSITORY}.git" -i inventory/submitty playbooks/submitty_install.yml
           ansible-playbook --private-key /home/runner/.ssh/id_rsa -e 'ansible_user=runner' -i inventory/submitty playbooks/submitty_course_creation.yml
 
       - name: Set perms

--- a/.github/workflows/first_issue_reply.yml
+++ b/.github/workflows/first_issue_reply.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Check for existing bot comments
         id: check-comments
         run: |
-          ISSUE_NUMBER=${{ github.event.issue.number }}
           BOT_COMMENT_EXISTS=$(gh issue view "$ISSUE_NUMBER" --json comments --jq '.comments[].body' | grep -q "Hi @$USERNAME," && echo "true" || echo "false")
           echo "bot_comment_exists=$BOT_COMMENT_EXISTS" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
           USERNAME: ${{ github.event.comment.user.login }}
 
       - name: First issue reply

--- a/.github/workflows/first_pr_open.yml
+++ b/.github/workflows/first_pr_open.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Check if this is user's first PR
         id: check-first-pr
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
           SIX_MONTHS_AGO=$(date -d '6 months ago' +%Y-%m-%d)
           FIRST_PR=$(gh pr list --author "$USERNAME" --state all --search "created:>=$SIX_MONTHS_AGO" --limit 1 | wc -l | xargs -I {} test {} -eq 1 && echo "false" || echo "true")
           echo "first_pr=$FIRST_PR" >> $GITHUB_ENV
@@ -32,11 +31,11 @@ jobs:
       - name: Check for existing bot comments
         id: check-comments
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
           BOT_COMMENT_EXISTS=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -q "Hi @$USERNAME," && echo "true" || echo "false")
           echo "bot_comment_exists=$BOT_COMMENT_EXISTS" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           USERNAME: ${{ github.event.pull_request.user.login }}
 
       - name: First PR Open

--- a/.github/workflows/notify_main_fail.yml
+++ b/.github/workflows/notify_main_fail.yml
@@ -16,10 +16,13 @@ jobs:
     steps:
       - name: Send notification to Zulip on failure
         if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        env:
+          ZULIP_AUTHENTICATION: ${{ secrets.ZULIP_AUTHENTICATION }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-            curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
+            curl -X POST https://submitty.zulipchat.com/api/v1/messages -u "$ZULIP_AUTHENTICATION" --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' \
             --data-urlencode 'topic=Main CI Failures' --data-urlencode \
-            'content=The Github Actions CI has failed on the Main branch, View here: [Main CI](https://github.com/Submitty/Submitty/actions/runs/${{ github.event.workflow_run.id }})'
+            "content=The Github Actions CI has failed on the Main branch, View here: [Main CI](https://github.com/Submitty/Submitty/actions/runs/$WORKFLOW_RUN_ID)"
       - name: Echo success message
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: |

--- a/.github/workflows/save_vm.yaml
+++ b/.github/workflows/save_vm.yaml
@@ -55,15 +55,22 @@ jobs:
 
       - name: Get HCP token
         id: hcp-token
+        env:
+          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
         run: |
-          hcp auth login --client-id=${{ secrets.HCP_CLIENT_ID }} --client-secret=${{ secrets.HCP_CLIENT_SECRET }}
+          hcp auth login --client-id="$HCP_CLIENT_ID" --client-secret="$HCP_CLIENT_SECRET"
           echo "HCP_TOKEN=$(hcp auth print-access-token)" >> $GITHUB_OUTPUT
 
       - name: Publish image
+        env:
+          VAGRANT_CLOUD_TOKEN_SECRET: ${{ secrets.VAGRANT_CLOUD_TOKEN }}
+          HCP_TOKEN: ${{ steps.hcp-token.outputs.HCP_TOKEN }}
+          IMAGE_VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          export VAGRANT_CLOUD_TOKEN="${{ secrets.VAGRANT_CLOUD_TOKEN }};${{ steps.hcp-token.outputs.HCP_TOKEN }}"
+          export VAGRANT_CLOUD_TOKEN="${VAGRANT_CLOUD_TOKEN_SECRET};${HCP_TOKEN}"
           vagrant cloud auth login
-          vagrant cloud publish SubmittyBot/ubuntu22-dev ${{ steps.get-version.outputs.version }}.$(date +"%y%m%d%H%M") virtualbox submitty.box --release --force
+          vagrant cloud publish SubmittyBot/ubuntu22-dev "${IMAGE_VERSION}.$(date +"%y%m%d%H%M")" virtualbox submitty.box --release --force
           vagrant cloud auth logout
 
       - name: Acquire Job ID
@@ -71,16 +78,24 @@ jobs:
         id: get-job-id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
-          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          jobs=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs")
+          job_id=$(echo "$jobs" | jq -r --arg name "$RUNNER_NAME" '.jobs[] | select(.runner_name==$name) | .id')
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Send zulip message on failure
         if: failure()
+        env:
+          ZULIP_AUTHENTICATION: ${{ secrets.ZULIP_AUTHENTICATION }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ steps.get-job-id.outputs.job_id }}
         run: |
-          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} \
+          curl -X POST https://submitty.zulipchat.com/api/v1/messages -u "$ZULIP_AUTHENTICATION" \
             --data-urlencode 'type=stream' \
             --data-urlencode 'to=Submitty Developer Studio' \
             --data-urlencode 'topic=Vagrant Up Failures' \
-            --data-urlencode 'content=The Package Vagrant VM Github Action has failed, this means the VM is not saved, and requires attention. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'
+            --data-urlencode "content=The Package Vagrant VM Github Action has failed, this means the VM is not saved, and requires attention. View here: https://github.com/Submitty/Submitty/actions/runs/$RUN_ID/job/$JOB_ID"

--- a/.github/workflows/vagrant_up.yaml
+++ b/.github/workflows/vagrant_up.yaml
@@ -33,11 +33,19 @@ jobs:
         id: get-job-id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
-          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          jobs=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs")
+          job_id=$(echo "$jobs" | jq -r --arg name "$RUNNER_NAME" '.jobs[] | select(.runner_name==$name) | .id')
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
       - name: Send zulip message on failure
         if: failure()
+        env:
+          ZULIP_AUTHENTICATION: ${{ secrets.ZULIP_AUTHENTICATION }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ steps.get-job-id.outputs.job_id }}
         run: |
-         curl -X POST https://submitty.zulipchat.com/api/v1/messages -u ${{ secrets.ZULIP_AUTHENTICATION }} --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' --data-urlencode 'topic=Vagrant Up Failures' --data-urlencode 'content=The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/${{ github.run_id }}/job/${{ steps.get-job-id.outputs.job_id }}'
+         curl -X POST https://submitty.zulipchat.com/api/v1/messages -u "$ZULIP_AUTHENTICATION" --data-urlencode 'type=stream' --data-urlencode 'to=Submitty Developer Studio' --data-urlencode 'topic=Vagrant Up Failures' --data-urlencode "content=The Vagrant Up Github Action has failed. View here: https://github.com/Submitty/Submitty/actions/runs/$RUN_ID/job/$JOB_ID"


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Using GitHub Actions variable interpolation in `run` blocks is a dangerous pattern because it enables command injection when the variable value is user-controlled, such as in https://github.com/Submitty/Submitty/pull/13298.

### What is the New Behavior?
This PR replaces all GHA variable interpolation with environment variable interpolation, which safely wraps variables in quoted shell strings.