### PR TITLE
[Testing:System] Improve utils code coverage

### DIFF
--- a/site/tests/app/libraries/DateUtilsTester.php
+++ b/site/tests/app/libraries/DateUtilsTester.php
@@ -239,4 +239,41 @@ class DateUtilsTester extends \PHPUnit\Framework\TestCase {
     public function testTimeIntoToString(int $time, string $expected): void {
         $this->assertSame($expected, DateUtils::timeIntToString($time));
     }
+
+    public function testGetDateTimeNowThrowsWithoutTimezone(): void {
+        $property = new \ReflectionProperty(DateUtils::class, 'timezone');
+        $property->setAccessible(true);
+        $original = $property->getValue();
+        $property->setValue(null, null);
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Need to call setTimezone before calling getDateTimeNow');
+            DateUtils::getDateTimeNow();
+        }
+        finally {
+            $property->setValue(null, $original);
+        }
+    }
+
+    public function testSetTimezoneAndGetDateTimeNow(): void {
+        DateUtils::setTimezone(new \DateTimeZone('America/New_York'));
+        $now = DateUtils::getDateTimeNow();
+        $this->assertInstanceOf(\DateTime::class, $now);
+        $this->assertSame('America/New_York', $now->getTimezone()->getName());
+    }
+
+    public function testGetOrderedTZWithUTCOffset(): void {
+        $result = DateUtils::getOrderedTZWithUTCOffset();
+        $this->assertIsArray($result);
+        $this->assertGreaterThan(1, count($result));
+        $this->assertSame('NOT_SET/NOT_SET', $result[0]);
+        foreach (array_slice($result, 1) as $entry) {
+            $this->assertMatchesRegularExpression('/^\(UTC[^)]*\) .+/', $entry);
+        }
+    }
+
+    public function testGetFileNameTimeStamp(): void {
+        $timestamp = DateUtils::getFileNameTimeStamp();
+        $this->assertMatchesRegularExpression('/^\d{14}$/', $timestamp);
+    }
 }

--- a/site/tests/app/libraries/FileUtilsTester.php
+++ b/site/tests/app/libraries/FileUtilsTester.php
@@ -1023,4 +1023,223 @@ STRING;
             chmod($test_file, 0777);
         }
     }
+
+    public function testIsEmptyDirTrue() {
+        FileUtils::createDir($this->path);
+        $this->assertTrue(FileUtils::isEmptyDir($this->path));
+    }
+
+    public function testIsEmptyDirFalse() {
+        FileUtils::createDir($this->path);
+        file_put_contents(FileUtils::joinPaths($this->path, 'test.txt'), 'a');
+        $this->assertFalse(FileUtils::isEmptyDir($this->path));
+    }
+
+    public function testValidateZipFileSizeNotZip() {
+        FileUtils::createDir($this->path);
+        $file = FileUtils::joinPaths($this->path, 'notzip.txt');
+        file_put_contents($file, 'not a zip');
+        $this->assertFalse(FileUtils::validateZipFileSize($file));
+    }
+
+    public function testValidateZipFileSizeValidZip() {
+        FileUtils::createDir($this->path);
+        $file = FileUtils::joinPaths($this->path, 'test.zip');
+        $zip = new \ZipArchive();
+        $zip->open($file, \ZipArchive::CREATE);
+        $zip->addFromString('a.txt', 'hello world');
+        $zip->addFromString('b.txt', 'goodbye world');
+        $zip->close();
+        $this->assertTrue(FileUtils::validateZipFileSize($file));
+    }
+
+    public static function submissionMetaFileProvider() {
+        return [
+            ['.submit.notebook', true],
+            ['.submit.timestamp', true],
+            ['.submit.VCS_CHECKOUT', true],
+            ['.user_assignment_access.json', true],
+            ['.bulk_upload_data.json', true],
+            ['.upload_page_1', true],
+            ['.upload_version_2', true],
+            ['not_a_meta_file.txt', false],
+        ];
+    }
+
+    /**
+     * @dataProvider submissionMetaFileProvider
+     */
+    public function testIsSubmissionMetaFile($filename, $expected) {
+        $this->assertSame($expected, FileUtils::isSubmissionMetaFile($filename));
+    }
+
+    public function testReadAsDataUrl() {
+        FileUtils::createDir($this->path);
+        $file = FileUtils::joinPaths($this->path, 'test.txt');
+        file_put_contents($file, 'hello world');
+        $expected = 'data:text/plain;base64,' . base64_encode('hello world');
+        $this->assertSame($expected, FileUtils::readAsDataURL($file));
+    }
+
+    public function testReadAsDataUrlNotReadable() {
+        $this->expectException(FileReadException::class);
+        $this->expectExceptionMessage('Unable to read file at the given path.');
+        FileUtils::readAsDataURL(FileUtils::joinPaths($this->path, 'missing.txt'));
+    }
+
+    public function testGetDirContents() {
+        FileUtils::createDir($this->path);
+        file_put_contents(FileUtils::joinPaths($this->path, 'a.txt'), 'a');
+        FileUtils::createDir(FileUtils::joinPaths($this->path, 'sub'));
+        file_put_contents(FileUtils::joinPaths($this->path, 'sub', 'b.txt'), 'b');
+
+        $results = [];
+        FileUtils::getDirContents($this->path, $results);
+        sort($results);
+
+        $expected = [
+            FileUtils::joinPaths($this->path, 'a.txt'),
+            FileUtils::joinPaths($this->path, 'sub'),
+            FileUtils::joinPaths($this->path, 'sub', 'b.txt'),
+        ];
+        sort($expected);
+        $this->assertEquals($expected, $results);
+    }
+
+    public function testGetTopEmptyDir() {
+        FileUtils::createDir(FileUtils::joinPaths($this->path, 'a', 'b', 'c'), true);
+
+        $results = [];
+        FileUtils::getTopEmptyDir(
+            FileUtils::joinPaths($this->path, 'a', 'b', 'c', 'missing.txt'),
+            $this->path,
+            $results
+        );
+
+        $expected = [
+            FileUtils::joinPaths($this->path, 'a'),
+            FileUtils::joinPaths($this->path, 'a', 'b'),
+            FileUtils::joinPaths($this->path, 'a', 'b', 'c'),
+        ];
+        $this->assertEquals($expected, $results);
+    }
+
+    public function testGetTopEmptyDirStopsAtNonEmptyDir() {
+        FileUtils::createDir(FileUtils::joinPaths($this->path, 'x', 'y'), true);
+        file_put_contents(FileUtils::joinPaths($this->path, 'x', 'file.txt'), 'a');
+
+        $results = [];
+        FileUtils::getTopEmptyDir(
+            FileUtils::joinPaths($this->path, 'x', 'y', 'missing.txt'),
+            $this->path,
+            $results
+        );
+
+        $expected = [FileUtils::joinPaths($this->path, 'x', 'y')];
+        $this->assertEquals($expected, $results);
+    }
+
+    public static function validPathProvider() {
+        return [
+            ['folder/file.txt', true],
+            ['folder:name', false],
+            ['folder*name', false],
+            ['folder?name', false],
+            ['folder"name', false],
+            ['folder<name', false],
+            ['folder>name', false],
+            ['folder|name', false],
+            ['folder\0name', false],
+            ['folder/../file.txt', false],
+            ['../file.txt', false],
+        ];
+    }
+
+    /**
+     * @dataProvider validPathProvider
+     */
+    public function testValidPath($path, $expected) {
+        $this->assertSame($expected, FileUtils::validPath($path));
+    }
+
+    public function testCheckForPermissionErrorsFileDoesNotExist() {
+        $file = FileUtils::joinPaths($this->path, 'missing.txt');
+        $this->assertEquals(
+            ["'{$file}' does not exist."],
+            FileUtils::checkForPermissionErrors($file, null, null, null)
+        );
+    }
+
+    /**
+     * /etc/passwd is root-owned, root-group-owned, and world-readable on every Unix system,
+     * which lets us exercise real owner/group name resolution without needing chown/chgrp
+     * privileges (unavailable to the unprivileged, unmapped UID the test container runs as)
+     * to control ownership of a file ourselves. Writability depends on whether the test
+     * happens to run as root, so that expectation is computed rather than hardcoded.
+     */
+    private function expectedNotWritableErrors(string $path): array {
+        return is_writable($path) ? [] : ["'{$path}' is not writable."];
+    }
+
+    public function testCheckForPermissionErrorsOwnerMatch() {
+        $this->assertEquals(
+            $this->expectedNotWritableErrors('/etc/passwd'),
+            FileUtils::checkForPermissionErrors('/etc/passwd', null, 'root', null)
+        );
+    }
+
+    public function testCheckForPermissionErrorsOwnerMismatch() {
+        $expected = array_merge(
+            ["Expected '/etc/passwd' to have owner 'not_a_real_owner' but instead got 'root'."],
+            $this->expectedNotWritableErrors('/etc/passwd')
+        );
+        $this->assertEquals(
+            $expected,
+            FileUtils::checkForPermissionErrors('/etc/passwd', null, 'not_a_real_owner', null)
+        );
+    }
+
+    public function testCheckForPermissionErrorsGroupMismatch() {
+        // No group in this container has any members listed in /etc/group, and an unprivileged
+        // user can't chgrp a file into a group they don't already belong to, so the membership
+        // check below always fails too -- both messages are genuine, simultaneous real output.
+        $expected = array_merge(
+            [
+                "Current user 'nonexistent_user_zzz' is not in the group 'root' that owns '/etc/passwd'.",
+                "Expected '/etc/passwd' to have group 'not_a_real_group' but instead got 'root'.",
+            ],
+            $this->expectedNotWritableErrors('/etc/passwd')
+        );
+        $this->assertEquals(
+            $expected,
+            FileUtils::checkForPermissionErrors('/etc/passwd', 'nonexistent_user_zzz', null, 'not_a_real_group')
+        );
+    }
+
+    public function testCheckForPermissionErrorsUserNotInGroup() {
+        $expected = array_merge(
+            ["Current user 'nonexistent_user_zzz' is not in the group 'root' that owns '/etc/passwd'."],
+            $this->expectedNotWritableErrors('/etc/passwd')
+        );
+        $this->assertEquals(
+            $expected,
+            FileUtils::checkForPermissionErrors('/etc/passwd', 'nonexistent_user_zzz', null, 'root')
+        );
+    }
+
+    public function testCheckForPermissionErrorsNotReadableOrWritable() {
+        FileUtils::createDir($this->path);
+        $file = FileUtils::joinPaths($this->path, 'test.txt');
+        file_put_contents($file, 'a');
+        try {
+            chmod($file, 0000);
+            $this->assertEquals(
+                ["'{$file}' is not readable.", "'{$file}' is not writable."],
+                FileUtils::checkForPermissionErrors($file, null, null, null)
+            );
+        }
+        finally {
+            chmod($file, 0644);
+        }
+    }
 }

--- a/site/tests/app/libraries/UtilsTester.php
+++ b/site/tests/app/libraries/UtilsTester.php
@@ -830,4 +830,242 @@ PDF);
             Utils::mb_str_split("αβγδεfg", 2)
         );
     }
+
+    public function testIsAcceptedUserIdLengthTooShort() {
+        $requirements = ['min_length' => 5, 'max_length' => 10];
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'abc', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdLengthTooLong() {
+        $requirements = ['min_length' => 1, 'max_length' => 3];
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'abcdefg', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdAnyUserId() {
+        $requirements = ['min_length' => 1, 'max_length' => 20, 'any_user_id' => true];
+        $this->assertTrue(Utils::isAcceptedUserId($requirements, 'anything', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdNameMatchGivenFirst() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 20,
+            'any_user_id' => false,
+            'require_name' => true,
+            'name_requirements' => ['given_first' => 'true', 'given_name' => 4, 'family_name' => 4],
+        ];
+        $this->assertTrue(Utils::isAcceptedUserId($requirements, 'johnsmit', 'John', 'Smith', 'test@example.com'));
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'xxxxxxxx', 'John', 'Smith', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdNameMatchFamilyFirst() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 20,
+            'any_user_id' => false,
+            'require_name' => true,
+            'name_requirements' => ['given_first' => 'false', 'given_name' => 4, 'family_name' => 4],
+        ];
+        $this->assertTrue(Utils::isAcceptedUserId($requirements, 'smitjohn', 'John', 'Smith', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdEmailWholeEmail() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 40,
+            'any_user_id' => false,
+            'require_name' => false,
+            'require_email' => true,
+            'email_requirements' => ['whole_email' => true, 'whole_prefix' => false, 'prefix_count' => 0],
+        ];
+        $this->assertTrue(
+            Utils::isAcceptedUserId($requirements, 'test@example.com', 'Given', 'Family', 'test@example.com')
+        );
+        $this->assertFalse(
+            Utils::isAcceptedUserId($requirements, 'nope@example.com', 'Given', 'Family', 'test@example.com')
+        );
+    }
+
+    public function testIsAcceptedUserIdEmailWholePrefix() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 40,
+            'any_user_id' => false,
+            'require_name' => false,
+            'require_email' => true,
+            'email_requirements' => ['whole_email' => false, 'whole_prefix' => true, 'prefix_count' => 0],
+        ];
+        $this->assertTrue(Utils::isAcceptedUserId($requirements, 'test', 'Given', 'Family', 'test@example.com'));
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'nope', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdEmailPrefixCount() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 40,
+            'any_user_id' => false,
+            'require_name' => false,
+            'require_email' => true,
+            'email_requirements' => ['whole_email' => false, 'whole_prefix' => false, 'prefix_count' => 3],
+        ];
+        $this->assertTrue(Utils::isAcceptedUserId($requirements, 'tes', 'Given', 'Family', 'test@example.com'));
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'xyz', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testIsAcceptedUserIdNoRequirementsMatch() {
+        $requirements = [
+            'min_length' => 1,
+            'max_length' => 40,
+            'any_user_id' => false,
+            'require_name' => false,
+            'require_email' => false,
+        ];
+        $this->assertFalse(Utils::isAcceptedUserId($requirements, 'test', 'Given', 'Family', 'test@example.com'));
+    }
+
+    public function testAcceptedEmailNoAtSign() {
+        $core = $this->createMockCore(['accepted_emails' => ['gmail.com']]);
+        $reqs = $core->getConfig()->getAcceptedEmails();
+        $this->assertFalse(Utils::isAcceptedEmail($reqs, 'not_an_email'));
+    }
+
+    public function testGenerateVerificationCodeDebug() {
+        $core = $this->createMockCore(['use_mock_time' => true]);
+        $result = Utils::generateVerificationCode($core, true);
+        $this->assertEquals('00000000', $result['code']);
+        $this->assertInstanceOf(\DateTime::class, $result['expiration']);
+    }
+
+    public function testGenerateVerificationCodeNotDebug() {
+        $core = $this->createMockCore(['use_mock_time' => true]);
+        $result = Utils::generateVerificationCode($core, false);
+        $this->assertEquals(32, strlen($result['code']));
+    }
+
+    public function testCheckUploadedImageOrPdfFileInvalidId() {
+        $this->assertFalse(Utils::checkUploadedImageOrPdfFile('invalid'));
+    }
+
+    public function testGetAutoFillDataAppendNumericId() {
+        $details = [
+            'user_id' => "test",
+            'anon_id' => "TestAnon",
+            'user_numeric_id' => '123456789',
+            'user_password' => "test",
+            'user_givenname' => "User",
+            'user_preferred_givenname' => null,
+            'user_familyname' => "Tester",
+            'user_preferred_familyname' => null,
+            'user_pronouns' => '',
+            'display_pronouns' => false,
+            'user_email' => "test@example.com",
+            'user_email_secondary' => "test@exampletwo.com",
+            'user_email_secondary_notify' => false,
+            'user_group' => User::GROUP_STUDENT,
+            'registration_section' => 1,
+            'rotating_section' => null,
+            'manual_registration' => false,
+            'grading_registration_sections' => [1, 2]
+        ];
+
+        $core = new Core();
+        $users = [new User($core, $details)];
+
+        $expected = '[{"value":"test","label":"User Tester <test> <123456789>"}]';
+        $this->assertEquals($expected, Utils::getAutoFillData($users, null, true));
+    }
+
+    public function testStripComments() {
+        $code = "int main() { // line comment\n/* block\ncomment */ return 0; }";
+        $expected = "int main() { \n return 0; }";
+        $this->assertEquals($expected, Utils::stripComments($code));
+    }
+
+    public function testEscapeDoubleQuotes() {
+        $this->assertEquals('ab\"cd\"ef', Utils::escapeDoubleQuotes('ab"cd"ef'));
+    }
+
+    public function testConvertBooleansDefaultFalse() {
+        $this->assertFalse(Utils::getBooleanValue([]));
+        $this->assertFalse(Utils::getBooleanValue(null));
+    }
+
+    public static function webSocketPageIdentifierProvider() {
+        return [
+            'missing params' => [['page' => 'discussion_forum', 'term' => 's26'], null],
+            'discussion_forum' => [
+                ['page' => 'discussion_forum', 'term' => 's26', 'course' => 'cs101'],
+                's26-cs101-discussion_forum'
+            ],
+            'office_hours_queue' => [
+                ['page' => 'office_hours_queue', 'term' => 's26', 'course' => 'cs101'],
+                's26-cs101-office_hours_queue'
+            ],
+            'chatrooms with id' => [
+                ['page' => 'chatrooms', 'term' => 's26', 'course' => 'cs101', 'chatroom_id' => '5'],
+                's26-cs101-chatrooms-5'
+            ],
+            'chatrooms all_chatrooms' => [
+                [
+                    'page' => 'chatrooms', 'term' => 's26', 'course' => 'cs101',
+                    'all_chatrooms' => true, 'chatroom_id' => '5'
+                ],
+                's26-cs101-chatrooms'
+            ],
+            'chatrooms no id' => [
+                ['page' => 'chatrooms', 'term' => 's26', 'course' => 'cs101'],
+                's26-cs101-chatrooms'
+            ],
+            'polls missing poll_id' => [
+                ['page' => 'polls', 'term' => 's26', 'course' => 'cs101', 'instructor' => 'true'],
+                null
+            ],
+            'polls missing instructor' => [
+                ['page' => 'polls', 'term' => 's26', 'course' => 'cs101', 'poll_id' => '1'],
+                null
+            ],
+            'polls instructor true' => [
+                ['page' => 'polls', 'term' => 's26', 'course' => 'cs101', 'poll_id' => '1', 'instructor' => 'true'],
+                's26-cs101-polls-1-instructor'
+            ],
+            'polls instructor false' => [
+                ['page' => 'polls', 'term' => 's26', 'course' => 'cs101', 'poll_id' => '1', 'instructor' => 'false'],
+                's26-cs101-polls-1-student'
+            ],
+            'grade_inquiry missing gradeable_id' => [
+                ['page' => 'grade_inquiry', 'term' => 's26', 'course' => 'cs101', 'submitter_id' => 'bob'],
+                null
+            ],
+            'grade_inquiry missing submitter_id' => [
+                ['page' => 'grade_inquiry', 'term' => 's26', 'course' => 'cs101', 'gradeable_id' => 'hw1'],
+                null
+            ],
+            'grade_inquiry complete' => [
+                [
+                    'page' => 'grade_inquiry', 'term' => 's26', 'course' => 'cs101',
+                    'gradeable_id' => 'hw1', 'submitter_id' => 'bob'
+                ],
+                's26-cs101-grade_inquiry-hw1_bob'
+            ],
+            'grading missing gradeable_id' => [
+                ['page' => 'grading', 'term' => 's26', 'course' => 'cs101'],
+                null
+            ],
+            'grading complete' => [
+                ['page' => 'grading', 'term' => 's26', 'course' => 'cs101', 'gradeable_id' => 'hw1'],
+                's26-cs101-grading-hw1'
+            ],
+            'unknown page' => [
+                ['page' => 'unknown', 'term' => 's26', 'course' => 'cs101'],
+                null
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider webSocketPageIdentifierProvider
+     */
+    public function testBuildWebSocketPageIdentifier($params, $expected) {
+        $this->assertEquals($expected, Utils::buildWebSocketPageIdentifier($params));
+    }
 }


### PR DESCRIPTION
### Why is this Change Important & Necessary?
Our PHP unit test code coverage is currently abysmally low.  Making changes to library code is currently risky because so much of it is untested.

### What is the New Behavior?
This PR adds unit tests which cover most of the untested functions under `site/tests/app/libraries/*`.  I plan for this to be the first in a series of PRs improving code coverage for core Submitty PHP code.