### PR TITLE
[Testing:Developer] Install apt CI dependencies in parallel

### DIFF
--- a/.github/actions/e2e-Setup-Composite/action.yml
+++ b/.github/actions/e2e-Setup-Composite/action.yml
@@ -132,12 +132,13 @@ runs:
     - name: Install apt-get packages
       run: |
         sudo apt-get update
-        sudo apt-get install libseccomp-dev
-        sudo apt-get install libboost-all-dev
-        sudo apt-get install poppler-utils
-        sudo apt-get install valgrind
-        sudo apt-get install ca-certificates
-        sudo apt-get install moreutils
+        sudo apt-get install \
+          libseccomp-dev \
+          libboost-all-dev \
+          poppler-utils \
+          valgrind \
+          ca-certificates \
+          moreutils
       shell: bash
 
     - name: Install third party dependencies
@@ -194,12 +195,13 @@ runs:
       run: |
         sudo add-apt-repository ppa:ondrej/php
         sudo apt update
-        sudo apt-get install apache2
-        sudo apt-get install apache2-suexec-custom
-        sudo apt-get install libapache2-mod-authnz-external
-        sudo apt-get install libapache2-mod-authz-unixgroup
-        sudo apt-get install libapache2-mod-wsgi-py3
-        sudo apt-get install php${PHP_VER}-fpm
+        sudo apt-get install \
+          apache2 \
+          apache2-suexec-custom \
+          libapache2-mod-authnz-external \
+          libapache2-mod-authz-unixgroup \
+          libapache2-mod-wsgi-py3 \
+          php${PHP_VER}-fpm
         cd $SUBMITTY_REPOSITORY
         sudo a2enmod include rewrite actions cgi alias headers suexec authnz_external headers proxy_fcgi proxy_http proxy_wstunnel ssl
         sudo cp .setup/php-fpm/pool.d/submitty.conf /etc/php/$PHP_VER/fpm/php-fpm.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,8 +369,9 @@ jobs:
       - name: Install bulk upload dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y poppler-utils
-          sudo apt-get install -y libzbar0
+          sudo apt-get install -y \
+            poppler-utils \
+            libzbar0
 
       - name: Run bulk upload unit tests
         working-directory: sbin/submitty_daemon_jobs


### PR DESCRIPTION
### Why is this Change Important & Necessary?
CI currently runs `apt-get install` many times back-to-back, which adds unnecessary overhead each time.

### What is the New Behavior?
This PR installs all packages at each step in a single command, which is theoretically much more performant.