### PR TITLE
[Bugfix:Notifications] Omit a due date the gradeable lacks

### DIFF
--- a/sbin/send_notification.py
+++ b/sbin/send_notification.py
@@ -136,6 +136,7 @@ def construct_notifications(term, course, pending, notification_type):
             "title": notification.get('g_title'),
             "depends_on": notification.get('depends_on'),
             "submission_due_date": notification.get('submission_due_date'),
+            "has_due_date": notification.get('has_due_date'),
             "team_id": notification.get('team_id'),
             "user_id": notification.get('user_id'),
             "user_email": notification.get('user_email'),
@@ -160,16 +161,25 @@ def construct_notifications(term, course, pending, notification_type):
         # Notification-related content
         if notification_type == "gradeable_release":
             email_subject = f"Submissions Open: {gradeable['title']}"
-            notification_content = (
-                f"{email_subject} | Due {format_timestamp(gradeable['submission_due_date'])}"
-            )
+            # eg_submission_due_date is NOT NULL, so a gradeable configured with
+            # no due date still carries a date here. eg_has_due_date is the only
+            # thing that says whether it means anything, and quoting it
+            # otherwise announces a deadline that does not exist.
             email_body = (
                 f"Submissions are now being accepted for \"{gradeable['title']}\" in course "
-                f"{get_full_course_name(term, course)}.\n\n"
-                f"Deadline: {format_timestamp(gradeable['submission_due_date'])}\n"
-                f"Late Days: {gradeable['remaining_late_days']} remaining, "
-                f"{gradeable['max_late_days']} allowed"
+                f"{get_full_course_name(term, course)}."
             )
+            if gradeable['has_due_date']:
+                notification_content = (
+                    f"{email_subject} | Due {format_timestamp(gradeable['submission_due_date'])}"
+                )
+                email_body += (
+                    f"\n\nDeadline: {format_timestamp(gradeable['submission_due_date'])}\n"
+                    f"Late Days: {gradeable['remaining_late_days']} remaining, "
+                    f"{gradeable['max_late_days']} allowed"
+                )
+            else:
+                notification_content = email_subject
         else:
             email_subject = notification_content = f"Grade Available for {gradeable['title']}"
             email_body = (
@@ -374,6 +384,7 @@ def send_pending_notifications():
                 g.g_title AS g_title,
                 eg.eg_depends_on AS depends_on,
                 eg.eg_submission_due_date AS submission_due_date,
+                eg.eg_has_due_date AS has_due_date,
                 u.user_id AS user_id,
                 u.user_email AS user_email,
                 COALESCE(ns.all_gradeable_releases, TRUE) AS site_enabled,
@@ -439,7 +450,8 @@ def send_pending_notifications():
                         AND n.content ILIKE '%' || 'Submissions Open: ' || g.g_title || '%'
                     )
                 )
-            GROUP BY g.g_id, g.g_title, eg.eg_submission_due_date, u.user_id, u.user_email,
+            GROUP BY g.g_id, g.g_title, eg.eg_submission_due_date, eg.eg_has_due_date,
+                u.user_id, u.user_email,
                 ns.all_gradeable_releases, ns.all_gradeable_releases_email, eg.eg_late_days,
                 eg.eg_depends_on, ldc.late_days_remaining
             """), {


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #13202.

`electronic_gradeable.eg_submission_due_date` is `NOT NULL`, so a gradeable configured with **no** due date still carries a date in that column. `eg_has_due_date` is the only thing that says whether that date means anything.

`sbin/send_notification.py` read the column and never the flag, so the release notification announced a deadline that does not exist — in the site notification and in the email, which is both screenshots in the issue.

### What is the New Behavior?

The query selects `eg.eg_has_due_date`, and the `| Due …` suffix, the `Deadline:` line and the late-day line are emitted only when it is true.

The late-day line goes with them deliberately: late days are counted against a due date, so `Late Days: 3 remaining, 2 allowed` on a gradeable with no deadline is the same class of statement as the date itself. Say the word if you would rather keep it.

Replaying the message construction with the same f-strings the file now contains:

**`eg_has_due_date = true` — unchanged, byte for byte**

```
site notification: Submissions Open: Homework 1 | Due 2026-09-20 @ 11:59 PM
email subject:     Submissions Open: Homework 1
email body:
    Submissions are now being accepted for "Homework 1" in course cs101 (f26).

    Deadline: 2026-09-20 @ 11:59 PM
    Late Days: 3 remaining, 2 allowed
```

**`eg_has_due_date = false` — the fix**

```
site notification: Submissions Open: Homework 1
email subject:     Submissions Open: Homework 1
email body:
    Submissions are now being accepted for "Homework 1" in course cs101 (f26).
```

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. As an instructor, create an electronic gradeable and set **Due Date** to *no* on the dates page, with student view and student submit on and the open date in the past.
2. Wait for `submitty_daemon`'s notification pass, or run `sbin/send_notification.py` by hand.
3. The site notification now reads **Submissions Open: &lt;title&gt;** with no `| Due …`, and the email body has no `Deadline:` and no `Late Days:` line.
4. Repeat on a gradeable that *does* have a due date and confirm both are exactly as before.

### Automated Testing & Documentation

No automated test added. `sbin/send_notification.py` has no test module — it talks to the course database throughout, and `construct_notifications()` takes a live result set, so testing this branch means either a database fixture or splitting the message building out into a pure function. Both are bigger than this fix and neither belongs in it uninvited; happy to open a follow-up issue for the refactor if you want the coverage.

What I ran locally:

- Replayed the changed block against both `has_due_date` values with stub data — that is the output above.
- `python3 -m flake8 sbin/send_notification.py` — clean.

No documentation change: nothing configurable changed, only what a notification says about a gradeable that was already configured this way.

### Other information

Not a breaking change, no migration; `eg_has_due_date` already exists (added in `20181013180203_has_due_date.py`) and is only being read.

One thing I deliberately did **not** change, since it is beyond the issue: the `WHERE` clause still requires `eg.eg_submission_due_date >= NOW()`. For a gradeable with no due date that stale column decides whether a notification is sent at all, which looks wrong — a gradeable with no deadline is always open — but changing it would start sending notifications that are not sent today, which wants its own issue and its own review.

Per CONTRIBUTING's "citing/crediting all individuals and tools": this change was written with AI assistance. I understand it, ran the checks above myself, and can revise it in review.
