### PR TITLE
[Bugfix:Developer] Fix `submitty_test <abc>`  with no args

### DIFF
--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -156,7 +156,7 @@ run_shell_lint() {
 
 run_php_unit() {
     parse_args "${@:2}"
-    run_in_container /home/submitty/site php vendor/bin/phpunit "${ARGS[@]}"
+    run_in_container /home/submitty/site php vendor/bin/phpunit ${ARGS[@]+"${ARGS[@]}"}
 }
 
 run_py_flake8() {
@@ -179,22 +179,22 @@ run_py_pylint() {
 
 run_py_unit_utils() {
     parse_args "${@:2}"
-    run_in_container /home/submitty/python_submitty_utils python3 -m unittest discover "${ARGS[@]}"
+    run_in_container /home/submitty/python_submitty_utils python3 -m unittest discover ${ARGS[@]+"${ARGS[@]}"}
 }
 
 run_py_unit_migration() {
     parse_args "${@:2}"
-    run_in_container /home/submitty/migration python3 -m unittest discover "${ARGS[@]}"
+    run_in_container /home/submitty/migration python3 -m unittest discover ${ARGS[@]+"${ARGS[@]}"}
 }
 
 run_py_unit_autograder() {
     parse_args "${@:2}"
-    run_in_container /home/submitty/autograder python3 -m unittest discover "${ARGS[@]}"
+    run_in_container /home/submitty/autograder python3 -m unittest discover ${ARGS[@]+"${ARGS[@]}"}
 }
 
 run_py_unit_daemon() {
     parse_args "${@:2}"
-    run_in_container /home/submitty/sbin/submitty_daemon_jobs python3 -m unittest discover tests -t . "${ARGS[@]}"
+    run_in_container /home/submitty/sbin/submitty_daemon_jobs python3 -m unittest discover tests -t . ${ARGS[@]+"${ARGS[@]}"}
 }
 
 # process input arguments


### PR DESCRIPTION
### Why is this Change Important & Necessary?
`submitty_test php-unit` (and other scripts) with no extra arguments currently fails on macOS since macOS comes with an old version of Bash.

```
./.setup/SUBMITTY_TEST.sh: line 159: ARGS[@]: unbound variable
```

### What is the New Behavior?
This PR fixes the issue by using parameter expansion to expand the empty variable to nothing.  If anyone has a better way to fix this, please feel free to push commits to this PR or open a separate PR.