### PR TITLE
[Feature:Developer] Add twig-lint to submitty_test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --dev
       - name: Lint Twig Templates
-        run: php scripts/symfony_console lint:twig --format=github app/ public/ room_templates/
+        run: composer run-script lint:twig -- --format=github
 
   php-lint:
     name: PHP Lint

--- a/.setup/SUBMITTY_TEST.sh
+++ b/.setup/SUBMITTY_TEST.sh
@@ -25,6 +25,7 @@ HELP_MESSAGE="
     js-lint   : eslint [option: --fix]
     js-unit   : run js unit tests with jest [option: --api] # if run on host with --api, the VM must be up
     css-lint  : css-stylelint [option: --fix]
+    twig-lint : lint twig templates [option: --format github, ...]
     shell-lint: run ShellCheck
     py-flake8 : run flake8 [option: specific_file.py]
     py-pylint : run pylint [option: specific_file.py]
@@ -150,6 +151,15 @@ run_css_style() {
     fi
 }
 
+run_twig_lint() {
+    parse_args "${@:2}"
+    if [ ${#ARGS[@]} -gt 0 ]; then
+        run_in_container /home/submitty/site composer run-script lint:twig -- "${ARGS[@]}"
+    else
+        run_in_container /home/submitty/site composer run-script lint:twig
+    fi
+}
+
 run_shell_lint() {
     run_in_container /home/submitty python3 run_shellcheck.py
 }
@@ -220,6 +230,9 @@ case "${1:-}" in
         ;;
     css-lint)
         run_css_style "$@"
+        ;;
+    twig-lint)
+        run_twig_lint "$@"
         ;;
     shell-lint)
         run_shell_lint

--- a/site/composer.json
+++ b/site/composer.json
@@ -55,6 +55,7 @@
     "test": "phpunit",
     "lint": "php vendor/bin/phpcs --extensions=php ./app",
     "lint:fix": "php vendor/bin/phpcbf --extensions=php ./app",
+    "lint:twig": "php scripts/symfony_console lint:twig app/ public/ room_templates/",
     "static-analysis": "php vendor/bin/phpstan analyze"
   }
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?

Closes #13296.

Twig lint runs in CI (`.github/workflows/ci.yml`, the `twig-lint` job) but had no `submitty_test` option, so it was the one linter a contributor could not reproduce with the utility — you found out from a red check instead.

### What is the New Behavior?

```
    css-lint  : css-stylelint [option: --fix]
    twig-lint : lint twig templates [option: --format github, ...]
    shell-lint: run ShellCheck
```

```bash
./.setup/SUBMITTY_TEST.sh twig-lint
./.setup/SUBMITTY_TEST.sh twig-lint --format github
```

Arguments are forwarded exactly the way the other linters forward theirs, through the existing `parse_args` helper.

The one thing here that is a judgement call rather than mechanical: the command itself moves into `site/composer.json` as a `lint:twig` script,

```json
"lint:twig": "php scripts/symfony_console lint:twig app/ public/ room_templates/",
```

and **both** the utility and the CI job now call that instead of spelling out the path list. Otherwise this PR would create a second copy of `app/ public/ room_templates/`, and the next directory added to the lint would get added to one of them. It also puts Twig alongside `lint`, `lint:fix` and `static-analysis`, which is where the other linters already live and what `run_php_cs` / `run_php_stan` already call. CI keeps `--format=github`, now passed through:

```yaml
- name: Lint Twig Templates
  run: composer run-script lint:twig -- --format=github
```

`working-directory: site` is already set on that job, and composer runs scripts from the directory of its `composer.json`, so the relative paths resolve identically in both callers.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. `./.setup/SUBMITTY_TEST.sh help` — `twig-lint` is listed between `css-lint` and `shell-lint`.
2. `./.setup/SUBMITTY_TEST.sh twig-lint` — passes on a clean tree.
3. Break a template, e.g. drop the `%}` from a tag in `site/app/templates/Navigation.twig`, and re-run — it fails and names the file and line.
4. `./.setup/SUBMITTY_TEST.sh twig-lint --format github` — same result in the CI annotation format.
5. Confirm the CI `Twig Lint` job on this PR is still green with the reworded step.

### Automated Testing & Documentation

No automated test; `SUBMITTY_TEST.sh` has none, and this follows the shape of the eleven options already there.

What I ran locally:

- `shellcheck .setup/SUBMITTY_TEST.sh` — clean.
- `bash -n .setup/SUBMITTY_TEST.sh` — clean.
- `site/composer.json` and `.github/workflows/ci.yml` both parse.

**Not verified locally:** actually executing `twig-lint`. It runs inside the `submitty_test` Docker image and needs `site/vendor`, which I do not have on this machine, so the CI `Twig Lint` job on this PR is the first real run of the new composer script — and since CI now goes through the same script the utility does, a green job there is evidence for both paths.

Documentation: the utility's own `help` output is updated. If `twig-lint` should also appear on submitty.org's developer page alongside the other options, point me at it and I will send that too.

### Other information

Not a breaking change, no migration, no security impact. Three files, no behaviour change to what is linted — the same three directories, by the same command.

Per CONTRIBUTING's "citing/crediting all individuals and tools": this change was written with AI assistance. I understand it, ran the checks above myself, and can revise it in review.
