### PR TITLE
[Bugfix:TAGrading] Fix cluster mode state

### DIFF
--- a/site/app/controllers/grading/ElectronicGraderController.php
+++ b/site/app/controllers/grading/ElectronicGraderController.php
@@ -2442,10 +2442,15 @@ class ElectronicGraderController extends AbstractController {
         $custom_message = $_POST['custom_message'] ?? null;
         $custom_points = $_POST['custom_points'] ?? null;
         $component_version = $_POST['graded_version'] ?? null;
+        $cluster_grading = $_POST['cluster_grading'] ?? null;
         // Optional marks parameter
         $marks = $_POST['mark_ids'] ?? [];
 
         // Validate required parameters
+        if (!in_array($cluster_grading, ['true', 'false'], true)) {
+            $this->core->getOutput()->renderJsonFail('Invalid or missing cluster_grading parameter. Please refresh the page.');
+            return;
+        }
         if ($custom_message === null) {
             $this->core->getOutput()->renderJsonFail('Missing custom_message parameter');
             return;
@@ -2538,7 +2543,7 @@ class ElectronicGraderController extends AbstractController {
             }
         }
         $clustering_enabled = $this->core->getConfig()->isSubmissionClusteringEnabled() && $this->core->getUser()->accessFullGrading();
-        $ta_grading_cluster_mode = $clustering_enabled && ($_COOKIE['ta_grading_cluster_mode'] ?? '') === 'true' && $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
+        $ta_grading_cluster_mode = $clustering_enabled && $cluster_grading === 'true' && $this->core->getCourseEntityManager()->getRepository(\app\entities\grading_cluster\GradingClusterConfig::class)->hasClusters($gradeable_id);
 
         // Check if the user can silently edit assigned marks
         if ($ta_grading_cluster_mode || !$this->core->getAccess()->canI('grading.electronic.silent_edit')) {

--- a/site/app/templates/grading/electronic/RubricPanel.twig
+++ b/site/app/templates/grading/electronic/RubricPanel.twig
@@ -1,4 +1,4 @@
-<div id="grading_rubric" class="rubric_panel {{ is_ta_grading ? "" : "empty" }}" data-testid="grading-rubric">
+<div id="grading_rubric" class="rubric_panel {{ is_ta_grading ? "" : "empty" }}" data-testid="grading-rubric" data-cluster-grading="{{ ta_grading_cluster_mode ? 'true' : 'false' }}">
     <div id="allow_custom_marks" data-gradeable_custom_marks="{{ allow_custom_marks }}"></div>
     <div>
         {% if is_ta_grading %}

--- a/site/ts/ta-grading-rubric.ts
+++ b/site/ts/ta-grading-rubric.ts
@@ -453,6 +453,7 @@ async function ajaxSaveGradedComponent(gradeable_id: string | undefined, compone
                 custom_message: custom_message,
                 silent_edit: silent_edit,
                 mark_ids: mark_ids,
+                cluster_grading: $('#grading_rubric').attr('data-cluster-grading'),
             },
         }) as Record<string, string | undefined>;
     }


### PR DESCRIPTION
<!-- ** Please remove all comment blocks in the description before submitting this PR. ** -->

<!-- NOTE: Please ensure your title and description align with Submitty conventions (see 
https://submitty.org/developer/getting_started/make_a_pull_request for more details). 
Each title has a prefix, and a limit of 40 chars. A description template has been 
provided and must be completed in full. Please also ensure that all CI tests 
are passing. Pull requests that do not meet these requirements are ineligible for 
review and may be closed. -->

### Why is this Change Important & Necessary?
<!-- Include any GitHub issue that is fixed/closed using "Fixes #<number>" or "Closes #<number>" syntax.  
Alternately write "Partially addresses #<number>" or "Related to #<number>" as appropriate. -->

Fixes #13326

When multiple grading tabs are open. Changing cluster grading mode in one tab can change the shared storage value used when saving from another tab, even though that tab's displayed grading mode has not changed.

This can cause the backend to process a save using a cluster grading mode that does not match the mode displayed in the tab where the save was initiated.

The bug can even create confusion among graders and can accidentally make them grade the whole cluster instead of one individual student. (Incase of working with multiple tabs in the browser)

### What is the New Behavior?
<!-- Include before & after screenshots/videos if the user interface has changed. -->

Each browser tab now has the cluster grading state. When a grader saves a graded component, the tab's cluster grading mode is included in the save request. The server validates this value and uses it to determine whether cluster grading behavior should be applied.

This prevents changes to the shared cluster grading cookie from another browser tab from affecting the grading behavior of the tab performing the save.

### What steps should a reviewer take to reproduce or test the bug or new feature?

1. Create a cluster for a particular gradeable
2. Open the grading interface with cluster grading off (Tab A)
3. Duplicate the tab (Tab B) and enable cluster grading
4. Do not refresh any of the tabs
5. Return to Tab A. It still displays cluster grading off
6. Edit and save the grades in Tab B
7. Check the grades of other students in the cluster. It will remain unchanged.

### Automated Testing & Documentation
<!-- Is this feature sufficiently tested by unit tests and end-to-end tests?  
If this PR does not add/update the necessary automated tests, write a new GitHub issue and link it below.  
Is this feature sufficiently documented on submitty.org?
Link related PRs or new GitHub issue to update documentation. -->

### Other information
<!-- Is this a breaking change?  
Does this PR include migrations to update existing installations?  
Are there security concerns with this PR? -->

Bug reproduced video

https://imgur.com/a/FJcWoFu


